### PR TITLE
Overhaul of job cancelling.

### DIFF
--- a/pulsar/managers/queued.py
+++ b/pulsar/managers/queued.py
@@ -77,6 +77,7 @@ class QueueManager(Manager):
                     os.remove(self._job_file(job_id, JOB_FILE_COMMAND_LINE))
                 except Exception:
                     log.exception("Running command but failed to delete - command may rerun on Pulsar boot.")
+                # _run will not do anything if job has been cancelled.
                 self._run(job_id, command_line, async=False)
             except:
                 log.warn("Uncaught exception running job with job_id %s" % job_id)

--- a/test/manager_drmaa_test.py
+++ b/test/manager_drmaa_test.py
@@ -1,0 +1,28 @@
+from .test_utils import (
+    BaseManagerTestCase,
+    skipUnlessModule
+)
+
+from pulsar.managers.queued_drmaa import DrmaaQueueManager
+
+
+class DrmaaManagerTest(BaseManagerTestCase):
+
+    def setUp(self):
+        super(DrmaaManagerTest, self).setUp()
+        self._set_manager()
+
+    def tearDown(self):
+        super(DrmaaManagerTest, self).setUp()
+        self.manager.shutdown()
+
+    def _set_manager(self, **kwds):
+        self.manager = DrmaaQueueManager('_default_', self.app, **kwds)
+
+    @skipUnlessModule("drmaa")
+    def test_simple_execution(self):
+        self._test_simple_execution(self.manager)
+
+    @skipUnlessModule("drmaa")
+    def test_cancel(self):
+        self._test_cancelling(self.manager)

--- a/test/manager_factory_test.py
+++ b/test/manager_factory_test.py
@@ -4,7 +4,7 @@ import os.path
 from pulsar import manager_factory
 
 from .test_utils import temp_directory
-from .manager_test import build_minimal_app
+from .test_utils import minimal_app_for_managers
 
 
 def test_default():
@@ -59,7 +59,7 @@ def __assert_manager_of_type(manager, expected_type):
 
 @contextmanager
 def __test_managers(conf):
-    app = build_minimal_app()
+    app = minimal_app_for_managers()
     managers = manager_factory.build_managers(app, conf)
     try:
         yield managers

--- a/test/manager_queued_test.py
+++ b/test/manager_queued_test.py
@@ -1,0 +1,57 @@
+import os
+import time
+
+from .test_utils import BaseManagerTestCase
+
+from pulsar.managers.queued import QueueManager
+
+CANCEL_TEST_PROGRAM = """import os
+open('%s', 'w').write(str(os.getpid()))
+import time
+time.sleep(10000)
+"""
+
+
+class PythonQueuedManagerTest(BaseManagerTestCase):
+
+    def setUp(self):
+        super(PythonQueuedManagerTest, self).setUp()
+        self._set_manager(num_concurrent_jobs=1)
+
+    def tearDown(self):
+        super(PythonQueuedManagerTest, self).setUp()
+        self.manager.shutdown()
+
+    def _set_manager(self, **kwds):
+        self.manager = QueueManager('_default_', self.app, **kwds)
+
+    def test_simple_execution(self):
+        self._test_simple_execution(self.manager)
+
+    def test_cancel_simple(self):
+        self._test_cancelling(self.manager)
+
+    def test_cancel_deeper(self):
+        manager = self.manager
+        # Test goes deeper than needed when deferring to
+        # external managers. Ensure the PID dies when killed
+        # and subsequent jobs never run.
+
+        pid1 = os.path.join(self.staging_directory, "pid1")
+        pid2 = os.path.join(self.staging_directory, "pid2")
+        command1 = self._python_to_command(CANCEL_TEST_PROGRAM % pid1)
+        command2 = self._python_to_command(CANCEL_TEST_PROGRAM % pid2)
+
+        job1_id = manager.setup_job("124", "tool1", "1.0.0")
+        job2_id = manager.setup_job("125", "tool1", "1.0.0")
+        manager.launch(job1_id, command1)
+        manager.launch(job2_id, command2)
+        time.sleep(0.05)
+        assert os.path.exists(pid1)
+        assert not os.path.exists(pid2)
+        manager.kill(job2_id)
+        manager.kill(job1_id)
+        self._assert_status_becomes_cancelled(job1_id, manager)
+        self._assert_status_becomes_cancelled(job2_id, manager)
+        time.sleep(0.05)
+        assert not os.path.exists(pid2)


### PR DESCRIPTION
The LWR use to not make a distinction between cancelled jobs and complete jobs but with server side postprocessing it is more nessecary. Bugfixes including actually recording and use cancelled status in external job runners and persisting the the recorded cancel status in queued and unqueued Python job managers (in some conditions it would revert the cancelled and mark the job as complete).

Catch and suppress exceptions related to cancelling jobs and fetching that status. Failure to ping the metadata store (disk) and determine if a job has been cancelled shouldn't be interpreted as a job failure.

Lots of refactoring and tests to support this.
