### PR TITLE
Fix pip dependency installation

### DIFF
--- a/pulsar/scripts/config.py
+++ b/pulsar/scripts/config.py
@@ -337,7 +337,7 @@ def _handle_install(args, dependencies):
         if pip is None:
             raise ImportError("Bootstrapping Pulsar dependencies requires pip library.")
 
-        pip.main("install", *dependencies)
+        pip.main(["install"] + dependencies)
 
 
 # def _install_pulsar_in_virtualenv(venv):


### PR DESCRIPTION
Otherwise, was getting the following error:

```
$ pulsar-config --supervisor --wsgi_server uwsgi --libdrmaa_path /usr/lib/slurm-drmaa/lib/libdrmaa.so --install
Bootstrapping pulsar configuration into directory .
Traceback (most recent call last):
  File "/mnt/p3/.venv/bin/pulsar-config", line 9, in <module>
    load_entry_point('pulsar-app==0.5.0', 'console_scripts', 'pulsar-config')()
  File "/mnt/p3/.venv/local/lib/python2.7/site-packages/pulsar/scripts/config.py", line 207, in main
    _handle_install(args, dependencies)
  File "/mnt/p3/.venv/local/lib/python2.7/site-packages/pulsar/scripts/config.py", line 340, in _handle_install
    pip.main("install", *dependencies)
TypeError: main() takes at most 1 argument (4 given)
```