### PR TITLE
Added the slash for the self-closed plugin pulsar tag

### DIFF
--- a/docs/files/job_conf_sample_remote_cluster.xml
+++ b/docs/files/job_conf_sample_remote_cluster.xml
@@ -2,7 +2,7 @@
 <job_conf>
     <plugins>
         <plugin id="drmaa" type="runner" load="galaxy.jobs.runners.drmaa:DRMAAJobRunner"/>
-        <plugin id="pulsar" type="runner" load="galaxy.jobs.runners.pulsar:PulsarRESTJobRunner">
+        <plugin id="pulsar" type="runner" load="galaxy.jobs.runners.pulsar:PulsarRESTJobRunner"/>
     </plugins>
     <handlers>
         <handler id="main"/>


### PR DESCRIPTION
Added the slash for the self-closed plugin pulsar tag in the file `job_conf_sample_remote_cluster.xml` located in `docs/files/`, otherwise we get the Exception:

```
Exception: Problem parsing the XML in file /Users/marenc01/Dev/galaxy/config/job_conf.xml, please correct the indicated portion of the file and restart Galaxy.mismatched tag: line 6, column 6
```

When running Galaxy.