### PR TITLE
Updated the job_conf_sample_remote_cluster.xml for the right default …

### DIFF
--- a/docs/files/job_conf_sample_remote_cluster.xml
+++ b/docs/files/job_conf_sample_remote_cluster.xml
@@ -7,7 +7,7 @@
     <handlers>
         <handler id="main"/>
     </handlers>
-    <destinations default="drmaa">
+    <destinations default="local_cluster">
         <destination id="local_cluster" runner="drmaa">
             <param id="native_specification">-P littlenodes -R y -pe threads 4</param>
         </destination>


### PR DESCRIPTION
…`destinations` id

In the `job_conf_sample_remote_cluster.xml`, the default destinations attribute was set on `drmaa` instead of `local_cluster`.

This was producing the following Exception:

```
Exception: Problem parsing the XML in file /Users/marenc01/Dev/galaxy/config/job_conf.xml, please correct the indicated portion of the file and restart Galaxy.<destinations> default attribute 'drmaa' does not match a defined id or tag in a child element
```

When launching Galaxy.