### PR TITLE
Use a global DRMAA session

### DIFF
--- a/pulsar/managers/util/drmaa/__init__.py
+++ b/pulsar/managers/util/drmaa/__init__.py
@@ -49,7 +49,6 @@ class DrmaaSession(object):
                 DrmaaSession.session.initialize()
             DrmaaSession.session_count += 1
 
-
     @contextlib.contextmanager
     def _session_lock(self):
         with DrmaaSession.session_lock:

--- a/pulsar/managers/util/drmaa/__init__.py
+++ b/pulsar/managers/util/drmaa/__init__.py
@@ -1,3 +1,6 @@
+import threading
+import logging
+
 try:
     from drmaa import Session, JobControlAction
 except OSError as e:
@@ -9,6 +12,8 @@ except ImportError as e:
     Session = None
 
 NO_DRMAA_MESSAGE = "Attempt to use DRMAA, but DRMAA Python library cannot be loaded. "
+
+log = logging.getLogger(__name__)
 
 
 class DrmaaSessionFactory(object):
@@ -22,39 +27,46 @@ class DrmaaSessionFactory(object):
         session_constructor = self.session_constructor
         if session_constructor is None:
             raise Exception(NO_DRMAA_MESSAGE + LOAD_ERROR_MESSAGE)
-        return DrmaaSession(session_constructor(), **kwds)
+        return DrmaaSession(session_constructor, **kwds)
 
 
 class DrmaaSession(object):
     """
     Abstraction around `drmaa` module `Session` objects.
     """
+    session_lock = threading.Semaphore(1)
+    session = None
 
-    def __init__(self, session, **kwds):
-        self.session = session
-        session.initialize()
+    def __init__(self, session_constructor, **kwds):
+        with DrmaaSession.session_lock:
+            if DrmaaSession.session is None:
+                log.debug("Initializing DRMAA session from thread %s", threading.current_thread().name)
+                DrmaaSession.session = session_constructor()
+                DrmaaSession.session.initialize()
 
     def run_job(self, **kwds):
         """
         Create a DRMAA job template, populate with specified properties,
         run the job, and return the external_job_id.
         """
-        template = self.session.createJobTemplate()
+        template = DrmaaSession.session.createJobTemplate()
         try:
             for key in kwds:
                 setattr(template, key, kwds[key])
-            return self.session.runJob(template)
+            with DrmaaSession.session_lock:
+                return DrmaaSession.session.runJob(template)
         finally:
-            self.session.deleteJobTemplate(template)
+            DrmaaSession.session.deleteJobTemplate(template)
 
     def kill(self, external_job_id):
-        return self.session.control(str(external_job_id), JobControlAction.TERMINATE)
+        with DrmaaSession.session_lock:
+            return DrmaaSession.session.control(str(external_job_id), JobControlAction.TERMINATE)
 
     def job_status(self, external_job_id):
-        return self.session.jobStatus(str(external_job_id))
+        return DrmaaSession.session.jobStatus(str(external_job_id))
 
     def close(self):
-        return self.session.exit()
+        return DrmaaSession.session.exit()
 
 
 __all__ = ['DrmaaSessionFactory']

--- a/pulsar/managers/util/drmaa/__init__.py
+++ b/pulsar/managers/util/drmaa/__init__.py
@@ -34,7 +34,7 @@ class DrmaaSession(object):
     """
     Abstraction around `drmaa` module `Session` objects.
     """
-    session_lock = threading.Semaphore(1)
+    session_lock = threading.Lock()
     session = None
 
     def __init__(self, session_constructor, **kwds):

--- a/pulsar/managers/util/drmaa/__init__.py
+++ b/pulsar/managers/util/drmaa/__init__.py
@@ -1,5 +1,6 @@
-import threading
+import contextlib
 import logging
+import threading
 
 try:
     from drmaa import Session, JobControlAction
@@ -35,14 +36,24 @@ class DrmaaSession(object):
     Abstraction around `drmaa` module `Session` objects.
     """
     session_lock = threading.Lock()
+    session_count = 0
     session = None
 
     def __init__(self, session_constructor, **kwds):
-        with DrmaaSession.session_lock:
+        with self._session_lock():
             if DrmaaSession.session is None:
+                if DrmaaSession.session_count != 0:
+                    log.warn("DrmaaSession.session is None but session_count is non-zero - logic error occurred.")
                 log.debug("Initializing DRMAA session from thread %s", threading.current_thread().name)
                 DrmaaSession.session = session_constructor()
                 DrmaaSession.session.initialize()
+            DrmaaSession.session_count += 1
+
+
+    @contextlib.contextmanager
+    def _session_lock(self):
+        with DrmaaSession.session_lock:
+            yield
 
     def run_job(self, **kwds):
         """
@@ -66,7 +77,19 @@ class DrmaaSession(object):
         return DrmaaSession.session.jobStatus(str(external_job_id))
 
     def close(self):
-        return DrmaaSession.session.exit()
+        with self._session_lock():
+            if DrmaaSession.session_count == 0:
+                log.warn("close() called with zero active session counted - logic error.")
+                return
+
+            DrmaaSession.session_count -= 1
+            if DrmaaSession.session_count == 0:
+                if DrmaaSession.session is None:
+                    log.warn("close() called with a non-zero session count but no session is defined.")
+                    return
+
+                DrmaaSession.session.exit()
+                DrmaaSession.session = None
 
 
 __all__ = ['DrmaaSessionFactory']


### PR DESCRIPTION
Only one active DRMAA session is possible per process. This allows multiple Galaxy runner plugins to be active in the same handler if Pulsar is being used as an embedded runner (they all have to target the same DRMAA library, however). Also add locking to calls that modify the number of active jobs, as per the Python-drmaa documentation.

See also galaxyproject/galaxy#2102