### PR TITLE
Make check_job_script_integrity configurable

### DIFF
--- a/app.yml.sample
+++ b/app.yml.sample
@@ -7,6 +7,7 @@
 #  _default_:
 #    type: queued_python
 #    num_concurrent_jobs: 1
+#    check_job_script_integrity: True
 
 
 ## Mode to create job releated directories with. If unset

--- a/pulsar/managers/queued_cli.py
+++ b/pulsar/managers/queued_cli.py
@@ -29,6 +29,7 @@ class CliQueueManager(ExternalBaseManager):
         command_line = self._expand_command_line(command_line, dependencies_description)
         job_script_kwargs = self._job_template_env(job_id, command_line=command_line, env=env)
         extra_kwargs = job_interface.job_script_kwargs(stdout_path, stderr_path, job_name)
+        job_script_kwargs["check_job_script_integrity"] = self.check_job_script_integrity
         job_script_kwargs.update(extra_kwargs)
         script = job_script(**job_script_kwargs)
         script_path = self._write_job_script(job_id, script)

--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -34,6 +34,7 @@ class StatefulManagerProxy(ManagerProxy):
 
     def __init__(self, manager, **manager_options):
         super(StatefulManagerProxy, self).__init__(manager)
+        self._proxied_manager.check_job_script_integrity = manager_options.get("check_job_script_integrity", True)
         min_polling_interval = float(manager_options.get("min_polling_interval", DEFAULT_MIN_POLLING_INTERVAL))
         preprocess_retry_action_kwds = filter_destination_params(manager_options, "preprocess_action_")
         postprocess_retry_action_kwds = filter_destination_params(manager_options, "postprocess_action_")

--- a/pulsar/managers/util/job_script/__init__.py
+++ b/pulsar/managers/util/job_script/__init__.py
@@ -81,6 +81,8 @@ def job_script(template=DEFAULT_JOB_FILE_TEMPLATE, **kwds):
         working_directory = kwds.get("metadata_directory", kwds["working_directory"])
         kwds["instrument_pre_commands"] = job_instrumenter.pre_execute_commands(working_directory) or ''
         kwds["instrument_post_commands"] = job_instrumenter.post_execute_commands(working_directory) or ''
+    if not kwds["check_job_script_integrity"]:
+        kwds["integrity_injection"] = ""
 
     template_params = OPTIONAL_TEMPLATE_PARAMS.copy()
     template_params.update(**kwds)

--- a/pulsar/managers/util/job_script/__init__.py
+++ b/pulsar/managers/util/job_script/__init__.py
@@ -81,7 +81,7 @@ def job_script(template=DEFAULT_JOB_FILE_TEMPLATE, **kwds):
         working_directory = kwds.get("metadata_directory", kwds["working_directory"])
         kwds["instrument_pre_commands"] = job_instrumenter.pre_execute_commands(working_directory) or ''
         kwds["instrument_post_commands"] = job_instrumenter.post_execute_commands(working_directory) or ''
-    if not kwds["check_job_script_integrity"]:
+    if "check_job_script_integrity" in kwds and not kwds["check_job_script_integrity"]:
         kwds["integrity_injection"] = ""
 
     template_params = OPTIONAL_TEMPLATE_PARAMS.copy()


### PR DESCRIPTION
The job integrity check causes PBS submissions to fail, so this PR adds the
possibility to turn this check on or off (default on) using the
check_job_script_integrity variable in the managers section.

xref #100 