### PR TITLE
Fix PBS status reporting

### DIFF
--- a/pulsar/managers/util/cli/job/torque.py
+++ b/pulsar/managers/util/cli/job/torque.py
@@ -104,7 +104,7 @@ class Torque(BaseJobExec):
     def parse_single_status(self, status, job_id):
         for line in status.splitlines():
             line = line.split(' = ')
-            if line[0] == 'job_state':
+            if line[0].strip() == 'job_state':
                 return self._get_job_state(line[1].strip())
         # no state found, job has exited
         return job_states.OK


### PR DESCRIPTION
Without this commit only very short jobs completed successfully, because the
status was always set to complete. This was because the status returned by
qstat contains leading spaces before the `job_state = Q` part, so I'm adding a
`.strip()`.