### PR TITLE
Fail jobs that error during job submission

### DIFF
--- a/pulsar/managers/queued_cli.py
+++ b/pulsar/managers/queued_cli.py
@@ -35,8 +35,8 @@ class CliQueueManager(ExternalBaseManager):
         submission_command = job_interface.submit(script_path)
         cmd_out = shell.execute(submission_command)
         if cmd_out.returncode != 0:
-            log.warn("Failed to submit job - command was %s" % submission_command)
-            raise Exception("Failed to submit job, error was:\n %s" % cmd_out.stderr)
+            log.warn("Failed to submit job - command was:\n%s" % submission_command)
+            raise Exception("Failed to submit job, error was:\n%s" % cmd_out.stderr)
         external_id = parse_external_id(cmd_out.stdout.strip())
         if not external_id:
             message_template = "Failed to obtain externl id for job_id %s and submission_command %s"

--- a/pulsar/managers/queued_cli.py
+++ b/pulsar/managers/queued_cli.py
@@ -36,7 +36,7 @@ class CliQueueManager(ExternalBaseManager):
         cmd_out = shell.execute(submission_command)
         if cmd_out.returncode != 0:
             log.warn("Failed to submit job - command was %s" % submission_command)
-            raise Exception("Failed to submit job")
+            raise Exception("Failed to submit job, error was:\n %s" % cmd_out.stderr)
         external_id = parse_external_id(cmd_out.stdout.strip())
         if not external_id:
             message_template = "Failed to obtain externl id for job_id %s and submission_command %s"

--- a/pulsar/managers/staging/post.py
+++ b/pulsar/managers/staging/post.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 def postprocess(job_directory, action_executor):
-    # Returns True iff outputs were collected.
+    # Returns True if outputs were collected.
     try:
         staging_config = job_directory.load_metadata("staging_config", None)
         collected = __collect_outputs(job_directory, staging_config, action_executor)
@@ -29,7 +29,6 @@ def __collect_outputs(job_directory, staging_config, action_executor):
         client_outputs = staging.ClientOutputs.from_dict(staging_config["client_outputs"])
         pulsar_outputs = __pulsar_outputs(job_directory)
         output_collector = PulsarServerOutputCollector(job_directory, action_executor)
-        results_collector = ResultsCollector(output_collector, file_action_mapper, client_outputs, pulsar_outputs)
         results_collector = ResultsCollector(output_collector, file_action_mapper, client_outputs, pulsar_outputs)
         collection_failure_exceptions = results_collector.collect()
         if collection_failure_exceptions:

--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -86,6 +86,7 @@ class StatefulManagerProxy(ManagerProxy):
                     job_directory.store_metadata(JOB_FILE_PREPROCESSING_FAILED, True)
                     job_directory.store_metadata("return_code", 1)
                     job_directory.write_file("stderr", str(e))
+                self.__state_change_callback(status.FAILED, job_id)
                 log.exception("Failed job preprocessing for job %s:", job_id)
 
         new_thread_for_job(self, "preprocess", job_id, do_preprocess, daemon=False)
@@ -150,7 +151,7 @@ class StatefulManagerProxy(ManagerProxy):
                 deactivate_method(job_id)
             except Exception:
                 log.exception("Failed to deactivate via proxied manager job %s" % job_id)
-        if proxy_status in [ status.COMPLETE, status.CANCELLED]:
+        if proxy_status == status.COMPLETE:
             self.__handle_postprocessing(job_id)
 
     def __handle_postprocessing(self, job_id):


### PR DESCRIPTION
Previously jobs that failed to submit (bad resource requests, malformed
scripts, no qsub available, staging problems) would remain in waiting status
until pulsar was restarted.

Let me know if there is a better way to do this @jmchilton 