### PR TITLE
Try getting manager_name from req.params

### DIFF
--- a/pulsar/client/interface.py
+++ b/pulsar/client/interface.py
@@ -91,6 +91,7 @@ class HttpPulsarInterface(PulsarInterface):
             remote_host = "http://%s" % remote_host
         self.remote_host = remote_host
         self.private_token = destination_params.get("private_token", None)
+        self.manager = destination_params.get("manager", None)
 
     def execute(self, command, args={}, data=None, input_path=None, output_path=None):
         url = self.__build_url(command, args)
@@ -102,6 +103,7 @@ class HttpPulsarInterface(PulsarInterface):
         path = COMMAND_TO_PATH.get(command, Template(command)).safe_substitute(args)
         if self.private_token:
             args["private_token"] = self.private_token
+        args["manager_name"] = self.manager
         arg_bytes = dict([(k, text_type(args[k]).encode('utf-8')) for k in args])
         data = urlencode(arg_bytes)
         url = self.remote_host + path + "?" + data

--- a/pulsar/client/interface.py
+++ b/pulsar/client/interface.py
@@ -103,7 +103,8 @@ class HttpPulsarInterface(PulsarInterface):
         path = COMMAND_TO_PATH.get(command, Template(command)).safe_substitute(args)
         if self.private_token:
             args["private_token"] = self.private_token
-        args["manager_name"] = self.manager
+        if self.manager:
+            args["manager_name"] = self.manager
         arg_bytes = dict([(k, text_type(args[k]).encode('utf-8')) for k in args])
         data = urlencode(arg_bytes)
         url = self.remote_host + path + "?" + data

--- a/pulsar/web/routes.py
+++ b/pulsar/web/routes.py
@@ -34,7 +34,9 @@ class PulsarController(Controller):
     def _app_args(self, args, req):
         app = req.app
         managers = app.managers
-        manager_name = args.get('manager_name', DEFAULT_MANAGER_NAME)
+        manager_name = args.get('manager_name', None)
+        if not manager_name:
+            manager_name = req.params.get("manager_name", DEFAULT_MANAGER_NAME)
         app_args = {}
         app_args['manager'] = managers[manager_name]
         app_args['file_cache'] = getattr(app, 'file_cache', None)


### PR DESCRIPTION
Galaxy may insert the manager name into the request, if communicating with
pulsar by HTTP.

There is probably a better way to do this, probably involving https://github.com/galaxyproject/pulsar/blob/67543f3753d10d4176862355f23a9a0ef2ff9d2d/pulsar/web/wsgi.py#L54-L54, but I don't know how the request should look like.

Suggestions welcome @jmchilton 

~~Also needs galaxy PR #~~