### PR TITLE
Use managers defined in job destination parameters

### DIFF
--- a/pulsar/client/interface.py
+++ b/pulsar/client/interface.py
@@ -3,14 +3,12 @@ from abc import abstractmethod
 from string import Template
 
 from six import BytesIO
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib.parse import urljoin
 try:
     from six import text_type
 except ImportError:
     from galaxy.util import unicodify as text_type
-try:
-    from urllib import urlencode
-except ImportError:
-    from urllib.parse import urlencode
 
 from .util import copy_to_path
 
@@ -85,10 +83,13 @@ class HttpPulsarInterface(PulsarInterface):
         self.transport = transport
         remote_host = destination_params.get("url")
         assert remote_host is not None, "Failed to determine url for Pulsar client."
-        if not remote_host.endswith("/"):
-            remote_host = "%s/" % remote_host
         if not remote_host.startswith("http"):
             remote_host = "http://%s" % remote_host
+        if not remote_host.endswith("/"):
+            remote_host = "%s/" % remote_host
+        manager = destination_params.get("manager", None)
+        if manager:
+            remote_host = urljoin(remote_host, "managers/%s" % manager)
         self.remote_host = remote_host
         self.private_token = destination_params.get("private_token", None)
 

--- a/pulsar/client/interface.py
+++ b/pulsar/client/interface.py
@@ -12,6 +12,9 @@ except ImportError:
 
 from .util import copy_to_path
 
+import logging
+log = logging.getLogger(__name__)
+
 
 class PulsarInterface(object):
     """
@@ -87,7 +90,10 @@ class HttpPulsarInterface(PulsarInterface):
             remote_host = "http://%s" % remote_host
         manager = destination_params.get("manager", None)
         if manager:
-            remote_host = urljoin(remote_host, "managers/%s" % manager)
+            if "/managers/" in remote_host:
+                log.warning("Ignoring manager tag '%s', Pulsar client URL already contains a \"/managers/\" path." % manager)
+            else:
+                remote_host = urljoin(remote_host, "managers/%s" % manager)
         if not remote_host.endswith("/"):
             remote_host = "%s/" % remote_host
         self.remote_host = remote_host

--- a/pulsar/client/interface.py
+++ b/pulsar/client/interface.py
@@ -85,11 +85,11 @@ class HttpPulsarInterface(PulsarInterface):
         assert remote_host is not None, "Failed to determine url for Pulsar client."
         if not remote_host.startswith("http"):
             remote_host = "http://%s" % remote_host
-        if not remote_host.endswith("/"):
-            remote_host = "%s/" % remote_host
         manager = destination_params.get("manager", None)
         if manager:
             remote_host = urljoin(remote_host, "managers/%s" % manager)
+        if not remote_host.endswith("/"):
+            remote_host = "%s/" % remote_host
         self.remote_host = remote_host
         self.private_token = destination_params.get("private_token", None)
 


### PR DESCRIPTION
This way there is no discrepancy between the arguments that message queue pulsar and http pulsar consume.