### PR TITLE
Fix for locating cli shell/job plugins

### DIFF
--- a/pulsar/managers/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
+++ b/pulsar/managers/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
@@ -15,6 +15,8 @@ elif [ -n "$SLURM_NTASKS" ] || [ -n "$SLURM_CPUS_PER_TASK" ]; then
     GALAXY_SLOTS=`expr "${SLURM_NTASKS:-1}" \* "${SLURM_CPUS_PER_TASK:-1}"`
 elif [ -n "$NSLOTS" ]; then
     GALAXY_SLOTS="$NSLOTS"
+elif [ -n "$NCPUS" ]; then
+    GALAXY_SLOTS="$NCPUS"
 elif [ -n "$PBS_NCPUS" ]; then
     GALAXY_SLOTS="$PBS_NCPUS"
 elif [ -f "$PBS_NODEFILE" ]; then

--- a/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -1,6 +1,7 @@
 #!$shell
-$integrity_injection
+
 $headers
+$integrity_injection
 $slots_statement
 export GALAXY_SLOTS
 GALAXY_LIB="$galaxy_lib"

--- a/pulsar/managers/util/job_script/__init__.py
+++ b/pulsar/managers/util/job_script/__init__.py
@@ -67,7 +67,7 @@ def job_script(template=DEFAULT_JOB_FILE_TEMPLATE, **kwds):
     >>> 'PBS -test\\n' in script
     False
     >>> script = job_script(working_directory='wd', command='uptime', exit_code_path='ec', headers='#PBS -test', integrity_injection='')
-    >>> script.startswith('#!/bin/bash\\n\\n#PBS -test\\n')
+    >>> script.startswith('#!/bin/bash\\n\\n#PBS -test')
     True
     >>> script = job_script(working_directory='wd', command='uptime', exit_code_path='ec', slots_statement='GALAXY_SLOTS="$SLURM_JOB_NUM_NODES"')
     >>> script.find('GALAXY_SLOTS="$SLURM_JOB_NUM_NODES"\\nexport GALAXY_SLOTS\\n') > 0


### PR DESCRIPTION
and update the job templates (just copied over from galaxy).

I feel that f539af2 is a terrible hack, suggestions for improvement welcome.
It does fix 
```
serving on http://127.0.0.1:8913
2016-04-12 14:59:30,536 DEBUG [pulsar.managers.base][[manager=_default_]-[action=preprocess]-[job=33]] job_id: 33 - Checking authorization of command_line [printenv > "/lustrework/vandenbeek/pulsar/pulsar-master/files/staging/33/outputs/dataset_33.dat"]
2016-04-12 14:59:30,537 ERROR [pulsar.managers.stateful][[manager=_default_]-[action=preprocess]-[job=33]] Failed job preprocess for 33:
Traceback (most recent call last):
  File "/Users/marius/.venv/lib/python2.7/site-packages/pulsar/managers/stateful.py", line 79, in do_preprocess
    self._proxied_manager.launch(job_id, *args, **kwargs)
  File "/Users/marius/.venv/lib/python2.7/site-packages/pulsar/managers/queued_cli.py", line 25, in launch
    shell, job_interface = self.__get_cli_plugins()
  File "/Users/marius/.venv/lib/python2.7/site-packages/pulsar/managers/queued_cli.py", line 49, in __get_cli_plugins
    return self.cli_interface.get_plugins(self.shell_params, self.job_params)
  File "/Users/marius/.venv/lib/python2.7/site-packages/pulsar/managers/util/cli/__init__.py", line 49, in get_plugins
    shell = self.get_shell_plugin(shell_params)
  File "/Users/marius/.venv/lib/python2.7/site-packages/pulsar/managers/util/cli/__init__.py", line 55, in get_shell_plugin
    shell = self.cli_shells[shell_plugin](**shell_params)
KeyError: 'SecureShell'
```

mentioned in #100 for me.