### PR TITLE
curl transport improvements (timeout handling)

### DIFF
--- a/pulsar/client/__init__.py
+++ b/pulsar/client/__init__.py
@@ -48,6 +48,7 @@ from .client import OutputNotFoundException
 from .manager import build_client_manager
 from .destination import url_to_destination_params
 from .path_mapper import PathMapper
+from .exceptions import PulsarClientTransportError
 
 __all__ = [
     'build_client_manager',
@@ -59,4 +60,5 @@ __all__ = [
     'PulsarOutputs',
     'ClientOutputs',
     'PathMapper',
+    'PulsarClientTransportError',
 ]

--- a/pulsar/client/exceptions.py
+++ b/pulsar/client/exceptions.py
@@ -1,0 +1,39 @@
+"""
+Pulsar client exceptions
+"""
+
+
+class PulsarClientTransportError(Exception):
+    TIMEOUT = 'timeout'
+    CONNECTION_REFUSED = 'connection_refused'
+    UNKNOWN = 'unknown'
+
+    messages = {
+        TIMEOUT: 'Connection timed out',
+        CONNECTION_REFUSED: 'Connection refused',
+        UNKNOWN: 'Unknown transport error'
+    }
+
+    INVALID_CODE_MESSAGE = 'Unknown transport error code: %s'
+
+    def __init__(self, code=None, message=None,
+                 transport_code=None, transport_message=None):
+        self.code = code or PulsarClientTransportError.UNKNOWN
+        self.message = message or PulsarClientTransportError.messages.get(
+            self.code,
+            PulsarClientTransportError.INVALID_CODE_MESSAGE % code
+        )
+        self.transport_code = transport_code
+        self.transport_message = transport_message
+        if transport_code or transport_message:
+            self.message += " ("
+            if transport_code:
+                self.message += "transport code: %s" % transport_code
+                if transport_message:
+                    self.message += ", "
+            if transport_message:
+                self.message += "transport message: %s" % transport_message
+            self.message += ")"
+
+    def __str__(self):
+        return self.message

--- a/pulsar/client/manager.py
+++ b/pulsar/client/manager.py
@@ -63,7 +63,8 @@ class ClientManager(object):
         else:
             self.job_manager_interface_class = HttpPulsarInterface
             transport_type = kwds.get('transport', None)
-            transport = get_transport(transport_type)
+            transport_params = dict([(p.replace('transport_', '', 1), v) for p, v in kwds.items() if p.startswith('transport_')])
+            transport = get_transport(transport_type, transport_params=transport_params)
             self.job_manager_interface_args = dict(transport=transport)
         cache = kwds.get('cache', None)
         if cache is None:

--- a/pulsar/client/transport/__init__.py
+++ b/pulsar/client/transport/__init__.py
@@ -18,12 +18,14 @@ else:
     from .poster import post_file
 
 
-def get_transport(transport_type=None, os_module=os):
+def get_transport(transport_type=None, os_module=os, transport_params=None):
     transport_type = _get_transport_type(transport_type, os_module)
+    if not transport_params:
+        transport_params = {}
     if transport_type == 'urllib':
-        transport = Urllib2Transport()
+        transport = Urllib2Transport(**transport_params)
     else:
-        transport = PycurlTransport()
+        transport = PycurlTransport(**transport_params)
     return transport
 
 

--- a/pulsar/client/transport/standard.py
+++ b/pulsar/client/transport/standard.py
@@ -4,23 +4,27 @@ Pulsar HTTP Client layer based on Python Standard Library (urllib2)
 from __future__ import with_statement
 from os.path import getsize
 import mmap
+import socket
 try:
-    from urllib2 import urlopen
+    from urllib2 import urlopen, URLError
 except ImportError:
     from urllib.request import urlopen
+    from urllib.error import URLError
 try:
     from urllib2 import Request
 except ImportError:
     from urllib.request import Request
 
+from ..exceptions import PulsarClientTransportError
+
 
 class Urllib2Transport(object):
 
-    def __init__(self, **kwrgs):
-        pass
+    def __init__(self, timeout=None, **kwrgs):
+        self.timeout = timeout
 
     def _url_open(self, request, data):
-        return urlopen(request, data)
+        return urlopen(request, data, self.timeout)
 
     def execute(self, url, method=None, data=None, input_path=None, output_path=None):
         request = self.__request(url, data, method)
@@ -34,7 +38,12 @@ class Urllib2Transport(object):
                 else:
                     data = b""
                 request.add_header('Content-Length', str(size))
-            response = self._url_open(request, data)
+            try:
+                response = self._url_open(request, data)
+            except socket.timeout as exc:
+                raise PulsarClientTransportError(code=PulsarClientTransportError.TIMEOUT)
+            except URLError as exc:
+                raise PulsarClientTransportError(transport_message=exc.reason)
         finally:
             if input:
                 input.close()

--- a/pulsar/client/transport/standard.py
+++ b/pulsar/client/transport/standard.py
@@ -16,6 +16,9 @@ except ImportError:
 
 class Urllib2Transport(object):
 
+    def __init__(self, **kwrgs):
+        pass
+
     def _url_open(self, request, data):
         return urlopen(request, data)
 


### PR DESCRIPTION
Allow the curl client transport to have a timeout value set (includes a general framework for setting any other transport options that might be necessary), and add an exception that can be raised up to the pulsar runner in Galaxy to handle communication problems while checking state
or submitting jobs.

Fixes a problem encountered on usegalaxy.org where the monitor thread would encounter some network problem and block forever (until handler restart).

Partially fixes #114 in that restarts will not kill running jobs, but if Galaxy attempts to submit a job while Pulsar is down it will still fail.

The Galaxy side looks like this, with a new `<param id="transport_timeout>` on `PulsarRESTJobRunner` plugins:

```diff
diff --git a/lib/galaxy/jobs/runners/pulsar.py b/lib/galaxy/jobs/runners/pulsar.py
index d2f1b6d..dad1b19 100644
--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -18,6 +18,7 @@ from pulsar.client import ClientJobDescription
 from pulsar.client import PulsarOutputs
 from pulsar.client import ClientOutputs
 from pulsar.client import PathMapper
+from pulsar.client import PulsarClientTransportError
 
 import pulsar.core
 
@@ -63,6 +64,10 @@ PULSAR_PARAM_SPECS = dict(
         valid=specs.is_in("urllib", "curl", None),
         default=None
     ),
+    transport_timeout=dict(
+        map=lambda val: None if val == "None" else int(val),
+        default=None,
+    ),
     cache=dict(
         map=specs.to_bool_or_none,
         default=None,
@@ -191,7 +196,7 @@ class PulsarJobRunner( AsynchronousJobRunner ):
             client_manager_kwargs[ "file_cache" ] = None
 
         for kwd in self.runner_params.keys():
-            if kwd.startswith( 'amqp_' ):
+            if kwd.startswith( 'amqp_' ) or kwd.startswith( 'transport_' ):
                 client_manager_kwargs[ kwd ] = self.runner_params[ kwd ]
         self.client_manager = build_client_manager(**client_manager_kwargs)
 
@@ -224,6 +229,9 @@ class PulsarJobRunner( AsynchronousJobRunner ):
         try:
             client = self.get_client_from_state(job_state)
             status = client.get_status()
+        except PulsarClientTransportError as exc:
+            log.error("Communication error with Pulsar server on state check, will retry: %s", exc)
+            return job_state
         except Exception:
             # An orphaned job was put into the queue at app startup, so remote server went down
             # either way we are done I guess.
```