### PR TITLE
Avoid loop when preprocessing fails and polling enabled.

### DIFF
--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -113,7 +113,8 @@ class StatefulManagerProxy(ManagerProxy):
         """
         state_change = None
         if job_directory.has_metadata(JOB_FILE_PREPROCESSING_FAILED):
-            proxy_status = status.COMPLETE
+            proxy_status = status.FAILED
+            job_directory.store_metadata(JOB_FILE_FINAL_STATUS, proxy_status)
             state_change = "to_complete"
         elif not job_directory.has_metadata(JOB_FILE_PREPROCESSED):
             proxy_status = status.PREPROCESSING


### PR DESCRIPTION
Tweak to behavior added here https://github.com/galaxyproject/pulsar/commit/8242741ba15e5b753fbd7f2845156552071adfa0. Don't postprocess the failed job, just indicate the proxy status as failed and be done with it.