### PR TITLE
Fixing conda_auto resolving

### DIFF
--- a/dependency_resolvers_conf.xml.sample
+++ b/dependency_resolvers_conf.xml.sample
@@ -1,0 +1,37 @@
+<dependency_resolvers>
+	<!-- the default configuration, first look for dependencies installed from the toolshed -->
+	<tool_shed_packages />
+
+	<!-- then look for env.sh files in directories according to the "galaxy packages" schema.
+	These resolvers can take a base_path attribute to specify where to look for
+	package definitions, but by default look in the directory specified by tool_dependency_dir
+	in Galaxy's config/galaxy.ini -->
+
+	<galaxy_packages />
+
+	<!-- check whether the correct version has been installed via conda
+   	auto_install: Set to True to instruct Galaxy to look for and install missing tool dependencies before each job runs. (default: False)
+   	auto_init: Set to True to instruct Galaxy to install conda from the web automatically if it cannot find a local copy and conda_exec is not configured. 
+    	-->
+	<conda auto_install="True" auto_init="True"/>
+
+
+        <!-- look for a "default" symlink pointing to a directory containing an
+	            env.sh file for the package in the "galaxy packages" schema -->
+	<galaxy_packages versionless="true" />
+
+	<!-- look for any version of the dependency installed via conda -->
+	<conda versionless="true" />
+
+        <!-- Example configuration of modules dependency resolver, uses Environment Modules -->
+<!--
+  <modules modulecmd="/opt/Modules/3.2.9/bin/modulecmd" />
+  <modules modulecmd="/opt/Modules/3.2.9/bin/modulecmd" versionless="true" default_indicator="default" />
+  Attributes are:
+  * modulecmd - path to modulecmd
+  * versionless - default: false - whether to resolve tools using a version number or not
+  * find_by - directory or avail - use the DirectoryModuleChecker or AvailModuleChecker
+  * prefetch - default: true - in the AvailModuleChecker prefetch module info with 'module avail'
+  * default_indicator - default: '(default)' - what indicate to the AvailModuleChecker that a module is the default version
+-->
+</dependency_resolvers>

--- a/pulsar/core.py
+++ b/pulsar/core.py
@@ -127,8 +127,8 @@ class PulsarApp(object):
         conda_config = {}
         for key, value in conf.items():
             if key.startswith("conda_"):
-                conda_config[key] = value
-        self.dependency_manager = DependencyManager(dependencies_dir, resolvers_config_file, **conda_config)
+                conda_config[key[len('conda_'):]] = value
+        self.dependency_manager = DependencyManager(dependencies_dir, resolvers_config_file, app_config=conda_config)
 
     def __setup_job_metrics(self, conf):
         job_metrics = conf.get("job_metrics", None)


### PR DESCRIPTION
Using the previous version caused the error below; and pulsar failed to start. Applying the patch made it possible for pulsar to start and auto resolve dependencies.

Note: In addition i needed a dependency_resolvers_conf.xml in the pulsar folder containing
```<conda auto_install="True" auto_init="True"/>```

```
> Sourcing file ./local_env.sh
Starting pulsar with command [uwsgi --ini-paste "./server.ini" ""]
[uWSGI] getting INI configuration from ./server.ini
Starting uWSGI 2.0.15 (64bit) on [Fri May 12 14:01:37 2017]
compiled with version: 6.3.0 20170425 on 12 May 2017 13:17:07
os: Linux-4.9.0-2-amd64 #1 SMP Debian 4.9.18-1 (2017-03-30)
nodename: pulsar-runner
machine: x86_64
clock source: unix
detected number of CPU cores: 2
current working directory: /srv/pulsar
detected binary path: /srv/pulsar/venv/bin/uwsgi
!!! no internal routing support, rebuild with pcre support !!!
your processes number limit is 15736
your memory page size is 4096 bytes
detected max file descriptor number: 1024
lock engine: pthread robust mutexes
thunder lock: disabled (you can enable it with --thunder-lock)
uwsgi socket 0 bound to TCP address 0.0.0.0:3031 fd 3
Python version: 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
Python main interpreter initialized at 0x563bf48abf70
python threads support enabled
your server socket listen backlog is limited to 100 connections
your mercy for graceful operations on workers is 60 seconds
mapped 145536 bytes (142 KB) for 1 cores
Operational MODE: single process
Loading paste environment: config:/srv/pulsar/./server.ini
2017-05-12 14:01:37,546 INFO [pulsar.core][MainThread] Securing Pulsar web app with private key, please verify you are using HTTPS so key cannot be obtained by monitoring traffic.
2017-05-12 14:01:37,547 INFO [pulsar.core][MainThread] Starting the Pulsar without a toolbox to white-list.Ensure this application is protected by firewall or a configured private token.
Traceback (most recent call last):
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
return loadobj(APP, uri, name=name, kw)
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 272, in loadobj
return context.create()
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 710, in create
return self.object_type.invoke(self)
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 146, in invoke
return fix_call(context.object, context.global_conf, context.local_conf)
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/paste/deploy/util.py", line 58, in fix_call
reraise(exc_info)
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/paste/deploy/compat.py", line 23, in reraise
exec('raise t, e, tb', dict(t=t, e=e, tb=tb))
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/paste/deploy/util.py", line 55, in fix_call
val = callable(args, kw)
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/pulsar/web/wsgi.py", line 19, in app_factory
webapp = init_webapp(ini_path=configuration_file, local_conf=local_conf)
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/pulsar/web/wsgi.py", line 25, in init_webapp
pulsar_app = PulsarApp(app_conf)
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/pulsar/core.py", line 40, in init
self.setup_dependency_manager(conf)
File "/srv/pulsar/venv/local/lib/python2.7/site-packages/pulsar/core.py", line 131, in setup_dependency_manager
self.dependency_manager = DependencyManager(dependencies_dir, resolvers_config_file, **conda_config)
TypeError: init() got an unexpected keyword argument 'conda_auto_init'
```