### PR TITLE
Remote metadata fixes and enhancements

### DIFF
--- a/local_env.sh.sample
+++ b/local_env.sh.sample
@@ -7,7 +7,11 @@
 
 ## If you wish to use a variety of Galaxy tools that depend on galaxy.eggs being defined, 
 ## set GALAXY_HOME to point to a copy of Galaxy.
-#export GALAXY_HOME=/path/to/galaxy-dist
+#export GALAXY_HOME=/path/to/galaxy
+
+## In order to set metadata on the pulsar side, Pulsar needs to know where
+## Galaxy's virtualenv is. If not using remote metadata, this is unnecessary.
+#export GALAXY_VIRTUAL_ENV=/path/to/galaxy/.venv
 
 ## Uncomment to verify GALAXY_HOME is set properly before starting the Pulsar.
 #export TEST_GALAXY_LIBS=1

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -63,7 +63,7 @@ class BaseJobClient(object):
 
         self.setup_handler = build_setup_handler(self, destination_params)
 
-    def setup(self, tool_id=None, tool_version=None):
+    def setup(self, tool_id=None, tool_version=None, preserve_galaxy_python_environment=None):
         """
         Setup remote Pulsar server to run this job.
         """
@@ -72,6 +72,8 @@ class BaseJobClient(object):
             setup_args["tool_id"] = tool_id
         if tool_version:
             setup_args["tool_version"] = tool_version
+        if preserve_galaxy_python_environment:
+            setup_args["preserve_galaxy_python_environment"] = preserve_galaxy_python_environment
         return self.setup_handler.setup(**setup_args)
 
     @property
@@ -394,9 +396,11 @@ def _setup_params_from_job_config(job_config):
     job_id = job_config.get("job_id", None)
     tool_id = job_config.get("tool_id", None)
     tool_version = job_config.get("tool_version", None)
+    preserve_galaxy_python_environment = job_config.get("preserve_galaxy_python_environment", None)
     return dict(
         job_id=job_id,
         tool_id=tool_id,
         tool_version=tool_version,
         use_metadata=True,
+        preserve_galaxy_python_environment=preserve_galaxy_python_environment,
     )

--- a/pulsar/client/setup_handler.py
+++ b/pulsar/client/setup_handler.py
@@ -39,13 +39,14 @@ class LocalSetupHandler(object):
         self.system_properties = system_properties
         self.jobs_directory = destination_args["jobs_directory"]
 
-    def setup(self, job_id, tool_id=None, tool_version=None):
+    def setup(self, job_id, tool_id=None, tool_version=None, preserve_galaxy_python_environment=None):
         return build_job_config(
             job_id=job_id,
             job_directory=self.client.job_directory,
             system_properties=self.system_properties,
             tool_id=tool_id,
             tool_version=tool_version,
+            preserve_galaxy_python_environment=preserve_galaxy_python_environment,
         )
 
     @property
@@ -75,7 +76,7 @@ class RemoteSetupHandler(object):
         return False
 
 
-def build_job_config(job_id, job_directory, system_properties={}, tool_id=None, tool_version=None):
+def build_job_config(job_id, job_directory, system_properties={}, tool_id=None, tool_version=None, preserve_galaxy_python_environment=None):
     """
     """
     inputs_directory = job_directory.inputs_directory()
@@ -100,6 +101,7 @@ def build_job_config(job_id, job_directory, system_properties={}, tool_id=None, 
         "job_id": job_id,
         "system_properties": system_properties,
         "pulsar_version": pulsar_version,
+        "preserve_galaxy_python_environment": preserve_galaxy_python_environment,
     }
     if tool_id:
         job_config["tool_id"] = tool_id

--- a/pulsar/manager_endpoint_util.py
+++ b/pulsar/manager_endpoint_util.py
@@ -80,7 +80,7 @@ def submit_job(manager, job_config):
             input_job_id,
             tool_id,
             tool_version,
-            use_metadata
+            use_metadata,
         )
 
     if job_config is not None:
@@ -98,6 +98,7 @@ def submit_job(manager, job_config):
         submit_params,
         dependencies_description=dependencies_description,
         env=env,
+        setup_params=setup_params,
     )
 
 

--- a/pulsar/managers/__init__.py
+++ b/pulsar/managers/__init__.py
@@ -26,7 +26,7 @@ class ManagerInterface(object):
         """
 
     @abstractmethod
-    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[]):
+    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
         """
         Called to indicate that the client is ready for this job with specified
         job id and command line to be executed (i.e. run or queue this job

--- a/pulsar/managers/base/__init__.py
+++ b/pulsar/managers/base/__init__.py
@@ -87,6 +87,7 @@ class BaseManager(ManagerInterface):
 
     def __init_galaxy_system_properties(self, kwds):
         self.galaxy_home = kwds.get('galaxy_home', None)
+        self.galaxy_virtual_env = kwds.get('galaxy_virtual_env', None)
         self.galaxy_config_file = kwds.get('galaxy_config_file', None)
         self.galaxy_dataset_files_path = kwds.get('galaxy_dataset_files_path', None)
         self.galaxy_datatypes_config_file = kwds.get('galaxy_datatypes_config_file', None)
@@ -98,6 +99,9 @@ class BaseManager(ManagerInterface):
         galaxy_home = self._galaxy_home()
         if galaxy_home:
             system_properties["galaxy_home"] = galaxy_home
+        galaxy_virtual_env = self._galaxy_virtual_env()
+        if galaxy_virtual_env:
+            system_properties["galaxy_virtual_env"] = galaxy_virtual_env
         for property in ['galaxy_config_file', 'galaxy_dataset_files_path', 'galaxy_datatypes_config_file']:
             value = getattr(self, property, None)
             if value:
@@ -115,6 +119,9 @@ class BaseManager(ManagerInterface):
 
     def _galaxy_home(self):
         return self.galaxy_home or getenv('GALAXY_HOME', None)
+
+    def _galaxy_virtual_env(self):
+        return self.galaxy_virtual_env or getenv('GALAXY_VIRTUAL_ENV', None)
 
     def _galaxy_lib(self):
         galaxy_home = self._galaxy_home()

--- a/pulsar/managers/base/base_drmaa.py
+++ b/pulsar/managers/base/base_drmaa.py
@@ -51,12 +51,18 @@ class BaseDrmaaManager(ExternalBaseManager):
             JobState.FAILED: status.COMPLETE,  # Should be a FAILED state here as well
         }[drmaa_state]
 
-    def _build_template_attributes(self, job_id, command_line, dependencies_description=None, env=[], submit_params={}):
+    def _build_template_attributes(self, job_id, command_line, dependencies_description=None, env=[], submit_params={}, setup_params=None):
         stdout_path = self._stdout_path(job_id)
         stderr_path = self._stderr_path(job_id)
 
         attributes = {
-            "remoteCommand": self._setup_job_file(job_id, command_line, dependencies_description=dependencies_description, env=env),
+            "remoteCommand": self._setup_job_file(
+                job_id,
+                command_line,
+                dependencies_description=dependencies_description,
+                env=env,
+                setup_params=setup_params
+            ),
             "jobName": self._job_name(job_id),
             "outputPath": ":%s" % stdout_path,
             "errorPath": ":%s" % stderr_path,

--- a/pulsar/managers/queued.py
+++ b/pulsar/managers/queued.py
@@ -45,8 +45,14 @@ class QueueManager(Manager):
             worker.start()
             self.work_threads.append(worker)
 
-    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[]):
-        command_line = self._prepare_run(job_id, command_line, dependencies_description=dependencies_description, env=env)
+    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
+        command_line = self._prepare_run(
+            job_id,
+            command_line,
+            dependencies_description=dependencies_description,
+            env=env,
+            setup_params=setup_params
+        )
         try:
             self._job_directory(job_id).store_metadata(JOB_FILE_COMMAND_LINE, command_line)
         except Exception:

--- a/pulsar/managers/queued_cli.py
+++ b/pulsar/managers/queued_cli.py
@@ -20,14 +20,19 @@ class CliQueueManager(ExternalBaseManager):
         self.cli_interface = CliInterface(code_dir='.')
         self.shell_params, self.job_params = split_params(kwds)
 
-    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[]):
+    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
         self._check_execution_with_tool_file(job_id, command_line)
         shell, job_interface = self.__get_cli_plugins()
         stdout_path = self._stdout_path(job_id)
         stderr_path = self._stderr_path(job_id)
         job_name = self._job_name(job_id)
         command_line = self._expand_command_line(command_line, dependencies_description, job_directory=self.job_directory(job_id).job_directory)
-        job_script_kwargs = self._job_template_env(job_id, command_line=command_line, env=env)
+        job_script_kwargs = self._job_template_env(
+            job_id,
+            command_line=command_line,
+            env=env,
+            setup_params=setup_params
+        )
         extra_kwargs = job_interface.job_script_kwargs(stdout_path, stderr_path, job_name)
         job_script_kwargs.update(extra_kwargs)
         script = job_script(**job_script_kwargs)

--- a/pulsar/managers/queued_condor.py
+++ b/pulsar/managers/queued_condor.py
@@ -26,9 +26,15 @@ class CondorQueueManager(ExternalBaseManager):
         self.user_log_sizes = {}
         self.state_cache = {}
 
-    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[]):
+    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
         self._check_execution_with_tool_file(job_id, command_line)
-        job_file_path = self._setup_job_file(job_id, command_line, dependencies_description=dependencies_description, env=env)
+        job_file_path = self._setup_job_file(
+            job_id,
+            command_line,
+            dependencies_description=dependencies_description,
+            env=env,
+            setup_params=setup_params
+        )
         log_path = self.__condor_user_log(job_id)
         open(log_path, 'w')  # Touch log file
         build_submit_params = dict(

--- a/pulsar/managers/queued_drmaa.py
+++ b/pulsar/managers/queued_drmaa.py
@@ -10,7 +10,7 @@ class DrmaaQueueManager(BaseDrmaaManager):
     """
     manager_type = "queued_drmaa"
 
-    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[]):
+    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
         self._check_execution_with_tool_file(job_id, command_line)
         attributes = self._build_template_attributes(
             job_id,
@@ -18,6 +18,7 @@ class DrmaaQueueManager(BaseDrmaaManager):
             dependencies_description=dependencies_description,
             env=env,
             submit_params=submit_params,
+            setup_params=setup_params,
         )
         external_id = self.drmaa_session.run_job(**attributes)
         log.info("Submitted DRMAA job with Pulsar job id %s and external id %s", job_id, external_id)

--- a/pulsar/managers/queued_drmaa_xsede.py
+++ b/pulsar/managers/queued_drmaa_xsede.py
@@ -16,13 +16,14 @@ class XsedeDrmaaQueueManager(DrmaaQueueManager):
     """
     manager_type = "queued_drmaa_xsede"
 
-    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[]):
+    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
         super(XsedeDrmaaQueueManager, self).launch(
             job_id,
             command_line,
             submit_params=submit_params,
             dependencies_description=dependencies_description,
-            env=env
+            env=env,
+            setup_params=setup_params,
         )
         try:
             check_call([

--- a/pulsar/managers/queued_external_drmaa.py
+++ b/pulsar/managers/queued_external_drmaa.py
@@ -31,7 +31,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
         self.reclaimed = {}
         self.user_map = {}
 
-    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[]):
+    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
         self._check_execution_with_tool_file(job_id, command_line)
         attributes = self._build_template_attributes(
             job_id,
@@ -39,6 +39,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
             dependencies_description=dependencies_description,
             env=env,
             submit_params=submit_params,
+            setup_params=setup_params,
         )
         print(open(attributes['remoteCommand'], 'r').read())
         job_attributes_file = self._write_job_file(job_id, 'jt.json', dumps(attributes))

--- a/pulsar/managers/unqueued.py
+++ b/pulsar/managers/unqueued.py
@@ -142,11 +142,11 @@ class Manager(DirectoryBaseManager):
         else:
             self._monitor_execution(job_id, proc, stdout, stderr)
 
-    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[]):
-        command_line = self._prepare_run(job_id, command_line, dependencies_description=dependencies_description, env=env)
+    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
+        command_line = self._prepare_run(job_id, command_line, dependencies_description=dependencies_description, env=env, setup_params=setup_params)
         self._run(job_id, command_line)
 
-    def _prepare_run(self, job_id, command_line, dependencies_description, env):
+    def _prepare_run(self, job_id, command_line, dependencies_description, env, setup_params=None):
         self._check_execution_with_tool_file(job_id, command_line)
         self._record_submission(job_id)
         if platform.system().lower() == "windows":
@@ -154,7 +154,13 @@ class Manager(DirectoryBaseManager):
             # process them or at least warn about them being ignored.
             command_line = self._expand_command_line(command_line, dependencies_description, job_directory=self.job_directory(job_id).job_directory)
         else:
-            command_line = self._setup_job_file(job_id, command_line, dependencies_description=dependencies_description, env=env)
+            command_line = self._setup_job_file(
+                job_id,
+                command_line,
+                dependencies_description=dependencies_description,
+                env=env,
+                setup_params=setup_params
+            )
         return command_line
 
 

--- a/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -1,5 +1,7 @@
 #!$shell
 
+$headers
+
 _galaxy_setup_environment() {
     local _use_framework_galaxy="$1"
     if [ "$GALAXY_LIB" != "None" -a "$_use_framework_galaxy" = "True" ]; then
@@ -11,18 +13,17 @@ _galaxy_setup_environment() {
         export PYTHONPATH
     fi
     $env_setup_commands
-    if [ "$GALAXY_VIRTUAL_ENV" != "None" -a  "$_use_framework_galaxy" = "True" \
-         -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" \
+    if [ "$GALAXY_VIRTUAL_ENV" != "None" -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" \
          -a "`command -v python`" != "$GALAXY_VIRTUAL_ENV/bin/python" ]; then
         . "$GALAXY_VIRTUAL_ENV/bin/activate"
     fi
 }
 
-$headers
 $integrity_injection
 $slots_statement
 export GALAXY_SLOTS
 GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
+_GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
 PRESERVE_GALAXY_ENVIRONMENT="$preserve_python_environment"
 GALAXY_LIB="$galaxy_lib"
 _galaxy_setup_environment "$PRESERVE_GALAXY_ENVIRONMENT"

--- a/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -1,24 +1,32 @@
 #!$shell
 
+_galaxy_setup_environment() {
+    local _use_framework_galaxy="$1"
+    if [ "$GALAXY_LIB" != "None" -a "$_use_framework_galaxy" = "True" ]; then
+        if [ -n "$PYTHONPATH" ]; then
+            PYTHONPATH="$GALAXY_LIB:$PYTHONPATH"
+        else
+            PYTHONPATH="$GALAXY_LIB"
+        fi
+        export PYTHONPATH
+    fi
+    $env_setup_commands
+    if [ "$GALAXY_VIRTUAL_ENV" != "None" -a  "$_use_framework_galaxy" = "True" \
+         -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" \
+         -a "`command -v python`" != "$GALAXY_VIRTUAL_ENV/bin/python" ]; then
+        . "$GALAXY_VIRTUAL_ENV/bin/activate"
+    fi
+}
+
 $headers
 $integrity_injection
 $slots_statement
 export GALAXY_SLOTS
-GALAXY_LIB="$galaxy_lib"
-if [ "$GALAXY_LIB" != "None" ]; then
-    if [ -n "$PYTHONPATH" ]; then
-        PYTHONPATH="$GALAXY_LIB:$PYTHONPATH"
-    else
-        PYTHONPATH="$GALAXY_LIB"
-    fi
-    export PYTHONPATH
-fi
-$env_setup_commands
 GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
-if [ "$GALAXY_VIRTUAL_ENV" != "None" -a -z "$VIRTUAL_ENV" \
-     -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" ]; then
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
+PRESERVE_GALAXY_ENVIRONMENT="$preserve_python_environment"
+GALAXY_LIB="$galaxy_lib"
+_galaxy_setup_environment "$PRESERVE_GALAXY_ENVIRONMENT"
+GALAXY_PYTHON=`command -v python`
 $instrument_pre_commands
 cd $working_directory
 $command

--- a/pulsar/managers/util/job_script/__init__.py
+++ b/pulsar/managers/util/job_script/__init__.py
@@ -1,10 +1,11 @@
 import os
-from string import Template
 import subprocess
 import time
-from pkg_resources import resource_string
+from string import Template
 
+from pkg_resources import resource_string
 from six import text_type
+
 from galaxy.util import unicodify
 
 DEFAULT_SHELL = '/bin/bash'
@@ -44,6 +45,7 @@ OPTIONAL_TEMPLATE_PARAMS = {
     'instrument_post_commands': '',
     'integrity_injection': INTEGRITY_INJECTION,
     'shell': DEFAULT_SHELL,
+    'preserve_python_environment': True,
 }
 
 
@@ -140,9 +142,9 @@ def _handle_script_integrity(path, config):
         raise Exception("Failed to write job script, could not verify job script integrity.")
 
 
-__all__ = [
+__all__ = (
     'check_script_integrity',
     'job_script',
     'write_script',
     'INTEGRITY_INJECTION',
-]
+)


### PR DESCRIPTION
- Properly support `$GALAXY_VIRTUAL_ENV` in Pulsar. This will work if set in the environment or as `<param id="remote_property_galaxy_virtual_env">/path/to/venv</param>` on a Pulsar destination in Galaxy's `job_conf.xml`. And maybe if set in `app.yml`? On a manager??
- Support `$PRESERVE_GALAXY_ENVIRONMENT` so the Galaxy env won't be set up for tools that don't need it.
- Properly (re)activate the Galaxy virtualenv after running the tool command

Galaxy virtualenv reactivation works in Galaxy because the tool command is in a separate file, and so executes in a subshell of the job script, so any environmental changes made for the tool don't propagate back to the job script environment.

With Pulsar, the tool command line is generated with metadata commands on the Galaxy side and passed to Pulsar as the command to run - Pulsar has no knowledge which part is tool command and which part is metadata command. While we could wrap the Galaxy portion of the command in an inline subshell (e.g. `( tool-cmd ) ; metadata_cmd`), dependency setup command generation is done on the Pulsar side, so it'd happen outside the subshell and thus makes a subshell moot.

Ideally, we'd send the tool and metadata commands to Pulsar separately so it could perform the same isolation that's possible in Galaxy, but in lieu of that, we can fix what Galaxy already does to try to ensure a working Galaxy virtualenv and lib for `set_metadata.py`.

Prior to this change, the only way you could set up Galaxy's virtualenv for Pulsar remote metadata was to activate it with an `<env>` tag on the destination. This meant it was activated before the tool command, and the tool command could (and did, in the case of Unicycler) put a different `python` on `$PATH`, which would cause remote metadata to fail.

xref galaxyproject/galaxy#4622