### PR TITLE
Update link for logo image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. figure:: https://wiki.galaxyproject.org/Images/GalaxyLogos?action=AttachFile&do=get&target=pulsar_transparent.png
+.. figure:: https://galaxyproject.org/images/galaxy-logos/pulsar_transparent.png
    :alt: Pulsar Logo
 
 .. image:: https://readthedocs.org/projects/pulsar/badge/?version=latest


### PR DESCRIPTION
Old link is giving a 404 error. New link from dannon to new wiki.