### PR TITLE
Strip quotes from around filenames when matching

### DIFF
--- a/pulsar/client/staging/up.py
+++ b/pulsar/client/staging/up.py
@@ -351,7 +351,7 @@ class JobInputs(object):
         referenced_files = set()
         for input_contents in self.__items():
             referenced_files.update(findall(pattern, input_contents))
-        return list(referenced_files)
+        return map(lambda x: x.strip("'\""), list(referenced_files))
 
     def find_referenced_subfiles(self, directory):
         """


### PR DESCRIPTION
Fixes issues caused by a hanging `'` when quotes were used around a `$__tool_directory__` file.