### PR TITLE
Improve message handling if problems occur during job setup/staging.

### DIFF
--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -97,6 +97,9 @@ class StatefulManagerProxy(ManagerProxy):
 
         new_thread_for_job(self, "preprocess", job_id, do_preprocess, daemon=False)
 
+    def handle_failure_before_launch(self, job_id):
+        self.__state_change_callback(status.FAILED, job_id)
+
     def get_status(self, job_id):
         """ Compute status used proxied manager and handle state transitions
         and track additional state information needed.

--- a/test/integration_test_cli_submit.py
+++ b/test/integration_test_cli_submit.py
@@ -5,6 +5,7 @@ from .test_utils import (
     TempDirectoryTestCase,
     files_server,
     integration_test,
+    skip_unless_module,
 )
 
 from pulsar.client.util import to_base64_json
@@ -13,6 +14,7 @@ from pulsar.scripts import submit
 
 class CliTestCase(TempDirectoryTestCase):
 
+    @skip_unless_module("kombu")
     @integration_test
     def test(self):
         # TODO: test unstaging, would actually require files server and some

--- a/test/integration_test_state.py
+++ b/test/integration_test_state.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 import threading
 import time
 
@@ -17,13 +18,14 @@ from pulsar.client.amqp_exchange_factory import get_exchange
 from pulsar.managers.util.drmaa import DrmaaSessionFactory
 
 
-class RestartTestCase(TempDirectoryTestCase):
+class StateIntegrationTestCase(TempDirectoryTestCase):
 
     @skip_without_drmaa
     @skip_unless_module("kombu")
     @integration_test
     def test_restart_finishes_job(self):
-        with self._setup_app_provider("restart_and_finish") as app_provider:
+        test = "restart_finishes"
+        with self._setup_app_provider(test) as app_provider:
             job_id = '12345'
 
             with app_provider.new_app() as app:
@@ -47,7 +49,7 @@ class RestartTestCase(TempDirectoryTestCase):
             drmaa_session = DrmaaSessionFactory().get()
             drmaa_session.kill(external_id)
             drmaa_session.close()
-            consumer = self._status_update_consumer("restart_and_finish")
+            consumer = self._status_update_consumer(test)
             consumer.start()
 
             with app_provider.new_app() as app:
@@ -61,7 +63,7 @@ class RestartTestCase(TempDirectoryTestCase):
     @skip_unless_module("kombu")
     @integration_test
     def test_recovery_failure_fires_lost_status(self):
-        test = "restart_and_finish"
+        test = "restart_failure_fires_lost"
         with self._setup_app_provider(test) as app_provider:
             job_id = '12345'
 
@@ -85,12 +87,76 @@ class RestartTestCase(TempDirectoryTestCase):
             assert len(consumer.messages) == 1, len(consumer.messages)
             assert consumer.messages[0]["status"] == "lost"
 
+    @skip_unless_module("kombu")
+    @integration_test
+    def test_staging_failure_fires_failed_status(self):
+        test = "stating_failure_fires_failed"
+        with self._setup_app_provider(test, manager_type="queued_python") as app_provider:
+            job_id = '12345'
+
+            consumer = self._status_update_consumer(test)
+            consumer.start()
+
+            with app_provider.new_app() as app:
+                manager = app.only_manager
+                job_info = {
+                    'job_id': job_id,
+                    'command_line': 'sleep 1000',
+                    'setup': True,
+                    # Invalid staging description...
+                    'remote_staging': {"setup": [{"moo": "cow"}]}
+                }
+                # TODO: redo this with submit_job coming through MQ for test consistency.
+                submit_job(manager, job_info)
+
+            import time
+            time.sleep(2)
+            consumer.wait_for_messages()
+            consumer.join()
+
+            assert len(consumer.messages) == 1, len(consumer.messages)
+            assert consumer.messages[0]["status"] == "failed"
+
+    @skip_unless_module("kombu")
+    @integration_test
+    def test_setup_failure_fires_failed_status(self):
+        test = "stating_failure_fires_failed"
+        with self._setup_app_provider(test, manager_type="queued_python") as app_provider:
+            job_id = '12345'
+
+            consumer = self._status_update_consumer(test)
+            consumer.start()
+
+            with app_provider.new_app() as app:
+                manager = app.only_manager
+                job_info = {
+                    'job_id': job_id,
+                    'command_line': 'sleep 1000',
+                    'setup': True,
+                }
+
+                with open(os.path.join(app_provider.staging_directory, job_id), "w") as f:
+                    f.write("File where staging directory should be, setup should fail now.")
+
+                # TODO: redo this with submit_job coming through MQ for test consistency,
+                # would eliminate the need for the exception catch as well.
+                try:
+                    submit_job(manager, job_info)
+                except Exception:
+                    pass
+
+            consumer.wait_for_messages()
+            consumer.join()
+
+            assert len(consumer.messages) == 1, len(consumer.messages)
+            assert consumer.messages[0]["status"] == "failed"
+
     @contextlib.contextmanager
-    def _setup_app_provider(self, test):
+    def _setup_app_provider(self, test, manager_type="queued_drmaa"):
         mq_url = "memory://test_%s" % test
         manager = "manager_%s" % test
         app_conf = dict(message_queue_url=mq_url)
-        app_conf["managers"] = {manager: {'type': 'queued_drmaa'}}
+        app_conf["managers"] = {manager: {'type': manager_type}}
         with restartable_pulsar_app_provider(app_conf=app_conf, web=False) as app_provider:
             yield app_provider
 


### PR DESCRIPTION
For staging, it already worked I think but add a test case to make sure.

For setup problems, we now explicitly raise a message.

Fixes #129 (I think anyway).