### PR TITLE
Rework preprocessing job state.

### DIFF
--- a/pulsar/manager_endpoint_util.py
+++ b/pulsar/manager_endpoint_util.py
@@ -9,7 +9,6 @@ from pulsar import __version__ as pulsar_version
 from pulsar.client.setup_handler import build_job_config
 from pulsar.managers import status
 from pulsar.managers import PULSAR_UNKNOWN_RETURN_CODE
-from galaxy.tools.deps import dependencies
 
 log = logging.getLogger(__name__)
 
@@ -92,17 +91,15 @@ def submit_job(manager, job_config):
 
         # TODO: Handle __PULSAR_JOB_DIRECTORY__ config files, metadata files, etc...
         manager.touch_outputs(job_id, touch_outputs)
-        manager.handle_remote_staging(job_id, remote_staging)
-
-        dependencies_description = dependencies.DependenciesDescription.from_dict(dependencies_description)
-        return manager.launch(
-            job_id,
-            command_line,
-            submit_params,
-            dependencies_description=dependencies_description,
-            env=env,
-            setup_params=setup_params,
-        )
+        launch_config = {
+            "remote_staging": remote_staging,
+            "command_line": command_line,
+            "dependencies_description": dependencies_description,
+            "submit_params": submit_params,
+            "env": env,
+            "setup_params": setup_params,
+        }
+        manager.preprocess_and_launch(job_id, launch_config)
     except Exception:
         manager.handle_failure_before_launch(job_id)
         raise

--- a/pulsar/managers/staging/post.py
+++ b/pulsar/managers/staging/post.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 def postprocess(job_directory, action_executor):
     # Returns True if outputs were collected.
     try:
-        staging_config = job_directory.load_metadata("staging_config", None)
+        staging_config = job_directory.load_metadata("launch_config", {}).get("remote_staging", {})
         collected = __collect_outputs(job_directory, staging_config, action_executor)
         return collected
     finally:

--- a/pulsar/managers/staging/post.py
+++ b/pulsar/managers/staging/post.py
@@ -14,7 +14,16 @@ log = logging.getLogger(__name__)
 def postprocess(job_directory, action_executor):
     # Returns True if outputs were collected.
     try:
-        staging_config = job_directory.load_metadata("launch_config", {}).get("remote_staging", {})
+        if job_directory.has_metadata("launch_config"):
+            staging_config = job_directory.load_metadata("launch_config").get("remote_staging", None)
+        elif job_directory.has_metadata("staging_config"):
+            # This branch of the if is for Pulsar servers that have created jobs prior to
+            # #164 but are postprocessing after the inclusion of #164 (upgraded in the middle).
+            # This can be eliminated sometime - say in 2019 or whenever there is a breaking
+            # change in some other way.
+            staging_config = job_directory.load_metadata("staging_config", None)
+        else:
+            staging_config = None
         collected = __collect_outputs(job_directory, staging_config, action_executor)
         return collected
     finally:

--- a/test/persistence_test.py
+++ b/test/persistence_test.py
@@ -28,7 +28,7 @@ def test_persistence():
         queue1 = StatefulManagerProxy(QueueManager('test', app, num_concurrent_jobs=0))
         job_id = queue1.setup_job('4', 'tool1', '1.0.0')
         touch_file = join(staging_directory, 'ran')
-        queue1.launch(job_id, 'touch %s' % touch_file)
+        queue1.preprocess_and_launch(job_id, {"command_line": 'touch %s' % touch_file})
         time.sleep(.4)
         assert (not(exists(touch_file)))
         queue1.shutdown()

--- a/test/persistence_test.py
+++ b/test/persistence_test.py
@@ -1,44 +1,137 @@
+from contextlib import contextmanager
 from os.path import exists, join
-import shutil
-import tempfile
 import time
 
 from pulsar.managers.queued import QueueManager
 from pulsar.managers.stateful import StatefulManagerProxy
 from pulsar.tools.authorization import get_authorizer
-from .test_utils import TestDependencyManager
-
+from .test_utils import (
+    temp_directory,
+    TestDependencyManager
+)
 from galaxy.util.bunch import Bunch
 from galaxy.jobs.metrics import NULL_JOB_INSTRUMENTER
 
+TEST_JOB_ID = "4"
+TEST_STAGED_FILE = "cow"
+TEST_COMMAND_TOUCH_FILE = "ran"
 
-def test_persistence():
-    """
-    Tests persistence of a managers jobs.
-    """
-    staging_directory = tempfile.mkdtemp()
-    try:
-        app = Bunch(staging_directory=staging_directory,
-                    persistence_directory=staging_directory,
-                    authorizer=get_authorizer(None),
-                    dependency_manager=TestDependencyManager(),
-                    job_metrics=Bunch(default_job_instrumenter=NULL_JOB_INSTRUMENTER),
-                    )
-        assert not exists(join(staging_directory, "queued_jobs"))
+
+def test_launched_job_recovery():
+    """Tests persistence and recovery of launched managers jobs."""
+    with _app() as app:
+        staging_directory = app.staging_directory
         queue1 = StatefulManagerProxy(QueueManager('test', app, num_concurrent_jobs=0))
-        job_id = queue1.setup_job('4', 'tool1', '1.0.0')
-        touch_file = join(staging_directory, 'ran')
+        job_id = queue1.setup_job(TEST_JOB_ID, 'tool1', '1.0.0')
+        touch_file = join(staging_directory, TEST_COMMAND_TOUCH_FILE)
         queue1.preprocess_and_launch(job_id, {"command_line": 'touch %s' % touch_file})
         time.sleep(.4)
-        assert (not(exists(touch_file)))
+        assert not exists(touch_file)
         queue1.shutdown()
-        queue2 = StatefulManagerProxy(QueueManager('test', app, num_concurrent_jobs=1))
+        _setup_manager_that_executes(app)
+        assert exists(touch_file)
+
+
+def test_preprocessing_job_recovery():
+    """Tests persistence and recovery of preprocessing managers jobs (clean)."""
+    with _app() as app:
+        _setup_job_with_unexecuted_preprocessing_directive(app)
+        staging_directory = app.staging_directory
+        staged_file = join(staging_directory, TEST_JOB_ID, "inputs", TEST_STAGED_FILE)
+        touch_file = join(staging_directory, TEST_COMMAND_TOUCH_FILE)
+
+        # File shouldn't have been staged because we hacked stateful proxy manager to not
+        # run preprocess.
+        assert not exists(staged_file)
+
+        _setup_manager_that_preprocesses(app)
+
+        assert exists(staged_file)
+        assert not exists(touch_file)
+
+        _setup_manager_that_executes(app)
+        assert exists(touch_file)
+
+
+def test_preprocessing_job_recovery_dirty():
+    """Tests persistence and recovery of preprocessing managers jobs (dirty)."""
+
+    # Same test as above, but simulating existing files from a previous partial
+    # preprocess.
+    with _app() as app:
+        _setup_job_with_unexecuted_preprocessing_directive(app)
+        staging_directory = app.staging_directory
+        staged_file = join(staging_directory, TEST_JOB_ID, "inputs", TEST_STAGED_FILE)
+        touch_file = join(staging_directory, TEST_COMMAND_TOUCH_FILE)
+
+        # File shouldn't have been staged because we hacked stateful proxy manager to not
+        # run preprocess.
+        assert not exists(staged_file)
+        # write out partial contents, make sure preprocess writes over this with the correct
+        # contents.
+        open(staged_file, "wb").write(b"co")
+        _setup_manager_that_preprocesses(app)
+
+        assert exists(staged_file)
+        assert open(staged_file, "rb").read() == b"cow file"
+        assert not exists(touch_file)
+
+        _setup_manager_that_executes(app)
+        assert exists(touch_file)
+
+
+def _setup_manager_that_preprocesses(app):
+    # Setup a manager that will preprocess the job but won't execute it.
+
+    # Now start a real stateful manager proxy and watch the file get staged.
+    queue2 = StatefulManagerProxy(QueueManager('test', app, num_concurrent_jobs=0))
+    try:
         queue2.recover_active_jobs()
         time.sleep(1)
-        assert exists(touch_file)
     finally:
-        shutil.rmtree(staging_directory)
         try:
             queue2.shutdown()
         except Exception:
             pass
+
+
+def _setup_job_with_unexecuted_preprocessing_directive(app):
+    staging_directory = app.staging_directory
+    queue1 = DoesntPreprocessStatefulManagerProxy(QueueManager('test', app, num_concurrent_jobs=0))
+    job_id = queue1.setup_job(TEST_JOB_ID, 'tool1', '1.0.0')
+    action = {"name": TEST_STAGED_FILE, "type": "input", "action": {"action_type": "message", "contents": "cow file"}}
+    remote_staging = {"setup": [action]}
+    touch_file = join(staging_directory, TEST_COMMAND_TOUCH_FILE)
+    queue1.preprocess_and_launch(job_id, {"command_line": "touch '%s'" % touch_file, "remote_staging": remote_staging})
+    queue1.shutdown()
+
+
+def _setup_manager_that_executes(app):
+    queue2 = StatefulManagerProxy(QueueManager('test', app, num_concurrent_jobs=1))
+    try:
+        queue2.recover_active_jobs()
+        time.sleep(1)
+    finally:
+        try:
+            queue2.shutdown()
+        except Exception:
+            pass
+
+
+@contextmanager
+def _app():
+    with temp_directory() as staging_directory:
+        app = Bunch(
+            staging_directory=staging_directory,
+            persistence_directory=staging_directory,
+            authorizer=get_authorizer(None),
+            dependency_manager=TestDependencyManager(),
+            job_metrics=Bunch(default_job_instrumenter=NULL_JOB_INSTRUMENTER),
+        )
+        yield app
+
+
+class DoesntPreprocessStatefulManagerProxy(StatefulManagerProxy):
+
+    def _launch_prepreprocessing_thread(self, job_id, launch_config):
+        pass


### PR DESCRIPTION
- Instead of persisting job metadata for preprocessing - write out metadata for preprocessing and launching.
- Track list of jobs currently being "preprocessed" - not just launched.
- Use the list to attempt to "recover" preprocessing jobs after restart.
- Skip preprocessing complexity all together (extra metadata in the job for instance and this new list) if not preprocessing steps are needed.
- Test case for new behavior.

Should fix #161.