### PR TITLE
Kubernetes Two-Container Pod Staging and Exec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,5 +166,8 @@ _dist-lib:
 
 dist-lib: clean _dist-lib
 
+build-coexecutor-container:
+	$(MAKE) -C docker/coexecutor all
+
 #release-test-lib-artifacts: dist-lib _release-test-artifacts
 #release-lib-artifacts: release-test-lib-artifacts _release-artifacts

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 # Optional requirements used by test cases
 pycurl
 kombu
+pykube
 
 # For testing
 nose

--- a/docker/coexecutor/Dockerfile
+++ b/docker/coexecutor/Dockerfile
@@ -1,0 +1,24 @@
+FROM conda/miniconda2
+
+ENV PYTHONUNBUFFERED 1
+ENV DEBIAN_FRONTEND noninteractive
+ENV PULSAR_CONFIG_CONDA_PREFIX /usr/local
+
+# TODO: pycurl stuff...
+
+RUN apt-get update \
+    # Install CVMFS client
+    && apt-get install -y --no-install-recommends lsb-release wget \
+        gcc python-setuptools \
+        python-dev python-pip \
+    && apt-get -y autoremove \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
+
+RUN pip install -U pip && pip install wheel
+
+ADD pulsar_app-0.9.0-py2.py3-none-any.whl /pulsar_app-0.9.0-py2.py3-none-any.whl
+
+RUN pip install /pulsar_app-0.9.0-py2.py3-none-any.whl
+
+RUN pip install kombu pykube poster

--- a/docker/coexecutor/Makefile
+++ b/docker/coexecutor/Makefile
@@ -1,0 +1,7 @@
+
+
+docker-image:
+	cd ../..; make dist; cp dist/pulsar*whl docker/coexecutor
+
+all: docker-image
+	docker build -t 'galaxy/pulsar-pod-staging:0.1' .

--- a/pulsar/client/action_mapper.py
+++ b/pulsar/client/action_mapper.py
@@ -196,7 +196,7 @@ class FileActionMapper(object):
         if action_config_path:
             config = read_file(action_config_path)
         else:
-            config = dict()
+            config = getattr(client, "file_actions", {})
         config["default_action"] = client.default_file_action
         config["files_endpoint"] = client.files_endpoint
         for attr in ['ssh_key', 'ssh_user', 'ssh_port', 'ssh_host']:

--- a/pulsar/client/action_mapper.py
+++ b/pulsar/client/action_mapper.py
@@ -2,7 +2,6 @@ import fnmatch
 import tempfile
 
 from contextlib import contextmanager
-from json import load
 from os import makedirs
 from os import unlink
 from os.path import (
@@ -203,10 +202,6 @@ class FileActionMapper(object):
             if hasattr(client, attr):
                 config[attr] = getattr(client, attr)
         return config
-
-    def __load_action_config(self, path):
-        config = load(open(path, 'rb'))
-        self.mappers = mappers_from_dicts(config.get('paths', []))
 
     def __find_mapper(self, path, type, mapper=None):
         if not mapper:

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -3,6 +3,13 @@ import os
 
 from six import string_types
 
+from pulsar.managers.util.pykube_util import (
+    Job,
+    job_object_dict,
+    produce_unique_k8s_job_name,
+    pull_policy,
+    pykube_client_from_dict,
+)
 from .action_mapper import (
     actions,
     path_type,
@@ -21,6 +28,14 @@ from .util import to_base64_json
 log = logging.getLogger(__name__)
 
 CACHE_WAIT_SECONDS = 3
+TOOL_EXECUTION_CONTAINER_COMMAND_TEMPLATE = """
+path='%s/command_line';
+while [ ! -e $path ];
+    do sleep 1; echo 'waiting for job script...';
+done;
+echo 'running script';
+sh $path;
+echo 'ran script'"""
 
 
 class OutputNotFoundException(Exception):
@@ -343,6 +358,85 @@ class MessageCLIJobClient(BaseMessageJobClient):
 
     def kill(self):
         # TODO
+        pass
+
+
+class MessageCoexecutionPodJobClient(BaseMessageJobClient):
+
+    def __init__(self, destination_params, job_id, client_manager):
+        super(MessageCoexecutionPodJobClient, self).__init__(destination_params, job_id, client_manager)
+        self.pulsar_container_image = destination_params.get("pulsar_container_image", "galaxy/pulsar-pod-staging:0.1")
+        self._default_pull_policy = pull_policy(destination_params)
+
+    def launch(self, command_line, dependencies_description=None, env=[], remote_staging=[], job_config=None, container=None, pulsar_app_config=None):
+        """
+        """
+        launch_params = self._build_setup_message(
+            command_line,
+            dependencies_description=dependencies_description,
+            env=env,
+            remote_staging=remote_staging,
+            job_config=job_config,
+        )
+        base64_message = to_base64_json(launch_params)
+        base64_app_conf = to_base64_json(pulsar_app_config)
+
+        # TODO: instance_id for Pulsar...
+        job_name = produce_unique_k8s_job_name(app_prefix="pulsar")
+        params = self.destination_params
+
+        pulsar_container_image = self.pulsar_container_image
+
+        job_directory = self.job_directory
+
+        volumes = [
+            {"name": "staging-directory", "emptyDir": {}},
+        ]
+        volume_mounts = [
+            {"mountPath": "/pulsar_staging", "name": "staging-directory"},
+        ]
+        tool_container_image = container  # TODO: this isn't right at all...
+        pulsar_container_dict = {
+            "name": "pulsar-container",
+            "image": pulsar_container_image,
+            "command": ["pulsar-submit"],
+            "args": ["--base64", base64_message, "--app_conf_base64", base64_app_conf],
+            "workingDir": "/",
+            "volumeMounts": volume_mounts,
+        }
+        command = TOOL_EXECUTION_CONTAINER_COMMAND_TEMPLATE % job_directory.job_directory
+        tool_container_spec = {
+            "name": "tool-container",
+            "image": tool_container_image,
+            "command": ["bash"],
+            "args": ["-c", command],
+            "workingDir": "/",
+            "volumeMounts": volume_mounts,
+        }
+
+        container_dicts = [pulsar_container_dict, tool_container_spec]
+        for container_dict in container_dicts:
+            if self._default_pull_policy:
+                container_dict["imagePullPolicy"] = self._default_pull_policy
+
+        template = {
+            "metadata": {
+                "labels": {"app": job_name},
+            },
+            "spec": {
+                "volumes": volumes,
+                "restartPolicy": "Never",
+                "containers": container_dicts,
+            }
+        }
+        spec = {"template": template}
+        k8s_job_obj = job_object_dict(params, job_name, spec)
+        pykube_client = pykube_client_from_dict(self.destination_params)
+        job = Job(pykube_client, k8s_job_obj)
+        job.create()
+
+    def kill(self):
+        # TODO: kill pod...
         pass
 
 

--- a/pulsar/client/manager.py
+++ b/pulsar/client/manager.py
@@ -20,6 +20,7 @@ from .client import InputCachingJobClient
 from .client import JobClient
 from .client import MessageJobClient
 from .client import MessageCLIJobClient
+from .client import MessageCoexecutionPodJobClient
 from .destination import url_to_destination_params
 from .interface import HttpPulsarInterface
 from .interface import LocalPulsarInterface
@@ -212,6 +213,8 @@ class MessageQueueClientManager(object):
         if 'shell_plugin' in destination_params:
             shell = cli_factory.get_shell(destination_params)
             return MessageCLIJobClient(destination_params, job_id, self, shell)
+        elif destination_params.get('k8s_enabled', False):
+            return MessageCoexecutionPodJobClient(destination_params, job_id, self)
         else:
             return MessageJobClient(destination_params, job_id, self)
 

--- a/pulsar/client/staging/__init__.py
+++ b/pulsar/client/staging/__init__.py
@@ -70,6 +70,8 @@ class ClientJobDescription(object):
         arbitrary_files=None,
         rewrite_paths=True,
         touch_outputs=None,
+        container=None,
+        remote_pulsar_app_config=None,
     ):
         self.tool = tool
         self.command_line = command_line
@@ -83,6 +85,8 @@ class ClientJobDescription(object):
         self.rewrite_paths = rewrite_paths
         self.arbitrary_files = arbitrary_files or {}
         self.touch_outputs = touch_outputs or []
+        self.container = container
+        self.remote_pulsar_app_config = remote_pulsar_app_config
 
     @property
     def output_files(self):

--- a/pulsar/client/staging/up.py
+++ b/pulsar/client/staging/up.py
@@ -34,6 +34,11 @@ def submit_job(client, client_job_description, job_config=None):
         dependencies_description=client_job_description.dependencies_description,
         env=client_job_description.env,
     )
+    if client_job_description.container:
+        launch_kwds["container"] = client_job_description.container
+    if client_job_description.remote_pulsar_app_config:
+        launch_kwds["pulsar_app_config"] = client_job_description.remote_pulsar_app_config
+
     if file_stager.job_config:
         launch_kwds["job_config"] = file_stager.job_config
     remote_staging = {}

--- a/pulsar/client/test/check.py
+++ b/pulsar/client/test/check.py
@@ -332,8 +332,8 @@ def __assert_has_rewritten_bwa_path(client, temp_output4_path):
     if client.default_file_action != "none":
         rewritten_index_path = open(temp_output4_path, 'r', encoding='utf-8').read()
         # Path written to this file will differ between Windows and Linux.
-        if re.search(r"123456[/\\]unstructured[/\\]\w+[/\\]bwa[/\\]human.fa", rewritten_index_path) is None:
-            raise AssertionError("[%s] does not container rewritten path." % rewritten_index_path)
+        if re.search(r"%s[/\\]unstructured[/\\]\w+[/\\]bwa[/\\]human.fa" % client.job_id, rewritten_index_path) is None:
+            raise AssertionError("[%s] does not contain rewritten path." % rewritten_index_path)
 
 
 def __exercise_errors(options, client, temp_output_path, temp_directory):
@@ -399,6 +399,10 @@ def extract_client_options(options):
         client_options["jobs_directory"] = getattr(options, "jobs_directory")
     if hasattr(options, "files_endpoint"):
         client_options["files_endpoint"] = getattr(options, "files_endpoint")
+    if hasattr(options, "k8s_enabled"):
+        client_options["k8s_enabled"] = getattr(options, "k8s_enabled")
+    if hasattr(options, "container"):
+        client_options["container"] = getattr(options, "container")
     return client_options
 
 
@@ -452,7 +456,9 @@ def __extra_job_description_kwargs(options):
     env = []
     if test_env:
         env.append(dict(name="TEST_ENV", value="TEST_ENV_VALUE"))
-    return dict(dependencies_description=dependencies_description, env=env)
+    container = getattr(options, "container", None)
+    remote_pulsar_app_config = getattr(options, "remote_pulsar_app_config", None)
+    return dict(dependencies_description=dependencies_description, env=env, container=container, remote_pulsar_app_config=remote_pulsar_app_config)
 
 
 def __finish(options, client, client_outputs, result_status):

--- a/pulsar/managers/queued.py
+++ b/pulsar/managers/queued.py
@@ -54,13 +54,13 @@ class QueueManager(Manager):
             setup_params=setup_params
         )
         try:
-            self._job_directory(job_id).store_metadata(JOB_FILE_COMMAND_LINE, command_line)
+            self._write_command_line(job_id, command_line)
         except Exception:
             log.info("Failed to persist command line for job %s, will not be able to recover." % job_id)
         self.work_queue.put((RUN, (job_id, command_line)))
 
     def _recover_active_job(self, job_id):
-        command_line = self._job_directory(job_id).load_metadata(JOB_FILE_COMMAND_LINE, None)
+        command_line = self.read_command_line(job_id)
         if command_line:
             self.work_queue.put((RUN, (job_id, command_line)))
         else:

--- a/pulsar/managers/unqueued.py
+++ b/pulsar/managers/unqueued.py
@@ -1,10 +1,11 @@
 import os
-from subprocess import Popen
+import platform
 try:
     import thread
 except ImportError:
     import _thread as thread  # Py3K changed it.
-import platform
+import time
+from subprocess import Popen
 
 from .util import kill_pid
 from pulsar.managers.base.directory import DirectoryBaseManager
@@ -17,6 +18,44 @@ JOB_FILE_SUBMITTED = "submitted"
 JOB_FILE_PID = "pid"
 
 
+class BaseUnqueuedManager(DirectoryBaseManager):
+
+    def _record_submission(self, job_id):
+        self._job_directory(job_id).store_metadata(JOB_FILE_SUBMITTED, 'true')
+
+    def _get_status(self, job_id):
+        job_directory = self._job_directory(job_id)
+        if self._was_cancelled(job_id):
+            job_status = status.CANCELLED
+        elif job_directory.has_metadata(JOB_FILE_PID):
+            job_status = status.RUNNING
+        elif job_directory.has_metadata(JOB_FILE_SUBMITTED):
+            job_status = status.QUEUED
+        else:
+            job_status = status.COMPLETE
+        return job_status
+
+    def _finish_execution(self, job_id):
+        self._job_directory(job_id).remove_metadata(JOB_FILE_SUBMITTED)
+
+    def _prepare_run(self, job_id, command_line, dependencies_description, env, setup_params=None):
+        self._check_execution_with_tool_file(job_id, command_line)
+        self._record_submission(job_id)
+        if platform.system().lower() == "windows":
+            # TODO: Don't ignore requirements and env without warning. Ideally
+            # process them or at least warn about them being ignored.
+            command_line = self._expand_command_line(command_line, dependencies_description, job_directory=self.job_directory(job_id).job_directory)
+        else:
+            command_line = self._setup_job_file(
+                job_id,
+                command_line,
+                dependencies_description=dependencies_description,
+                env=env,
+                setup_params=setup_params
+            )
+        return command_line
+
+
 # Job Locks (for status updates). Following methods are locked.
 #    _finish_execution(self, job_id)
 #    _get_status(self, job_id)
@@ -24,7 +63,7 @@ JOB_FILE_PID = "pid"
 #    _record_pid(self, job_id, pid)
 #    _get_pid_for_killing_or_cancel(self, job_id)
 #
-class Manager(DirectoryBaseManager):
+class Manager(BaseUnqueuedManager):
     """
     A simple job manager that just directly runs jobs as given (no
     queueing). Preserved for compatibilty with older versions of Pulsar
@@ -36,9 +75,6 @@ class Manager(DirectoryBaseManager):
 
     def __init__(self, name, app, **kwds):
         super(Manager, self).__init__(name, app, **kwds)
-
-    def _record_submission(self, job_id):
-        self._job_directory(job_id).store_metadata(JOB_FILE_SUBMITTED, 'true')
 
     def __get_pid(self, job_id):
         pid = None
@@ -87,21 +123,12 @@ class Manager(DirectoryBaseManager):
 
     # with job lock
     def _finish_execution(self, job_id):
-        self._job_directory(job_id).remove_metadata(JOB_FILE_SUBMITTED)
+        super(Manager, self)._finish_execution(job_id)
         self._job_directory(job_id).remove_metadata(JOB_FILE_PID)
 
     # with job lock
     def _get_status(self, job_id):
-        job_directory = self._job_directory(job_id)
-        if self._was_cancelled(job_id):
-            job_status = status.CANCELLED
-        elif job_directory.has_metadata(JOB_FILE_PID):
-            job_status = status.RUNNING
-        elif job_directory.has_metadata(JOB_FILE_SUBMITTED):
-            job_status = status.QUEUED
-        else:
-            job_status = status.COMPLETE
-        return job_status
+        return super(Manager, self)._get_status(job_id)
 
     # with job lock
     def _was_cancelled(self, job_id):
@@ -127,6 +154,16 @@ class Manager(DirectoryBaseManager):
         with self._get_job_lock(job_id):
             if self._was_cancelled(job_id):
                 return
+
+        proc, stdout, stderr = self._proc_for_job_id(job_id, command_line)
+        with self._get_job_lock(job_id):
+            self._record_pid(job_id, proc.pid)
+        if background:
+            thread.start_new_thread(self._monitor_execution, (job_id, proc, stdout, stderr))
+        else:
+            self._monitor_execution(job_id, proc, stdout, stderr)
+
+    def _proc_for_job_id(self, job_id, command_line):
         job_directory = self.job_directory(job_id)
         working_directory = job_directory.working_directory()
         stdout = self._open_standard_output(job_id)
@@ -135,33 +172,56 @@ class Manager(DirectoryBaseManager):
                        working_directory=working_directory,
                        stdout=stdout,
                        stderr=stderr)
-        with self._get_job_lock(job_id):
-            self._record_pid(job_id, proc.pid)
-        if background:
-            thread.start_new_thread(self._monitor_execution, (job_id, proc, stdout, stderr))
-        else:
-            self._monitor_execution(job_id, proc, stdout, stderr)
+        return proc, stdout, stderr
 
     def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
         command_line = self._prepare_run(job_id, command_line, dependencies_description=dependencies_description, env=env, setup_params=setup_params)
         self._run(job_id, command_line)
 
-    def _prepare_run(self, job_id, command_line, dependencies_description, env, setup_params=None):
-        self._check_execution_with_tool_file(job_id, command_line)
-        self._record_submission(job_id)
-        if platform.system().lower() == "windows":
-            # TODO: Don't ignore requirements and env without warning. Ideally
-            # process them or at least warn about them being ignored.
-            command_line = self._expand_command_line(command_line, dependencies_description, job_directory=self.job_directory(job_id).job_directory)
-        else:
-            command_line = self._setup_job_file(
-                job_id,
-                command_line,
-                dependencies_description=dependencies_description,
-                env=env,
-                setup_params=setup_params
-            )
-        return command_line
+
+class CoexecutionManager(BaseUnqueuedManager):
+    """Manager that managers one job in a pod-like environment.
+
+    Assume some process in another container will execute the command.
+    """
+    manager_type = "coexecution"
+
+    def __init__(self, name, app, **kwds):
+        super(CoexecutionManager, self).__init__(name, app, **kwds)
+        self.singleton_job_id = "0"
+
+    def setup_job(self, input_job_id, tool_id, tool_version):
+        return self._setup_job_for_job_id(self.singleton_job_id, tool_id, tool_version)
+
+    def get_status(self, job_id):
+        return self._get_status(job_id)
+
+    def kill(self, job_id):
+        log.info("Attempting to kill job with job_id %s - unimplemented in CoexecutionManager..." % job_id)
+
+    def _monitor_execution(self, job_id):
+        return_code_path = self._return_code_path(job_id)
+        try:
+            while not os.path.exists(return_code_path):
+                time.sleep(0.1)
+                print("monitoring for %s" % return_code_path)
+                continue
+            print("found return code path...")
+            time.sleep(1)
+        finally:
+            self._finish_execution(job_id)
+
+    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
+        command_line = self._prepare_run(job_id, command_line, dependencies_description=dependencies_description, env=env, setup_params=setup_params)
+        job_directory = self.job_directory(job_id)
+        working_directory = job_directory.working_directory()
+        command_line += " > '%s' 2> '%s'" % (
+            self._stdout_path(job_id),
+            self._stderr_path(job_id),
+        )
+        command_line = "cd '%s'; sh %s" % (working_directory, command_line)
+        self._write_command_line(job_id, command_line)
+        self._monitor_execution(job_id)
 
 
 def execute(command_line, working_directory, stdout, stderr):

--- a/pulsar/managers/util/pykube_util.py
+++ b/pulsar/managers/util/pykube_util.py
@@ -1,0 +1,89 @@
+"""Interface layer for pykube library shared between Galaxy and Pulsar."""
+import os
+import uuid
+
+try:
+    from pykube.config import KubeConfig
+    from pykube.http import HTTPClient
+    from pykube.objects import (
+        Job,
+        Pod
+    )
+except ImportError as exc:
+    KubeConfig = None
+    Job = None
+    Pod = None
+    K8S_IMPORT_MESSAGE = ('The Python pykube package is required to use '
+                          'this feature, please install it or correct the '
+                          'following error:\nImportError %s' % str(exc))
+
+DEFAULT_JOB_API_VERSION = "batch/v1"
+DEFAULT_NAMESPACE = "default"
+
+
+def ensure_pykube():
+    if KubeConfig is None:
+        raise Exception(K8S_IMPORT_MESSAGE)
+
+
+def pykube_client_from_dict(params):
+    if "k8s_use_service_account" in params and params["k8s_use_service_account"]:
+        pykube_client = HTTPClient(KubeConfig.from_service_account())
+    else:
+        config_path = params.get("k8s_config_path")
+        if config_path is None:
+            config_path = os.environ.get('KUBECONFIG', None)
+        if config_path is None:
+            config_path = '~/.kube/config'
+        pykube_client = HTTPClient(KubeConfig.from_file(config_path))
+    return pykube_client
+
+
+def produce_unique_k8s_job_name(app_prefix=None, instance_id=None, job_id=None):
+    if job_id is None:
+        job_id = str(uuid.uuid4())
+
+    job_name = ""
+    if app_prefix:
+        job_name += "%s-" % app_prefix
+
+    if instance_id and instance_id > 0:
+        job_name += "%s-" % instance_id
+
+    return job_name + job_id
+
+
+def pull_policy(params):
+    # If this doesn't validate it returns None, that seems odd?
+    if "k8s_pull_policy" in params:
+        if params['k8s_pull_policy'] in ["Always", "IfNotPresent", "Never"]:
+            return params['k8s_pull_policy']
+    return None
+
+
+def job_object_dict(params, job_name, spec):
+    k8s_job_obj = {
+        "apiVersion": params.get('k8s_job_api_version', DEFAULT_JOB_API_VERSION),
+        "kind": "Job",
+        "metadata": {
+                # metadata.name is the name of the pod resource created, and must be unique
+                # http://kubernetes.io/docs/user-guide/configuring-containers/
+                "name": job_name,
+                "namespace": params.get('k8s_namespace', DEFAULT_NAMESPACE),
+                "labels": {"app": job_name}
+        },
+        "spec": spec,
+    }
+    return k8s_job_obj
+
+
+__all__ = (
+    "DEFAULT_JOB_API_VERSION",
+    "ensure_pykube",
+    "Job",
+    "job_object_dict",
+    "Pod",
+    "produce_unique_k8s_job_name",
+    "pull_policy",
+    "pykube_client_from_dict",
+)

--- a/test/client_staging_test.py
+++ b/test/client_staging_test.py
@@ -93,6 +93,22 @@ class TestStager(TempDirectoryTestCase):
         assert uploaded_file1[1] == "unstructured"
         self.assertEqual(uploaded_file1[0], local_unstructured_file)
 
+    def test_file_actions_by_dict(self):
+        self.client_job_description.rewrite_paths = True
+        self.client.set_action_map_config(dict(paths=[
+            dict(path=self.temp_directory, path_types="*any*"),
+        ]), by_path=False)
+        local_unstructured_file = os.path.join(self.temp_directory, "A_RANDOM_FILE")
+        open(local_unstructured_file, "wb").write(b"Hello World!")
+        command_line = "foo.exe %s" % local_unstructured_file
+        self.client_job_description.command_line = command_line
+        self.client.expect_put_paths(["/pulsar/staging/1/other/A_RANDOM_FILE"])
+        self.client.expect_command_line("foo.exe /pulsar/staging/1/other/A_RANDOM_FILE")
+        self._submit()
+        uploaded_file1 = self.client.put_files[0]
+        assert uploaded_file1[1] == "unstructured"
+        self.assertEqual(uploaded_file1[0], local_unstructured_file)
+
     def test_submit_no_rewrite(self):
         # Expect no rewrite of paths
         command_line_template = "run_test.exe --input1=%s --input2=%s"
@@ -144,8 +160,11 @@ class MockClient(object):
         ])
         self.put_files = []
 
-    def set_action_map_config(self, config):
-        self.action_config_path = write_config(self, config, name="actions.yaml")
+    def set_action_map_config(self, config, by_path=True):
+        if by_path:
+            self.action_config_path = write_config(self, config, name="actions.yaml")
+        else:
+            self.file_actions = config
 
     def expect_put_paths(self, paths):
         self.put_paths = deque(paths)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from os.path import join
-from os import makedirs, system
+from os import environ, makedirs, system
 from six import next, itervalues
 from six.moves import configparser
 from .test_utils import (
@@ -35,15 +35,20 @@ class BaseIntegrationTest(TempDirectoryTestCase):
         self._run_in_app(app_conf, **kwds)
 
     def _run_in_app(self, app_conf, **kwds):
-        if kwds.get("direct_interface", None):
+        direct_interface = kwds.get("direct_interface", None)
+        inject_files_endpoint = direct_interface or kwds.get("inject_files_endpoint", False)
+        if inject_files_endpoint:
             # Client directory hasn't bee created yet, don't restrict where
             # test files written.
             # Can only run tests using files_server if not constructing a test
             # server for Pulsar - webtest doesn't seem to like having two test
             # servers alive at same time.
             with files_server("/") as test_files_server:
-                files_endpoint = test_files_server.application_url
-                self._run_direct(app_conf, files_endpoint=files_endpoint, **kwds)
+                files_endpoint = to_infrastructure_uri(test_files_server.application_url)
+                if direct_interface:
+                    self._run_direct(app_conf, files_endpoint=files_endpoint, **kwds)
+                else:
+                    self._run_in_test_server(app_conf, files_endpoint=files_endpoint, **kwds)
         else:
             self._run_in_test_server(app_conf, **kwds)
 
@@ -66,7 +71,10 @@ class BaseIntegrationTest(TempDirectoryTestCase):
     def _update_options_for_app(self, options, app, **kwds):
         if kwds.get("local_setup", False):
             staging_directory = app.staging_directory
-            options["jobs_directory"] = staging_directory
+            if kwds.get("k8s_enabled"):
+                options["jobs_directory"] = "/pulsar_staging"
+            else:
+                options["jobs_directory"] = staging_directory
 
     def __setup_job_properties(self, app_conf, job_conf_props):
         if job_conf_props:
@@ -209,6 +217,51 @@ class IntegrationTests(BaseIntegrationTest):
         self._run(app_conf={}, job_conf_props={'type': 'queued_cli', 'job_plugin': 'Slurm'}, private_token=None, **self.default_kwargs)
 
 
+class ExternalQueueIntegrationTests(IntegrationTests):
+    default_kwargs = dict(direct_interface=False, test_requirement=False, test_unicode=True, test_env=True, test_rewrite_action=True)
+
+    @integration_test
+    @skip_unless_environ("PULSAR_RABBIT_MQ_CONNECTION")
+    def test_integration_external_rabbit(self):
+        # e.g. amqp://guest:guest@localhost:5672//
+        # TODO: nc docker.for.mac.localhost 5679
+        message_queue_url = environ.get("PULSAR_RABBIT_MQ_CONNECTION")
+        self._run(
+            app_conf=dict(message_queue_url=message_queue_url),
+            private_token=None,
+            local_setup=True,
+            default_file_action="remote_transfer",
+            manager_url=message_queue_url,
+            inject_files_endpoint=True,
+            **self.default_kwargs
+        )
+
+    @integration_test
+    @skip_unless_environ("PULSAR_RABBIT_MQ_CONNECTION")
+    def test_integration_kubernetes(self):
+        message_queue_url = environ.get("PULSAR_RABBIT_MQ_CONNECTION")
+        remote_pulsar_app_config = {
+            "staging_directory": "/pulsar_staging/",
+            "message_queue_url": to_infrastructure_uri(message_queue_url),
+            "manager": {
+                "type": "coexecution",
+            }
+        }
+        self._run(
+            app_conf=dict(message_queue_url=message_queue_url),
+            private_token=None,
+            local_setup=True,
+            default_file_action="remote_transfer",
+            manager_url=message_queue_url,
+            inject_files_endpoint=True,
+            k8s_enabled=True,
+            container="conda/miniconda2",
+            remote_pulsar_app_config=remote_pulsar_app_config,
+            job_id="0",
+            **self.default_kwargs
+        )
+
+
 class DirectIntegrationTests(IntegrationTests):
     default_kwargs = dict(direct_interface=True, test_requirement=False)
 
@@ -221,3 +274,18 @@ class DirectIntegrationTests(IntegrationTests):
             default_file_action="remote_transfer",
             **self.default_kwargs
         )
+
+
+def to_infrastructure_uri(uri):
+    # remap MQ or file server URI hostnames for in-container versions, this is sloppy
+    # should actually parse the URI and rebuild with correct host
+    infrastructure_host = environ.get("PULSAR_TEST_INFRASTRUCTURE_HOST")
+    infrastructure_uri = uri
+    if infrastructure_host:
+        if "0.0.0.0" in infrastructure_uri:
+            infrastructure_uri = infrastructure_uri.replace("0.0.0.0", infrastructure_host)
+        elif "localhost" in infrastructure_uri:
+            infrastructure_uri = infrastructure_uri.replace("localhost", infrastructure_host)
+        elif "127.0.0.1" in infrastructure_uri:
+            infrastructure_uri = infrastructure_uri.replace("127.0.0.1", infrastructure_host)
+    return infrastructure_uri

--- a/test/integration_test_cli_submit.py
+++ b/test/integration_test_cli_submit.py
@@ -6,42 +6,93 @@ from .test_utils import (
     files_server,
     integration_test,
     skip_unless_module,
+    temp_directory_persist,
 )
 
+from pulsar.client import ClientOutputs
 from pulsar.client.util import to_base64_json
 from pulsar.scripts import submit
 
 
-class CliTestCase(TempDirectoryTestCase):
+class BaseCliTestCase(TempDirectoryTestCase):
+
+    def run_and_check_submission(self):
+        job_id = "0"
+        galaxy_working = temp_directory_persist()
+        output_name = "dataset_1211231231231231231.dat"
+        galaxy_output = os.path.join(galaxy_working, output_name)
+        pulsar_output = os.path.join(self.staging_directory, job_id, "outputs", output_name)
+        pulsar_input = os.path.join(self.staging_directory, job_id, "inputs", "cow")
+        with files_server("/") as test_files_server:
+            files_endpoint = test_files_server.application_url
+            action = {"name": "cow", "type": "input", "action": {"action_type": "message", "contents": "cow file contents\n"}}
+            client_outputs = ClientOutputs(
+                working_directory=galaxy_working,
+                output_files=[os.path.join(galaxy_working, output_name)],
+            )
+            launch_params = dict(
+                command_line="cat '%s' > '%s'" % (pulsar_input, pulsar_output),
+                job_id=job_id,
+                setup_params=dict(
+                    job_id=job_id,
+                ),
+                setup=True,
+                remote_staging={
+                    "setup": [action],
+                    "action_mapper": {
+                        "default_action": "remote_transfer",
+                        "files_endpoint": files_endpoint,
+                    },
+                    "client_outputs": client_outputs.to_dict(),
+                },
+            )
+            base64 = to_base64_json(launch_params)
+            assert not os.path.exists(galaxy_output)
+            submit.main(["--base64", base64] + self._encode_application())
+            assert os.path.exists(galaxy_output)
+            out_contents = open(galaxy_output, "r").read()
+            assert out_contents == "cow file contents\n", out_contents
+
+    @property
+    def staging_directory(self):
+        return os.path.join(self.temp_directory, "staging")
+
+    @property
+    def config_directory(self):
+        config_directory = os.path.join(self.temp_directory, "config")
+        os.makedirs(config_directory)
+        return config_directory
+
+
+class CliFileAppConfigTestCase(BaseCliTestCase):
 
     @skip_unless_module("kombu")
     @integration_test
     def test(self):
-        # TODO: test unstaging, would actually require files server and some
-        # sort MQ listening.
-        with files_server("/"):  # as test_files_server:
-            config_directory = os.path.join(self.temp_directory, "config")
-            staging_directory = os.path.join(self.temp_directory, "staging")
-            os.makedirs(config_directory)
-            app_conf = dict(
-                staging_directory=staging_directory,
-                message_queue_url="memory://submittest"
-            )
-            app_conf_path = os.path.join(config_directory, "app.yml")
-            with open(app_conf_path, "w") as f:
-                f.write(yaml.dump(app_conf))
+        self.run_and_check_submission()
 
-            job_id = "43"
+    def _encode_application(self):
+        app_conf = dict(
+            staging_directory=self.staging_directory,
+            message_queue_url="memory://submittest"
+        )
+        app_conf_path = os.path.join(self.config_directory, "app.yml")
+        with open(app_conf_path, "w") as f:
+            f.write(yaml.dump(app_conf))
 
-            output_path = os.path.join(staging_directory, job_id, "out")
-            launch_params = dict(
-                command_line="echo 'moo' > '%s'" % output_path,
-                job_id=job_id,
-                setup_params=dict(
-                    job_id=job_id,
-                )
-            )
-            base64 = to_base64_json(launch_params)
-            submit.main(["--base64", base64, "--app_conf_path", app_conf_path])
-            out_contents = open(output_path, "r").read()
-            assert out_contents == "moo\n", out_contents
+        return ["--app_conf_path", app_conf_path]
+
+
+class CliCommandLineAppConfigTestCase(BaseCliTestCase):
+
+    @skip_unless_module("kombu")
+    @integration_test
+    def test(self):
+        self.run_and_check_submission()
+
+    def _encode_application(self):
+        app_conf = dict(
+            staging_directory=self.staging_directory,
+            message_queue_url="memory://submittest"
+        )
+        return ["--app_conf_base64", to_base64_json(app_conf)]

--- a/test/main_util_test.py
+++ b/test/main_util_test.py
@@ -83,6 +83,7 @@ class MockArgs(object):
     def __init__(self, ini_path, app):
         self.ini_path = ini_path
         self.app_conf_path = None
+        self.app_conf_base64 = None
         self.app = app
 
 

--- a/test/manager_coexecution_test.py
+++ b/test/manager_coexecution_test.py
@@ -1,0 +1,58 @@
+import subprocess
+import threading
+
+from .test_utils import (
+    BaseManagerTestCase,
+)
+
+from pulsar.managers.unqueued import CoexecutionManager
+
+
+class Coexecutor(object):
+    """Mimic shell script in other container of coexecutor pod-like environment."""
+
+    def __init__(self, manager):
+        self.manager = manager
+        self.has_command_line = False
+        self.command_line = None
+
+    def monitor(self):
+        singleton_job_id = "0"
+
+        while not self.has_command_line:
+            try:
+                command_line = self.manager.read_command_line(singleton_job_id)
+            except (IOError, ValueError):
+                continue
+            if not command_line:
+                # might be partially written... need to be make this atomic I think.
+                continue
+            self.command_line = command_line
+            self.has_command_line = True
+
+        subprocess.call(command_line, shell=True)
+        # we are ignoring this exit code and just trusting the one in the job script...
+        # I'm not sure what to do about that.
+
+
+class CoexecutionManagerTest(BaseManagerTestCase):
+
+    def setUp(self):
+        super(CoexecutionManagerTest, self).setUp()
+        self._set_manager()
+
+    def tearDown(self):
+        super(CoexecutionManagerTest, self).setUp()
+
+    def _set_manager(self, **kwds):
+        self.manager = CoexecutionManager('_default_', self.app, **kwds)
+
+    def test_simple_execution(self):
+        coexecutor = Coexecutor(self.manager)
+        t = threading.Thread(target=coexecutor.monitor)
+        t.start()
+        try:
+            self._test_simple_execution(self.manager, timeout=5)
+        finally:
+            coexecutor.has_command_line = True
+            t.join(2)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -232,11 +232,15 @@ def server_for_test_app(app):
     try:
         from paste.exceptions.errormiddleware import ErrorMiddleware
         error_app = ErrorMiddleware(app.app, debug=True, error_log="errors.log")
-        server = StopableWSGIServer.create(error_app)
     except ImportError:
         # paste.exceptions not available for Python 3.
         error_app = app.app
-        server = StopableWSGIServer.create(error_app)
+
+    create_kwds = {
+    }
+    if os.environ.get("PULSAR_TEST_FILE_SERVER_HOST"):
+        create_kwds["host"] = os.environ.get("PULSAR_TEST_FILE_SERVER_HOST")
+    server = StopableWSGIServer.create(error_app, **create_kwds)
     try:
         server.wait()
         yield server


### PR DESCRIPTION
Testing for Kubernetes installed with Docker for Mac:

- Run ``make build-coexecutor-container``
- Install and start rabbitmq on the localhost with Homebrew.
- ``PULSAR_TEST_INFRASTRUCTURE_HOST=docker.for.mac.localhost  PULSAR_TEST_FILE_SERVER_HOST=0.0.0.0 PULSAR_RABBIT_MQ_CONNECTION='amqp://guest:guest@localhost:5672//' nosetests test/integration_test.py:ExternalQueueIntegrationTests.test_integration_kubernetes``
