### PR TITLE
Revisions to Kubernetes coexecution pods.

### DIFF
--- a/docker/coexecutor/Dockerfile
+++ b/docker/coexecutor/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update \
 
 RUN pip install -U pip && pip install wheel
 
-ADD pulsar_app-0.9.0-py2.py3-none-any.whl /pulsar_app-0.9.0-py2.py3-none-any.whl
+ADD pulsar_app-0.10.0.dev0-py2.py3-none-any.whl /pulsar_app-0.10.0.dev0-py2.py3-none-any.whl
 
-RUN pip install /pulsar_app-0.9.0-py2.py3-none-any.whl
+RUN pip install /pulsar_app-0.10.0.dev0-py2.py3-none-any.whl
 
 RUN pip install kombu pykube poster

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -31,7 +31,7 @@ CACHE_WAIT_SECONDS = 3
 TOOL_EXECUTION_CONTAINER_COMMAND_TEMPLATE = """
 path='%s/command_line';
 while [ ! -e $path ];
-    do sleep 1; echo 'waiting for job script...';
+    do sleep 1; echo "waiting for job script $path";
 done;
 echo 'running script';
 sh $path;
@@ -410,7 +410,7 @@ class MessageCoexecutionPodJobClient(BaseMessageJobClient):
         tool_container_spec = {
             "name": "tool-container",
             "image": tool_container_image,
-            "command": ["bash"],
+            "command": ["sh"],
             "args": ["-c", command],
             "workingDir": "/",
             "volumeMounts": volume_mounts,

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -396,6 +396,8 @@ class MessageCoexecutionPodJobClient(BaseMessageJobClient):
             {"mountPath": "/pulsar_staging", "name": "staging-directory"},
         ]
         tool_container_image = container  # TODO: this isn't right at all...
+        if not container:
+            raise Exception("Must declare a container for kubernetes job execution.")
         pulsar_container_dict = {
             "name": "pulsar-container",
             "image": pulsar_container_image,

--- a/pulsar/managers/unqueued.py
+++ b/pulsar/managers/unqueued.py
@@ -188,10 +188,9 @@ class CoexecutionManager(BaseUnqueuedManager):
 
     def __init__(self, name, app, **kwds):
         super(CoexecutionManager, self).__init__(name, app, **kwds)
-        self.singleton_job_id = "0"
 
     def setup_job(self, input_job_id, tool_id, tool_version):
-        return self._setup_job_for_job_id(self.singleton_job_id, tool_id, tool_version)
+        return self._setup_job_for_job_id(input_job_id, tool_id, tool_version)
 
     def get_status(self, job_id):
         return self._get_status(job_id)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -257,7 +257,6 @@ class ExternalQueueIntegrationTests(IntegrationTests):
             k8s_enabled=True,
             container="conda/miniconda2",
             remote_pulsar_app_config=remote_pulsar_app_config,
-            job_id="0",
             **self.default_kwargs
         )
 

--- a/test/manager_coexecution_test.py
+++ b/test/manager_coexecution_test.py
@@ -17,11 +17,9 @@ class Coexecutor(object):
         self.command_line = None
 
     def monitor(self):
-        singleton_job_id = "0"
-
         while not self.has_command_line:
             try:
-                command_line = self.manager.read_command_line(singleton_job_id)
+                command_line = self.manager.read_command_line("123")
             except (IOError, ValueError):
                 continue
             if not command_line:


### PR DESCRIPTION
- Don't hardcode the job ID - it makes Galaxy mapping tricky, seems to be not reason to anyway.
- Don't assume tool execution container has bash.
- Rev to this version of Pulsar.
- Better exception handling related to containers.