### PR TITLE
Remove previous wheels before creating a new one.

### DIFF
--- a/docker/coexecutor/Makefile
+++ b/docker/coexecutor/Makefile
@@ -1,6 +1,7 @@
 
 
 docker-image:
+	find . -regex './pulsar_app-.*.whl' -delete
 	cd ../..; make dist; cp dist/pulsar*whl docker/coexecutor
 
 all: docker-image


### PR DESCRIPTION
Since there can be wheels belonging to different version of pulsar already existing in that folder, and since that can cause issues for building docker image as it uses `*`, hence it would be better to empty the folder of any previous wheels first.