### PR TITLE
Assign image tag based on the pulsar wheel version

### DIFF
--- a/docker/coexecutor/Makefile
+++ b/docker/coexecutor/Makefile
@@ -4,4 +4,7 @@ docker-image:
 	cd ../..; make dist; cp dist/pulsar*whl docker/coexecutor
 
 all: docker-image
+	re='pulsar_app-([0-9]+.[0-9]+.[0-9]+).dev0-py2.py3-none-any.whl'
+        f='$(shell ls -1a | egrep '$(re)')'
+        version=$(shell if [[ $(f) =~ $(re) ]]; then echo "v${BASH_REMATCH[1]}"; else echo "unknown_version"; fi)
 	docker build -t 'galaxy/pulsar-pod-staging:0.1' .


### PR DESCRIPTION
It can help find a docker image if its tag is set appropriately, e.g., using the version of pulsar wheel used for creating the image. 

On my mac I am not able to leverage `BASH_REMATCH[1]` to extract version number from the wheel filename, since it seems macOS has a different function that overrides the value of this variable: https://stackoverflow.com/a/40457982

Creating draft PR, in case anyone interested and know a workaround. 

Alternatively, we might be able to use a method similar to the following: 

https://github.com/galaxyproject/pulsar/blob/ddf2fdece779f19d5204db5ea491441821038a5c/setup.py#L46-L50