### PR TITLE
Improve readme linting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   - python: 2.7
     env: TOX_ENV=py27-lint
   - python: 2.7
-    env: TOX_ENV=py27-lint-readme
+    env: TOX_ENV=py27-lint-dist
   - python: 2.7
     env: TOX_ENV=lint-docs
   - python: 2.7

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	@echo "clean-test - remove test and coverage artifacts"
 	@echo "setup-venv - setup a development virutalenv in current directory."
 	@echo "lint - check style with flake8"
-	@echo "lint-readme - check README formatting for PyPI"
+	@echo "lint-dist - twine check dist results, including validating README content"
 	@echo "lint-docs - check sphinx docs for warnings"
 	@echo "tests - run tests quickly with the default Python"
 	@echo "coverage - check code coverage quickly with the default Python"
@@ -74,8 +74,8 @@ flake8:
 lint:
 	$(IN_VENV) tox -e py27-lint && tox -e py34-lint
 
-lint-readme:
-	$(IN_VENV) python setup.py check -r -s
+lint-dist: dist
+	$(IN_VENV) twine check dist/*
 
 tests:
 	$(IN_VENV) nosetests $(NOSE_TESTS)
@@ -122,7 +122,7 @@ open-rtd: docs
 open-project:
 	open $(PROJECT_URL) || xdg-open $(PROJECT_URL)
 
-dist: clean
+dist: clean-build clean-pyc
 	$(IN_VENV) python setup.py sdist bdist_wheel
 	ls -l dist
 
@@ -130,7 +130,7 @@ _release-test-artifacts:
 	$(IN_VENV) twine upload -r test dist/*
 	open https://testpypi.python.org/pypi/$(PROJECT_NAME) || xdg-open https://testpypi.python.org/pypi/$(PROJECT_NAME)
 
-dist-all: dist _dist-lib
+dist-all: lint-dist _dist-lib
 
 release-test-artifacts: dist-all _release-test-artifacts
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,9 +16,6 @@ sphinx==1.2
 pyflakes
 flake8
 
-# Used to check readme.
-readme
-
 # For release
 wheel
 twine

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-lint, py27-lint-readme, lint-docs, py35-lint,  py27, py34, py27-unit, py34-unit
+envlist = py27-lint, py27-lint-dist, lint-docs, py35-lint,  py27, py34, py27-unit, py34-unit
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]
@@ -37,12 +37,12 @@ commands = flake8 --ignore W504 pulsar test
 skip_install = True
 deps = flake8
 
-[testenv:py27-lint-readme]
-commands = make lint-readme
+[testenv:py27-lint-dist]
+commands = make lint-dist
 skip_install = True
 whitelist_externals = make
 deps =
-    readme
+    twine
 
 [testenv:lint-docs]
 commands = make lint-docs


### PR DESCRIPTION
Lint actual artifacts to publish, fail to publish if they don't lint, use twince check instead of deprecated readme package.