### PR TITLE
using queued_condor

### DIFF
--- a/docs/job_managers.rst
+++ b/docs/job_managers.rst
@@ -86,7 +86,7 @@ Condor_ can also be used as a backend.
 
     managers:
       _default_:
-        type: queued_drmaa
+        type: queued_condor
         # Optional attributes...
         submit_universe: vanilla
         submit_request_memory: 32


### PR DESCRIPTION
Using queued_drmaa works indeed, but I guess the intention was to use queued_condor here.