### PR TITLE
Handle extended remote metadata.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # TODO: test condor
 language: python
+dist: trusty
 matrix:
   include:
   - python: 2.7

--- a/.travis/setup_tests.sh
+++ b/.travis/setup_tests.sh
@@ -8,8 +8,7 @@ sudo apt-get install libxml2-dev libxslt1-dev libcurl3 python-pycurl openssh-ser
 #pip install -r requirements$REQUIREMENTS_SUFFIX.txt --use-mirrors || true
 #pip install -r dev-requirements.txt --use-mirrors || true
 pip install coveralls  # Required fro coveralls reporting.
-sudo apt-get install slurm-llnl
-# slurm-llnl slurm-llnl-torque # slurm-drmaa1 slurm-drmaa-dev
+sudo apt-get install slurm-llnl slurm-llnl-torque # slurm-drmaa1 slurm-drmaa-dev
 sudo apt-get install libswitch-perl  # A missing dependency of slurm-llnl-torque
 wget https://depot.galaxyproject.org/deb/slurm-drmaa1_1.2.0-dev.57ebc0c_amd64.deb
 sudo dpkg -i slurm-drmaa1_1.2.0-dev.57ebc0c_amd64.deb

--- a/.travis/setup_tests.sh
+++ b/.travis/setup_tests.sh
@@ -8,7 +8,8 @@ sudo apt-get install libxml2-dev libxslt1-dev libcurl3 python-pycurl openssh-ser
 #pip install -r requirements$REQUIREMENTS_SUFFIX.txt --use-mirrors || true
 #pip install -r dev-requirements.txt --use-mirrors || true
 pip install coveralls  # Required fro coveralls reporting.
-sudo apt-get install slurm-llnl slurm-llnl-torque # slurm-drmaa1 slurm-drmaa-dev
+sudo apt-get install slurm-llnl
+# slurm-llnl slurm-llnl-torque # slurm-drmaa1 slurm-drmaa-dev
 sudo apt-get install libswitch-perl  # A missing dependency of slurm-llnl-torque
 wget https://depot.galaxyproject.org/deb/slurm-drmaa1_1.2.0-dev.57ebc0c_amd64.deb
 sudo dpkg -i slurm-drmaa1_1.2.0-dev.57ebc0c_amd64.deb

--- a/docker/coexecutor/Dockerfile
+++ b/docker/coexecutor/Dockerfile
@@ -4,13 +4,14 @@ ENV PYTHONUNBUFFERED 1
 ENV DEBIAN_FRONTEND noninteractive
 ENV PULSAR_CONFIG_CONDA_PREFIX /usr/local
 
+# wget, gcc, pip - to build and install Pulsar.
+# bzip2 for Miniconda.
 # TODO: pycurl stuff...
-
 RUN apt-get update \
-    # Install CVMFS client
     && apt-get install -y --no-install-recommends lsb-release wget \
         gcc python-setuptools \
         python-dev python-pip \
+        bzip2 \
     && apt-get -y autoremove \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
@@ -20,3 +21,4 @@ RUN pip install -U pip && pip install wheel kombu pykube poster
 ADD pulsar_app-*.dev0-py2.py3-none-any.whl /pulsar_app-*.dev0-py2.py3-none-any.whl
 
 RUN pip install /pulsar_app-*.dev0-py2.py3-none-any.whl[galaxy_extended_metadata]
+RUN _pulsar-conda-init --conda_prefix=/pulsar_dependencies/conda

--- a/docker/coexecutor/Dockerfile
+++ b/docker/coexecutor/Dockerfile
@@ -19,4 +19,4 @@ RUN pip install -U pip && pip install wheel kombu pykube poster
 
 ADD pulsar_app-*.dev0-py2.py3-none-any.whl /pulsar_app-*.dev0-py2.py3-none-any.whl
 
-RUN pip install /pulsar_app-*.dev0-py2.py3-none-any.whl
+RUN pip install /pulsar_app-*.dev0-py2.py3-none-any.whl[galaxy_extended_metadata]

--- a/docker/coexecutor/Makefile
+++ b/docker/coexecutor/Makefile
@@ -1,7 +1,9 @@
 
 
-docker-image:
+dist:
 	cd ../..; make dist; cp dist/pulsar*whl docker/coexecutor
 
-all: docker-image
-	docker build -t 'galaxy/pulsar-pod-staging:0.12.0' .
+docker-image:
+	docker build -t 'galaxy/pulsar-pod-staging:0.13.0' .
+
+all: dist docker-image

--- a/pulsar/client/staging/__init__.py
+++ b/pulsar/client/staging/__init__.py
@@ -14,7 +14,7 @@ from galaxy.util.bunch import Bunch
 from ..util import PathHelper
 
 COMMAND_VERSION_FILENAME = "COMMAND_VERSION"
-DEFAULT_DYNAMIC_COLLECTION_PATTERN = [r"primary_.*|galaxy.json|metadata_.*|dataset_\d+\.dat|__instrument_.*|dataset_\d+_files.+"]
+DEFAULT_DYNAMIC_COLLECTION_PATTERN = [r"primary_.*|galaxy.json|metadata_.*|dataset_\d+\.dat|__instrument_.*|dataset_\d+_files.+|outputs_populated/.*"]
 
 
 class ClientJobDescription(object):

--- a/pulsar/scripts/_conda_init.py
+++ b/pulsar/scripts/_conda_init.py
@@ -1,0 +1,28 @@
+"""Small utility for bootstrapping a Conda environment for Pulsar.
+
+This should probably be moved into galaxy-tool-util.
+"""
+
+import os.path
+import sys
+from argparse import ArgumentParser
+
+from galaxy.tool_util.deps.conda_util import CondaContext, install_conda
+from galaxy.util import safe_makedirs
+
+
+def main(argv=None):
+    mod_docstring = sys.modules[__name__].__doc__
+    arg_parser = ArgumentParser(description=mod_docstring)
+    arg_parser.add_argument("--conda_prefix", required=True)
+    args = arg_parser.parse_args(argv)
+    conda_prefix = args.conda_prefix
+    safe_makedirs(os.path.dirname(conda_prefix))
+    conda_context = CondaContext(
+        conda_prefix=conda_prefix,
+    )
+    install_conda(conda_context)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
     install_requires=requirements,
     extras_require={
         ':python_version=="2.7"': py27_requirements,
+        'galaxy_extended_metadata': ['galaxy-job-execution>=19.9.0.dev0'],
     },
     license="Apache License 2.0",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         pulsar-chown-working-directory=pulsar.scripts.chown_working_directory:main
         pulsar-submit=pulsar.scripts.submit:main
         pulsar-run=pulsar.scripts.run:main
+        _pulsar-conda-init=pulsar.scripts._conda_init:main
     ''',
     scripts=scripts,
     package_data={'pulsar': [


### PR DESCRIPTION
Multiple threads working together here despite relatively small changes.
- These changes get extended remote metadata from https://github.com/galaxyproject/galaxy/pull/7058 working.
- These changes are meant to make working with dependency resolution configured from a hierarchical Galaxy config more easy - respect ``dependency_resolution:`` config tag from https://github.com/galaxyproject/galaxy/pull/8152.
- Trying to get more Kubernetes configuration and deployment options working - extended metadata, single container dependency resolution, maybe others....