### PR TITLE
Add autodeploy to pulsar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 # TODO: test condor
 language: python
 dist: trusty
+
+deploy:
+  provider: pypi
+  user: jmchilton
+  skip_existing: true
+  password:
+    secure: fFcd6WYK1BMaVGA/XEgKO+8PGXPog80N7xKW6nFvW/tty9KwEvB9fBYKm7WXw1fk9hickP5UgiSdFK2vSQrs8iveODS+2EmBTs3r1rUbQg0DFR4mNpGEzxHl5QZVAREoIEpQgLFOdrbd769oA/NFiz9VhTt4VwJIBY1Ks7rMXB8=
+  on:
+    tags: true
+  distributions: sdist bdist_wheel
+
 matrix:
   include:
   - python: 2.7
@@ -12,7 +23,7 @@ matrix:
   - python: 2.7
     env: TOX_ENV=py27 SETUP=true
   - python: 2.7
-    env:  TOX_ENV=py27-install-wheel
+    env: TOX_ENV=py27-install-wheel
   - python: 3.5
     env: TOX_ENV=py35-lint
   - python: 3.5

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     version=version,
     description='Distributed job execution application built for Galaxy (http://galaxyproject.org/).',
     long_description=readme + '\n\n' + history,
+    long_description_content_type='text/x-rst',
     author='Galaxy Project',
     author_email='jmchilton@gmail.com',
     url='https://github.com/galaxyproject/pulsar',


### PR DESCRIPTION
@jmchilton I found the travis auto-deploy feature really useful.

https://docs.travis-ci.com/user/deployment/pypi/

What you need to do is the following:

```
gem install travis
/home/bag/.gem/ruby/2.5.0/bin/travis encrypt <your_passwd_here> --add deploy.password -r galaxyproject/pulsar
git commit .travis.yml -m 'add key'
```

If you have some special symbols in your password, then this might be helpful: https://docs.travis-ci.com/user/encryption-keys/#note-on-escaping-certain-symbols

The current configuration pushes to pypi as soon as you tag a release.