### PR TITLE
Implement killing k8s jobs.

### DIFF
--- a/pulsar/managers/unqueued.py
+++ b/pulsar/managers/unqueued.py
@@ -190,12 +190,15 @@ class CoexecutionManager(BaseUnqueuedManager):
 
     def _monitor_execution(self, job_id):
         return_code_path = self._return_code_path(job_id)
+        # Write dummy JOB_FILE_PID so get_status thinks this job is running.
+        self._job_directory(job_id).store_metadata(JOB_FILE_PID, "1")
         try:
             while not os.path.exists(return_code_path):
                 time.sleep(0.1)
                 print("monitoring for %s" % return_code_path)
                 continue
             print("found return code path...")
+            self._job_directory(job_id).remove_metadata(JOB_FILE_PID)
             time.sleep(1)
         finally:
             self._finish_execution(job_id)

--- a/pulsar/managers/util/pykube_util.py
+++ b/pulsar/managers/util/pykube_util.py
@@ -68,6 +68,34 @@ def pull_policy(params):
     return None
 
 
+def find_job_object_by_name(pykube_api, job_name, namespace=None):
+    filter_kwd = dict(selector="app=%s" % job_name)
+    if namespace is not None:
+        filter_kwd["namespace"] = namespace
+
+    jobs = Job.objects(pykube_api).filter(**filter_kwd)
+    job = None
+    if len(jobs.response['items']) > 0:
+        job = Job(pykube_api, jobs.response['items'][0])
+    return job
+
+
+def stop_job(job, cleanup="always"):
+    job_failed = (job.obj['status']['failed'] > 0
+                  if 'failed' in job.obj['status'] else False)
+    # Scale down the job just in case even if cleanup is never
+    job.scale(replicas=0)
+    if (cleanup == "always" or
+            (cleanup == "onsuccess" and not job_failed)):
+        delete_options = {
+            "apiVersion": "v1",
+            "kind": "DeleteOptions",
+            "propagationPolicy": "Background"
+        }
+        r = job.api.delete(json=delete_options, **job.api_kwargs())
+        job.api.raise_for_status(r)
+
+
 def job_object_dict(params, job_name, spec):
     k8s_job_obj = {
         "apiVersion": params.get('k8s_job_api_version', DEFAULT_JOB_API_VERSION),


### PR DESCRIPTION
Builds on #220 

Though this is important in its own right - reproducibly fetching the job object from destination parameters in the client was one the challenges needed to track pod status we needed for podIP and doing remote IT jobs this way.