### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/pulsar/managers/queued.py
+++ b/pulsar/managers/queued.py
@@ -71,7 +71,7 @@ class QueueManager(Manager):
             self.work_queue.put((STOP_SIGNAL, None))
         for worker in self.work_threads:
             worker.join(timeout)
-            if worker.isAlive():
+            if worker.is_alive():
                 log.warn("Failed to stop worker thread [%s]" % worker)
 
     def run_next(self):

--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -342,7 +342,7 @@ class ManagerMonitor(object):
     def shutdown(self, timeout=None):
         self.active = False
         self.thread.join(timeout)
-        if self.thread.isAlive():
+        if self.thread.is_alive():
             log.warn("Failed to join monitor thread [%s]" % self.thread)
 
     def _run(self):

--- a/pulsar/messaging/__init__.py
+++ b/pulsar/messaging/__init__.py
@@ -39,7 +39,7 @@ class QueueState(object):
     def join(self, timeout=None):
         for t in self.threads:
             t.join(timeout)
-            if t.isAlive():
+            if t.is_alive():
                 log.warn("Failed to join thread [%s]." % t)
 
 


### PR DESCRIPTION
Python 2.6 is listed in setup.py but I guess it's safe to ignore it since it was EoL long time ago. Fixes #224 