### PR TITLE
fix the PyYAML "load() deprecation" warning

### DIFF
--- a/pulsar/client/config_util.py
+++ b/pulsar/client/config_util.py
@@ -56,7 +56,7 @@ def __read_yaml(path):
         raise ImportError("Attempting to read YAML configuration file - but PyYAML dependency unavailable.")
 
     with open(path, "rb") as f:
-        return yaml.load(f)
+        return yaml.load(f, Loader=yaml.FullLoader)
 
 
 def __read_ini(path):

--- a/pulsar/client/config_util.py
+++ b/pulsar/client/config_util.py
@@ -56,7 +56,7 @@ def __read_yaml(path):
         raise ImportError("Attempting to read YAML configuration file - but PyYAML dependency unavailable.")
 
     with open(path, "rb") as f:
-        return yaml.load(f, Loader=yaml.FullLoader)
+        return yaml.safe_load(f)
 
 
 def __read_ini(path):

--- a/pulsar/main.py
+++ b/pulsar/main.py
@@ -215,7 +215,7 @@ def load_app_configuration(ini_path=None, app_conf_path=None, app_name=None, loc
             raise Exception("Cannot load configuration from file %s, pyyaml is not available." % app_conf_path)
 
         with open(app_conf_path, "r") as f:
-            app_conf = yaml.load(f, Loader=yaml.FullLoader) or {}
+            app_conf = yaml.safe_load(f) or {}
             local_conf.update(app_conf)
 
     return apply_env_overrides_and_defaults(local_conf)

--- a/pulsar/main.py
+++ b/pulsar/main.py
@@ -216,7 +216,7 @@ def load_app_configuration(ini_path=None, app_conf_path=None, app_name=None, loc
             raise Exception("Cannot load configuration from file %s, pyyaml is not available." % app_conf_path)
 
         with open(app_conf_path, "r") as f:
-            app_conf = yaml.load(f) or {}
+            app_conf = yaml.load(f, Loader=yaml.FullLoader) or {}
             local_conf.update(app_conf)
 
     return apply_env_overrides_and_defaults(local_conf)

--- a/pulsar/main.py
+++ b/pulsar/main.py
@@ -177,7 +177,6 @@ def _find_default_app_config(*config_dirs):
         app_config_path = os.path.join(config_dir, DEFAULT_APP_YAML)
         if os.path.exists(app_config_path):
             return app_config_path
-
     return None
 
 


### PR DESCRIPTION
Explicitly specify the FullLoader to avoid the warning during the boot-up. 
This is currently (PyYAML 5.1) the default loader called by yaml.load(input) (after issuing the warning).
See [PyYAML-yaml.load(input)-Deprecation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)