### PR TITLE
Pin direct dependency versions and do a final Python 2.7 release.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ History
 .. to_doc
 
 ---------------------
+0.13.1 (2020-09-16)
+---------------------
+
+* Pinned all listed requirements. This is the final version of Pulsar to support Python 2.
+
+---------------------
 0.13.0 (2019-06-25)
 ---------------------
 

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.13.0'
+__version__ = '0.13.1'
 
 PROJECT_NAME = "pulsar"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
-webob
-psutil
-PasteDeploy
+webob<=1.8.6
+psutil<=5.7.2
+PasteDeploy<=2.1.0
 six==1.11.0
-pyyaml
-galaxy-job-metrics>=19.9.0.dev1
-galaxy-objectstore>=19.9.0.dev1
-galaxy-tool-util>=19.9.0.dev3
-paramiko
+pyyaml<=5.3.1
+galaxy-job-metrics<20.5.0
+galaxy-objectstore<20.5.0
+galaxy-tool-util<20.5.0
+paramiko<=2.7.2
 
 # Problematic for Python 3.
-paste ; python_version == '2.7'
-PasteScript ; python_version == '2.7'
+paste<=3.4.4 ; python_version == '2.7'
+PasteScript<=3.2.0 ; python_version == '2.7'
 
 ## Uncomment if using DRMAA queue manager.
 #drmaa


### PR DESCRIPTION
This won't merge and we'll want to revert the pins and so forth, just creating this for the record.

As discussed in #233.