### PR TITLE
Update coexecution container Dockerfile for 0.14.1

### DIFF
--- a/docker/coexecutor/Dockerfile
+++ b/docker/coexecutor/Dockerfile
@@ -1,4 +1,4 @@
-FROM conda/miniconda2
+FROM conda/miniconda3
 
 ENV PYTHONUNBUFFERED 1
 ENV DEBIAN_FRONTEND noninteractive
@@ -8,6 +8,7 @@ ENV PULSAR_CONFIG_CONDA_PREFIX /usr/local
 # bzip2 for Miniconda.
 # TODO: pycurl stuff...
 RUN apt-get update \
+    && apt-get install -y --no-install-recommends apt-transport-https \
     # Install CVMFS client
     && apt-get install -y --no-install-recommends lsb-release wget \
     && wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb \
@@ -15,24 +16,24 @@ RUN apt-get update \
     && rm -f cvmfs-release-latest_all.deb \
     # Install packages
     && apt-get update \
-    && apt-get install -y --no-install-recommends gcc python-setuptools \
-        python-dev python-pip \
+    && apt-get install -y --no-install-recommends gcc \
+        libcurl4-openssl-dev \
         cvmfs cvmfs-config-default \
         slurm-llnl slurm-drmaa-dev \
         bzip2 \
     # Install Pulsar Python requirements
     && pip install --no-cache-dir -U pip \
-    && pip install --no-cache-dir drmaa wheel kombu pykube poster \
+    && pip install --no-cache-dir drmaa wheel kombu pykube pycurl \
             webob psutil PasteDeploy six pyyaml paramiko \
     # Remove build deps and cleanup
-    && apt-get -y remove python-dev gcc wget lsb-release \
+    && apt-get -y remove gcc wget lsb-release \
     && apt-get -y autoremove \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log \
     && /usr/sbin/create-munge-key
 
-ADD pulsar_app-*.dev*-py2.py3-none-any.whl /pulsar_app-*.dev*-py2.py3-none-any.whl
+ADD pulsar_app-*-py2.py3-none-any.whl /pulsar_app-*-py2.py3-none-any.whl
 
-RUN pip install --no-cache-dir /pulsar_app-*.dev*-py2.py3-none-any.whl[galaxy_extended_metadata]
+RUN pip install --no-cache-dir /pulsar_app-*-py2.py3-none-any.whl[galaxy_extended_metadata]
 RUN _pulsar-configure-galaxy-cvmfs
 RUN _pulsar-conda-init --conda_prefix=/pulsar_dependencies/conda

--- a/docker/coexecutor/Makefile
+++ b/docker/coexecutor/Makefile
@@ -4,6 +4,6 @@ dist:
 	cd ../..; make dist; cp dist/pulsar*whl docker/coexecutor
 
 docker-image:
-	docker build -t 'galaxy/pulsar-pod-staging:0.13.0' .
+	docker build -t 'galaxy/pulsar-pod-staging:0.14.1' .
 
 all: dist docker-image


### PR DESCRIPTION
@jmchilton I started updating this before I remembered that I don't actually need to update Pulsar, just Galaxy's pulsar lib. Anyway, since this is still Python 2-based, it's probably not a bad idea to update it. But do you recall why you were using the system python instead of the Conda python?