### PR TITLE
Small fix for starting pulsar in webless mode

### DIFF
--- a/pulsar/main.py
+++ b/pulsar/main.py
@@ -196,7 +196,7 @@ def apply_env_overrides_and_defaults(conf):
 def load_app_configuration(ini_path=None, app_conf_path=None, app_name=None, local_conf=None, config_dir=PULSAR_CONFIG_DIR):
     """
     """
-    if ini_path and local_conf is None:
+    if os.path.exists(ini_path) and local_conf is None:
         from pulsar.util.pastescript.loadwsgi import ConfigLoader
         local_conf = ConfigLoader(ini_path).app_context(app_name).config()
     local_conf = local_conf or {}

--- a/scripts/pulsar
+++ b/scripts/pulsar
@@ -116,8 +116,10 @@ then
         MODE="circusd"
     elif hash chaussette 2>/dev/null; then
         MODE="chaussette"
-    else
+    elif hash paster 2>/dev/null; then
         MODE="paster"
+    else
+        MODE="webless"
     fi
 fi
 
@@ -140,7 +142,6 @@ elif [ "$MODE" == "webless" ]; then
         pulsar-main
     else
         # Running locally.
-        PROJECT_DIRECTORY=$PULSAR_SCRIPTS_DIR/..
         cd $PROJECT_DIRECTORY
         export PYTHONPATH=.:$PYTHONPATH
         echo "Starting pulsar with command [python pulsar/main.py]"


### PR DESCRIPTION
When pulsar is configured with --mq, running this command:
```
pulsar --mode webless
```
will throw this exception:
```
FileNotFoundError: [Errno 2] No such file or directory: '~/pulsar/server.ini.sample'
```
This occurs because ```ini_path``` is initialized to ```~/pulsar/server.ini.sample``` here https://github.com/galaxyproject/pulsar/blob/master/pulsar/main.py#L254, and the sample config file is not created by pulsar-config when passing the --mq option.