### PR TITLE
Send fewer files when doing extended & remote metadata.

### DIFF
--- a/pulsar/client/__init__.py
+++ b/pulsar/client/__init__.py
@@ -50,6 +50,7 @@ from .staging import (
     ClientInput,
     ClientOutputs,
     CLIENT_INPUT_PATH_TYPES,
+    EXTENDED_METADATA_DYNAMIC_COLLECTION_PATTERN,
     PulsarOutputs,
 )
 from .staging.down import finish_job
@@ -68,6 +69,7 @@ __all__ = [
     'ClientOutputs',
     'CLIENT_INPUT_PATH_TYPES',
     'ClientOutputs',
+    'EXTENDED_METADATA_DYNAMIC_COLLECTION_PATTERN',
     'PathMapper',
     'PulsarClientTransportError',
 ]

--- a/pulsar/client/staging/__init__.py
+++ b/pulsar/client/staging/__init__.py
@@ -29,6 +29,13 @@ DEFAULT_DYNAMIC_COLLECTION_PATTERN = [
         ]
     )
 ]
+EXTENDED_METADATA_DYNAMIC_COLLECTION_PATTERN = [
+    "|".join(
+        [
+            r"outputs_populated/.*",
+        ]
+    )
+]
 
 
 class ClientJobDescription(object):


### PR DESCRIPTION
Requires a Galaxy piece also. Also we should figure out if there is a clean way to just turn off static, structured outputs in this scenario also.