### PR TITLE
Move $_GALAXY_JOB_HOME_DIR out of /working dir

### DIFF
--- a/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -4,7 +4,7 @@ $headers
 
 _galaxy_setup_environment() {
     local _use_framework_galaxy="$1"
-    _GALAXY_JOB_HOME_DIR="$working_directory/home"
+    _GALAXY_JOB_HOME_DIR="$working_directory/../home"
     _GALAXY_JOB_TMP_DIR=$tmp_dir_creation_statement
     $env_setup_commands
     if [ "$GALAXY_LIB" != "None" -a "$_use_framework_galaxy" = "True" ]; then


### PR DESCRIPTION
I believe `_GALAXY_JOB_HOME_DIR` had not been used in pulsar before (unless a tool explicitly used it). It's probably a good idea to keep this out outside of the `/working` dir, which it seems to be created in currently (see the test that is going to fail in https://github.com/galaxyproject/galaxy/pull/12037/checks?check_run_id=2642104127).