### PR TITLE
Support globs in from_work_dir outputs

### DIFF
--- a/pulsar/client/job_directory.py
+++ b/pulsar/client/job_directory.py
@@ -4,6 +4,7 @@ import os.path
 import posixpath
 
 from collections import deque
+from glob import glob
 from logging import getLogger
 
 from galaxy.util import in_directory
@@ -119,7 +120,15 @@ def get_mapped_file(directory, remote_path, allow_nested_files=False, local_path
         if mkdir and not local_path_module.exists(local_directory):
             os.makedirs(local_directory)
         path = local_path
-    # FIXME: Do we need to do anything with allow_globs in this case?
+    if allow_globs and ('*' in path or '?' in path):
+        matches = glob(path)
+        if len(matches) == 0:
+            raise RuntimeError(f"No files matching glob: {path}")
+        elif len(matches) > 1:
+            log.warning(f"Found multiple files matching {path}, using the first match: {matches}")
+        else:
+            log.info(f"Glob path {path} mapped to matched file: {matches[0]}")
+        path = matches[0]
     return path
 
 

--- a/pulsar/managers/base/__init__.py
+++ b/pulsar/managers/base/__init__.py
@@ -2,7 +2,6 @@
 Base Classes and Infrastructure Supporting Concret Manager Implementations.
 
 """
-from collections import deque
 import errno
 import logging
 import os
@@ -16,7 +15,6 @@ from os import getenv
 from os import walk
 import json
 from uuid import uuid4
-import posixpath
 from shutil import rmtree
 
 import six
@@ -26,7 +24,6 @@ from pulsar.managers import ManagerInterface
 from pulsar.client.job_directory import (
     RemoteJobDirectory,
     get_mapped_file,
-    verify_is_in_directory,
 )
 
 JOB_DIRECTORY_INPUTS = "inputs"


### PR DESCRIPTION
Fixes #239.

I am not sure about what the duplication is for in `client/job_directory.py` and what to do for that case. Also, no idea how we'll get the tool profile handling down to `calculate_path()`, but that is a problem for future Nate?