### PR TITLE
Allow from_work_dir output stage out failure

### DIFF
--- a/pulsar/client/staging/down.py
+++ b/pulsar/client/staging/down.py
@@ -167,7 +167,7 @@ class DownloadExceptionTracker(object):
         except Exception as e:
             if allow_failure:
                 log.warning(
-                     "Allowed failure in postprocessing, will not force job failure but generally indicates a tool"
+                    "Allowed failure in postprocessing, will not force job failure but generally indicates a tool"
                     f" failure: {e}")
             else:
                 self.collection_failure_exceptions.append(e)


### PR DESCRIPTION
When a tool fails it's often not going to create `from_work_dir` outputs. Currently this causes Pulsar to send a `failed` state to Galaxy due to stageout failures, and this makes diagnosing job failure causes much less apparent to the user.

i.e. this change turns this unhelpful message:

<img width="282" alt="Screen Shot 2021-07-08 at 6 16 45 PM" src="https://user-images.githubusercontent.com/286969/124997511-c1314280-e018-11eb-92db-b36478916fbd.png">

into this:

<img width="284" alt="Screen Shot 2021-07-08 at 6 16 52 PM" src="https://user-images.githubusercontent.com/286969/124997534-c9897d80-e018-11eb-8586-cf9bad45bbc9.png">

(where "Tool failed for reasons" is the actual error message generated by my very fine failure testing tool).

Fixes #211.