### PR TITLE
Transfer entire tool directory instead of picking apart the generated command line to find tool files to transfer

### DIFF
--- a/pulsar/client/job_directory.py
+++ b/pulsar/client/job_directory.py
@@ -84,6 +84,7 @@ class RemoteJobDirectory(object):
         # client module, but this code is reused on server which may
         # serve legacy clients.
         allow_nested_files = file_type in ['input', 'unstructured', 'output', 'output_workdir', 'metadata', 'output_metadata']
+        allow_nested_files = file_type in ['input', 'unstructured', 'output', 'output_workdir', 'metadata', 'output_metadata', 'tool']
         directory_source = getattr(self, TYPES_TO_METHOD.get(file_type, None), None)
         if not directory_source:
             raise Exception("Unknown file_type specified %s" % file_type)

--- a/pulsar/client/staging/up.py
+++ b/pulsar/client/staging/up.py
@@ -471,7 +471,7 @@ class TransferTracker(object):
             remote_name = self.path_helper.remote_name(relpath(directory_file_path, directory))
             self.handle_transfer_path(directory_file_path, type, name=remote_name)
 
-    def handle_transfer_source(self, source, type, name=None, contents=None):
+    def handle_transfer_source(self, source, type, name=None, contents=None):  # noqa: C901
         action = self.__action_for_transfer(source, type, contents)
 
         if action.staging_needed:

--- a/pulsar/client/staging/up.py
+++ b/pulsar/client/staging/up.py
@@ -181,8 +181,9 @@ class FileStager(object):
             return None
 
     def __initialize_tool_directory(self):
+        # This following line is only for interpreter, we should disable it for 16.04+ tools
+        self.tool_files = self.job_inputs.find_referenced_subfiles(self.tool_dir)
         # Find and transfer all files and subdirs of $__tool_directory__
-        # TODO: What is this for? Was used in the previous "referenced" version of this method
         new_tool_directory = self.new_tool_directory
         if not new_tool_directory:
             return

--- a/pulsar/managers/base/__init__.py
+++ b/pulsar/managers/base/__init__.py
@@ -9,7 +9,6 @@ import os
 from os.path import exists, isdir, join, basename
 from os.path import relpath
 from os import curdir
-from os import listdir
 from os import makedirs
 from os import sep
 from os import getenv

--- a/pulsar/managers/base/__init__.py
+++ b/pulsar/managers/base/__init__.py
@@ -170,8 +170,8 @@ class BaseManager(ManagerInterface):
         job_directory = self._job_directory(job_id)
         tool_files_dir = job_directory.tool_files_directory()
         for file in self._list_dir(tool_files_dir):
-            contents = open(join(tool_files_dir, file), 'r').read()
             log.debug("job_id: %s - checking tool file %s" % (job_id, file))
+            contents = open(join(tool_files_dir, file), 'rb').read()
             authorization.authorize_tool_file(basename(file), contents)
         config_files_dir = job_directory.configs_directory()
         for file in self._list_dir(config_files_dir):
@@ -183,7 +183,8 @@ class BaseManager(ManagerInterface):
         if directory_or_none is None or not exists(directory_or_none):
             return []
         else:
-            return listdir(directory_or_none)
+            for dirpath, dirnames, filenames in walk(directory_or_none):
+                return [join(dirpath, filename) for filename in filenames]
 
     def _expand_command_line(self, command_line, dependencies_description, job_directory=None):
         if dependencies_description is None:

--- a/pulsar/tools/authorization.py
+++ b/pulsar/tools/authorization.py
@@ -43,7 +43,7 @@ class ToolBasedAuthorization(AllowAnyAuthorization):
         tool = self.tool
         tool_dir = tool.get_tool_dir()
         tool_dir_file = join(tool_dir, name)
-        allowed_contents = open(tool_dir_file).read()
+        allowed_contents = open(tool_dir_file, 'rb').read()
         if contents != allowed_contents:
             self.__unauthorized("Attempt to write tool file with contents differing from Pulsar copy of tool file.")
 

--- a/test/authorization_test.py
+++ b/test/authorization_test.py
@@ -24,12 +24,12 @@ class ToolBasedAuthorizationTestCase(TestCase):
 
     def test_valid_tool_file_passes(self):
         authorization = self.authorizer.get_authorization('tool1')
-        authorization.authorize_tool_file('tool1_wrapper.py', 'print \'Hello World!\'\n')
+        authorization.authorize_tool_file('tool1_wrapper.py', b'print \'Hello World!\'\n')
 
     def test_invalid_tool_file_fails(self):
         authorization = self.authorizer.get_authorization('tool1')
         with self.unauthorized_expectation():
-            authorization.authorize_tool_file('tool1_wrapper.py', '#!/bin/sh\nrm -rf /valuable/data')
+            authorization.authorize_tool_file('tool1_wrapper.py', b'#!/bin/sh\nrm -rf /valuable/data')
 
     def unauthorized_expectation(self):
         return self.assertRaises(Exception)


### PR DESCRIPTION
Many tools work by including/importing things from the tool directory in scripts that are not themselves called in the command. This transfers the entire tool directory (with the exception of `tool-data`, `test-data`, and `.hg`) instead. Maybe more than we need but hopefully shouldn't be *too* painful.

Fixes #113.