### PR TITLE
Accept description of tool files to transfer from Galaxy.

### DIFF
--- a/pulsar/client/job_directory.py
+++ b/pulsar/client/job_directory.py
@@ -84,7 +84,7 @@ class RemoteJobDirectory(object):
         # Obviously this client won't be legacy because this is in the
         # client module, but this code is reused on server which may
         # serve legacy clients.
-        allow_nested_files = file_type in ['input', 'unstructured', 'output', 'output_workdir', 'metadata', 'output_metadata']
+        allow_nested_files = file_type in ['input', 'unstructured', 'output', 'output_workdir', 'metadata', 'output_metadata', 'tool']
         allow_globs = file_type in ['output_workdir']  # TODO: tool profile version where this is invalid
         directory_source = getattr(self, TYPES_TO_METHOD.get(file_type, None), None)
         if not directory_source:

--- a/pulsar/client/staging/__init__.py
+++ b/pulsar/client/staging/__init__.py
@@ -94,6 +94,7 @@ class ClientJobDescription(object):
         env=[],
         arbitrary_files=None,
         job_directory_files=None,
+        tool_directory_required_files=None,
         rewrite_paths=True,
         touch_outputs=None,
         container=None,
@@ -114,6 +115,7 @@ class ClientJobDescription(object):
         self.dependencies_description = dependencies_description
         self.env = env
         self.job_directory_files = job_directory_files or []
+        self.tool_directory_required_files = tool_directory_required_files
         self.rewrite_paths = rewrite_paths
         self.arbitrary_files = arbitrary_files or {}
         self.touch_outputs = touch_outputs or []

--- a/pulsar/client/staging/up.py
+++ b/pulsar/client/staging/up.py
@@ -181,10 +181,10 @@ class FileStager(object):
 
     def __initialize_referenced_tool_files(self):
         if self.tool_directory_required_files:
-            self.referenced_tool_files = [join(self.tool_dir, x) for x in self.tool_directory_required_files.find_required_files(self.tool_dir)]
+            self.referenced_tool_files = [(join(self.tool_dir, x), x) for x in self.tool_directory_required_files.find_required_files(self.tool_dir)]
         else:
             # Was this following line only for interpreter, should we disable it of 16.04+ tools
-            self.referenced_tool_files = self.job_inputs.find_referenced_subfiles(self.tool_dir)
+            self.referenced_tool_files = [(x, None) for x in self.job_inputs.find_referenced_subfiles(self.tool_dir)]
             # If the tool was created with a correct $__tool_directory__ find those files and transfer
             new_tool_directory = self.new_tool_directory
             if not new_tool_directory:
@@ -193,7 +193,7 @@ class FileStager(object):
             for potential_tool_file in self.job_inputs.find_referenced_subfiles(new_tool_directory):
                 local_file = potential_tool_file.replace(new_tool_directory, self.tool_dir)
                 if exists(local_file):
-                    self.referenced_tool_files.append(local_file)
+                    self.referenced_tool_files.append((local_file, None))
 
     def __initialize_referenced_arbitrary_files(self):
         referenced_arbitrary_path_mappers = dict()
@@ -211,8 +211,8 @@ class FileStager(object):
             self.arbitrary_files.update(unstructured_map)
 
     def __upload_tool_files(self):
-        for referenced_tool_file in self.referenced_tool_files:
-            self.transfer_tracker.handle_transfer_path(referenced_tool_file, path_type.TOOL)
+        for (referenced_tool_file, name) in self.referenced_tool_files:
+            self.transfer_tracker.handle_transfer_path(referenced_tool_file, path_type.TOOL, name=name)
 
     def __upload_job_directory_files(self):
         for job_directory_file in self.job_directory_files:

--- a/pulsar/client/staging/up.py
+++ b/pulsar/client/staging/up.py
@@ -181,7 +181,7 @@ class FileStager(object):
 
     def __initialize_referenced_tool_files(self):
         if self.tool_directory_required_files:
-            self.referenced_tool_files = self.tool_directory_required_files.find_required_files(self.tool_dir)
+            self.referenced_tool_files = [join(self.tool_dir, x) for x in self.tool_directory_required_files.find_required_files(self.tool_dir)]
         else:
             # Was this following line only for interpreter, should we disable it of 16.04+ tools
             self.referenced_tool_files = self.job_inputs.find_referenced_subfiles(self.tool_dir)

--- a/pulsar/client/test/check.py
+++ b/pulsar/client/test/check.py
@@ -18,7 +18,6 @@ import traceback
 from collections import namedtuple
 from io import open
 
-# If galaxy-tool-util or Galaxy 19.09 present.
 from galaxy.tool_util.deps.dependencies import DependenciesDescription
 from galaxy.tool_util.deps.requirements import ToolRequirement
 from six import binary_type
@@ -45,10 +44,14 @@ import sys
 from os import getenv
 from os import listdir
 from os import makedirs
+from os.path import abspath
 from os.path import basename
 from os.path import dirname
 from os.path import exists
 from os.path import join
+
+SCRIPT_DIRECTORY = abspath(dirname(__file__))
+HELPER_DIRECTORY = join(SCRIPT_DIRECTORY, "subdir")
 
 print("stdout output")
 def assert_path_contents(path, expected_contents):
@@ -73,6 +76,7 @@ assert len(listdir(dirname(index_path))) == 2
 assert len(listdir(join(dirname(dirname(index_path)), "seq"))) == 1
 output4_index_path = open(sys.argv[11], 'w')
 metadata_dir = dirname(sys.argv[13])
+output5 = open(sys.argv[15], 'w')
 output_metadata_path = join(metadata_dir, "metadata_output")
 try:
     assert_path_contents(sys.argv[2], "Hello world input!!@!")
@@ -93,6 +97,7 @@ try:
     open(join(output1_extras_path, "extra"), "w").write("EXTRA_OUTPUT_CONTENTS")
     version_output.write("1.0.1")
     output4_index_path.write(index_path)
+    output5.write(str(exists(join(HELPER_DIRECTORY, "helper.R"))))
 finally:
     output.close()
     config_input.close()
@@ -137,7 +142,7 @@ class TestRequiredFilesObject:
     # stick to the interface here.
 
     def find_required_files(self, tool_directory):
-        return ["script.py"]
+        return ["script.py", "subdir/helper.R"]
 
 
 def run(options):
@@ -152,9 +157,11 @@ def run(options):
         temp_metadata_dir = os.path.join(temp_directory, "m")
         temp_false_working_dir = os.path.join(temp_metadata_dir, "working")
         temp_tool_dir = os.path.join(temp_directory, "t")
+        temp_tool_sub_dir = os.path.join(temp_tool_dir, "subdir")
 
         __makedirs([
             temp_tool_dir,
+            temp_tool_sub_dir,
             temp_work_dir,
             temp_index_dir,
             temp_index_dir_sibbling,
@@ -170,10 +177,12 @@ def run(options):
 
         temp_config_path = os.path.join(temp_work_dir, "config.txt")
         temp_tool_path = os.path.join(temp_directory, "t", "script.py")
+        temp_tool_helper_path = os.path.join(temp_directory, "t", "subdir", "helper.R")
         temp_output_path = os.path.join(temp_directory, "dataset_1.dat")
         temp_output2_path = os.path.join(temp_directory, "dataset_2.dat")
         temp_output3_path = os.path.join(temp_directory, "dataset_3.dat")
         temp_output4_path = os.path.join(temp_directory, "dataset_4.dat")
+        temp_output5_path = os.path.join(temp_directory, "dataset_5.dat")
         temp_version_output_path = os.path.join(temp_directory, "GALAXY_VERSION_1234")
         temp_output_workdir_destination = os.path.join(temp_directory, "dataset_77.dat")
         temp_output_workdir = os.path.join(temp_work_dir, "env_test")
@@ -188,6 +197,7 @@ def run(options):
         __write_to_file(temp_config_path, EXPECTED_OUTPUT)
         __write_to_file(temp_metadata_path, "meta input")
         __write_to_file(temp_tool_path, TEST_SCRIPT)
+        __write_to_file(temp_tool_helper_path, b"helper R file")
         __write_to_file(temp_index_path, b"AGTC")
         # Implicit files that should also get transferred since depth > 0
         __write_to_file("%s.fai" % temp_index_path, b"AGTC")
@@ -213,9 +223,10 @@ def run(options):
             temp_shared_dir,
             temp_metadata_path,
             temp_input_metadata_path,
+            temp_output5_path,
         )
         assert os.path.exists(temp_index_path)
-        command_line = u'python %s "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s"' % command_line_params
+        command_line = u'python %s "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s"' % command_line_params
         config_files = [temp_config_path]
         client_inputs = []
         client_inputs.append(ClientInput(temp_input_path, CLIENT_INPUT_PATH_TYPES.INPUT_PATH))
@@ -231,8 +242,9 @@ def run(options):
             temp_output2_path,
             temp_output3_path,
             temp_output4_path,
+            temp_output5_path,
             temp_output_workdir_destination,
-            temp_output_workdir_destination2
+            temp_output_workdir_destination2,
         ]
         client, client_manager = __client(temp_directory, options)
         waiter = Waiter(client, client_manager)
@@ -281,6 +293,8 @@ def run(options):
         else:
             __assert_contents(temp_output3_path, "moo_default", result_status)
         __assert_has_rewritten_bwa_path(client, temp_output4_path)
+        if getattr(options, "explicit_tool_declarations", False):
+            __assert_contents(temp_output5_path, str(True), result_status)
         __exercise_errors(options, client, temp_output_path, temp_directory)
         client_manager.shutdown()
     except BaseException:

--- a/pulsar/managers/base/__init__.py
+++ b/pulsar/managers/base/__init__.py
@@ -170,6 +170,8 @@ class BaseManager(ManagerInterface):
         job_directory = self._job_directory(job_id)
         tool_files_dir = job_directory.tool_files_directory()
         for file in self._list_dir(tool_files_dir):
+            if os.path.isdir(join(tool_files_dir, file)):
+                continue
             contents = open(join(tool_files_dir, file), 'r').read()
             log.debug("job_id: %s - checking tool file %s" % (job_id, file))
             authorization.authorize_tool_file(basename(file), contents)

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -189,6 +189,10 @@ class IntegrationTests(BaseIntegrationTest):
         self._run(private_token=None, transport="curl", **self.default_kwargs)
 
     @integration_test
+    def test_integration_explicit_tool_directory_includes(self):
+        self._run(private_token=None, explicit_tool_declarations=True, **self.default_kwargs)
+
+    @integration_test
     def test_integration_token(self):
         self._run(app_conf={"private_token": "testtoken"}, private_token="testtoken", **self.default_kwargs)
 


### PR DESCRIPTION
Pairs with https://github.com/galaxyproject/galaxy/pull/12250 as an alternative approach to https://github.com/galaxyproject/pulsar/pull/260 that allows Galaxy (either at the tool or framework level (for legacy tools)) to override how referenced tool files are found.

This:
- Allows nested tool files like https://github.com/galaxyproject/pulsar/pull/260.
- Allows the Pulsar client to override the tool files transferred via an explicit list (that can be setup a couple different ways in Galaxy in https://github.com/galaxyproject/galaxy/pull/12250.
- Adds an integration test case including with nested files.
