### PR TITLE
Attempt to fix local manager not respecting command exit codes.

### DIFF
--- a/pulsar/managers/base/directory.py
+++ b/pulsar/managers/base/directory.py
@@ -71,8 +71,10 @@ class DirectoryBaseManager(BaseManager):
     def _write_job_file(self, job_id, name, contents):
         return self._job_directory(job_id).write_file(name, contents)
 
-    def _write_return_code(self, job_id, return_code):
-        self._write_job_file(job_id, JOB_FILE_RETURN_CODE, str(return_code))
+    def _write_return_code_if_unset(self, job_id, return_code):
+        return_code_str = self._read_job_file(job_id, JOB_FILE_RETURN_CODE, default=PULSAR_UNKNOWN_RETURN_CODE)
+        if return_code_str == PULSAR_UNKNOWN_RETURN_CODE:
+            self._write_job_file(job_id, JOB_FILE_RETURN_CODE, str(return_code))
 
     def _write_tool_info(self, job_id, tool_id, tool_version):
         job_directory = self._job_directory(job_id)

--- a/pulsar/managers/unqueued.py
+++ b/pulsar/managers/unqueued.py
@@ -114,8 +114,9 @@ class Manager(BaseUnqueuedManager):
             stdout.close()
             stderr.close()
             return_code = proc.returncode
-            # TODO: This is invalid if we have written a job script.
-            self._write_return_code(job_id, str(return_code))
+            # job_script might have set return code so use that if set, otherwise use this one.
+            # Should there be someway to signal failure if this is non-0 in that case?
+            self._write_return_code_if_unset(job_id, str(return_code))
         finally:
             with self._get_job_lock(job_id):
                 self._finish_execution(job_id)


### PR DESCRIPTION
The exit codes aren't being respected in the framework tests but they must work in production right? Someone would have created an issue - so I assume it is the "local" runner equivalent and this TODO seems like it would cause the same problem.