### PR TITLE
Implement dynamic file sources abstraction for parsing files to transfer from galaxy.jsons

### DIFF
--- a/pulsar/client/staging/up.py
+++ b/pulsar/client/staging/up.py
@@ -54,9 +54,12 @@ def submit_job(client, client_job_description, job_config=None):
     # Somehow make the following optional.
     remote_staging["action_mapper"] = file_stager.action_mapper.to_dict()
     remote_staging["client_outputs"] = client_job_description.client_outputs.to_dict()
-
     if remote_staging:
         launch_kwds["remote_staging"] = remote_staging
+
+    # potentially duplicated but we don't want to count on remote staging to include this
+    # it needs to be in the response to Pulsar even Pulsar is inititing staging actions
+    launch_kwds["dynamic_file_sources"] = client_job_description.client_outputs.dynamic_file_sources
 
     client.launch(**launch_kwds)
     return job_id

--- a/pulsar/manager_endpoint_util.py
+++ b/pulsar/manager_endpoint_util.py
@@ -9,6 +9,7 @@ from pulsar import __version__ as pulsar_version
 from pulsar.client.setup_handler import build_job_config
 from pulsar.managers import status
 from pulsar.managers import PULSAR_UNKNOWN_RETURN_CODE
+from pulsar.managers.staging import realized_dynamic_file_sources
 
 log = logging.getLogger(__name__)
 
@@ -52,6 +53,7 @@ def __job_complete_dict(complete_status, manager, job_id):
         job_directory_contents=job_directory.job_directory_contents(),
         system_properties=manager.system_properties(),
         pulsar_version=pulsar_version,
+        realized_dynamic_file_sources=realized_dynamic_file_sources(job_directory)
     )
     return as_dict
 
@@ -72,6 +74,7 @@ def submit_job(manager, job_config):
         env = job_config.get('env', [])
         submit_params = job_config.get('submit_params', {})
         touch_outputs = job_config.get('touch_outputs', [])
+        dynamic_file_sources = job_config.get("dynamic_file_sources", None)
         job_config = None
         if setup_params or force_setup:
             input_job_id = setup_params.get("job_id", job_id)
@@ -100,6 +103,7 @@ def submit_job(manager, job_config):
             "submit_params": submit_params,
             "env": env,
             "setup_params": setup_params,
+            "dynamic_file_sources": dynamic_file_sources,
         }
         manager.preprocess_and_launch(job_id, launch_config)
     except Exception:

--- a/pulsar/managers/base/__init__.py
+++ b/pulsar/managers/base/__init__.py
@@ -304,6 +304,15 @@ class JobDirectory(RemoteJobDirectory):
         assert self.lock_manager, "Can only use job directory locks if lock manager defined."
         return self.lock_manager.get_lock(self._job_file(name))
 
+    def working_directory_file_contents(self, name):
+        working_directory = self.working_directory()
+        working_directory_path = join(working_directory, name)
+        if exists(working_directory_path):
+            with open(working_directory_path, "rb") as f:
+                return f.read()
+        else:
+            return None
+
     def working_directory_contents(self):
         working_directory = self.working_directory()
         return self.__directory_contents(working_directory)

--- a/pulsar/managers/staging/__init__.py
+++ b/pulsar/managers/staging/__init__.py
@@ -3,7 +3,7 @@ preprocessing (currently this means downloading or copying files) and then unsta
 or send results back to client during postprocessing.
 """
 
-from .post import postprocess
+from .post import postprocess, realized_dynamic_file_sources
 from .pre import preprocess
 
-__all__ = ['preprocess', 'postprocess']
+__all__ = ['preprocess', 'postprocess', 'realized_dynamic_file_sources']

--- a/pulsar/web/routes.py
+++ b/pulsar/web/routes.py
@@ -63,13 +63,14 @@ def clean(manager, job_id):
 
 @PulsarController(path="/jobs/{job_id}/submit", method="POST")
 def submit(manager, job_id, command_line, params='{}', dependencies_description='null', setup_params='{}',
-           remote_staging='{}', env='[]', submit_extras='{}'):
+           remote_staging='{}', env='[]', submit_extras='{}', dynamic_file_sources='null'):
     submit_params = loads(params)
     setup_params = loads(setup_params)
     dependencies_description = loads(dependencies_description)
     env = loads(env)
     remote_staging = loads(remote_staging)
     submit_extras = loads(submit_extras)
+    dynamic_file_sources = loads(dynamic_file_sources)
     submit_config = dict(
         job_id=job_id,
         command_line=command_line,
@@ -78,6 +79,7 @@ def submit(manager, job_id, command_line, params='{}', dependencies_description=
         dependencies_description=dependencies_description,
         env=env,
         remote_staging=remote_staging,
+        dynamic_file_sources=dynamic_file_sources,
     )
     submit_config.update(submit_extras)
     submit_job(manager, submit_config)

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ logging-level=INFO
 
 [flake8]
 max-line-length = 150
-max-complexity = 10
+max-complexity = 14
 exclude = pulsar/util/pastescript
 
 [bdist_wheel]

--- a/test/client_staging_test.py
+++ b/test/client_staging_test.py
@@ -176,8 +176,7 @@ class MockClient(object):
         assert tool_version == self.expected_tool.version
         return {}
 
-    def launch(self, command_line, dependencies_description, job_config={}, remote_staging={}, env=[]):
-        # TODO: test env
+    def launch(self, command_line, dependencies_description, job_config={}, remote_staging={}, env=[], dynamic_file_sources=None):
         if self.expected_command_line is not None:
             message = "Excepected command line %s, got %s" % (self.expected_command_line, command_line)
             assert self.expected_command_line == command_line, message

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -180,6 +180,10 @@ class IntegrationTests(BaseIntegrationTest):
         self._run(private_token=None, cache=True, **self.default_kwargs)
 
     @integration_test
+    def test_integration_legacy_galaxy_json(self):
+        self._run(private_token=None, legacy_galaxy_json=True, **self.default_kwargs)
+
+    @integration_test
     def test_integration_default(self):
         self._run(private_token=None, **self.default_kwargs)
 


### PR DESCRIPTION
A matching Galaxy PR needs to be done after the client is published that records the expected location of the tool provided metadata file and the type.

Matching client update in the integration tests.

https://github.com/galaxyproject/pulsar/pull/269/files#diff-8d13dd3d59bfdedd1272c7a1bd9f3b76f24224ca80a5c1185775c905e250827bR270

Fixes https://github.com/galaxyproject/pulsar/issues/93
