### PR TITLE
Modernize tox.

### DIFF
--- a/.github/workflows/pulsar.yaml
+++ b/.github/workflows/pulsar.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-env: [py37-lint, py37-lint-dist, lint-docs]
+        tox-env: [py37-lint, py37-dist, py37-docs]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -22,21 +22,21 @@ jobs:
     strategy:
       matrix:
         include:
-        - tox-env: py36
+        - tox-env: py36-test
           python: 3.6
-        - tox-env: py36-unit
+        - tox-env: py36-test-unit
           python: 3.6
-        - tox-env: py37
+        - tox-env: py37-test
           python: 3.7
-        - tox-env: py37-unit
+        - tox-env: py37-test-unit
           python: 3.7
-        - tox-env: py38
+        - tox-env: py38-test
           python: 3.8
-        - tox-env: py38-unit
+        - tox-env: py38-test-unit
           python: 3.8
-        - tox-env: py39
+        - tox-env: py39-test
           python: 3.9
-        - tox-env: py39-unit
+        - tox-env: py39-test-unit
           python: 3.9
         - tox-env: py37-install-wheel
           python: 3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,84 +1,38 @@
 [tox]
-envlist = py37-lint-dist, lint-docs, py36-lint, py37-lint, py36-unit, py37-unit, py38-unit, py39-unit
+envlist = py{36,37,38,39}-lint, py{36,37,38,39}-docs, py{36,37,38,39}-dist, py{36,37,38,39}-test-unit, py{36,37,38,39}-test, py{36,37,38,39}-install-wheel, py{36,37,38,39}-install-wheel-no-conda
 toxworkdir={env:TOX_WORK_DIR:.tox}
+source_dir = pulsar
+test_dir = test
 
 [testenv]
-commands = pytest -v --log-level=debug
+commands =
+    test: pytest -v --log-level=debug {env:PULSAR_GLOB:}
+    lint: flake8 --ignore W504 {[tox]source_dir} {[tox]test_dir}
+    dist: make lint-dist
+    docs: make lint-docs
+    install-wheel: make test-install-wheel
+    install-wheel-no-conda: make test-install-wheel-no-conda
+
 deps =
-    -rrequirements.txt
-    -rdev-requirements.txt
-    drmaa
-passenv = DRMAA_LIBRARY_PATH
+    test,lint-docs: -rrequirements.txt
+    test,test-install-wheel,test-install-wheel-no-conda: -rdev-requirements.txt
+    test: drmaa
+    lint: flake8
+    docs: sphinx==1.2
+    dist: twine
+    install-wheel,install-wheel-no-conda: virtualenv
 
-[testenv:py36-unit]
-commands = pytest -v --log-level=debug --ignore-glob='*integration*.py'
-deps =
-    -rrequirements.txt
-    -rdev-requirements.txt
+passenv =
+    DRMAA_LIBRARY_PATH
 
-[testenv:py37-unit]
-commands = pytest -v --log-level=debug --ignore-glob='*integration*.py'
-deps =
-    -rrequirements.txt
-    -rdev-requirements.txt
+setenv =
+    unit: PULSAR_GLOB="--ignore-glob='*integration*.py'"
 
-[testenv:py38-unit]
-commands = pytest -v --log-level=debug --ignore-glob='*integration*.py'
-deps =
-    -rrequirements.txt
-    -rdev-requirements.txt
+skip_install =
+    lint,dist,install-wheel,install-wheel-no-conda: True
 
-[testenv:py39-unit]
-commands = pytest -v --log-level=debug --ignore-glob='*integration*.py'
-deps =
-    -rrequirements.txt
-    -rdev-requirements.txt
+skipsdist = 
+    docs: True
 
-[testenv:py36-lint]
-commands = flake8 --ignore W504 pulsar test
-skip_install = True
-deps = flake8
-
-[testenv:py37-lint]
-commands = flake8 --ignore W504 pulsar test
-skip_install = True
-deps = flake8
-
-[testenv:py38-lint]
-commands = flake8 --ignore W504 pulsar test
-skip_install = True
-deps = flake8
-
-[testenv:py39-lint]
-commands = flake8 --ignore W504 pulsar test
-skip_install = True
-deps = flake8
-
-[testenv:py37-lint-dist]
-commands = make lint-dist
-skip_install = True
-whitelist_externals = make
-deps =
-    twine
-
-[testenv:lint-docs]
-commands = make lint-docs
-skip_install = True
-whitelist_externals = make
-deps =
-    -rrequirements.txt
-    sphinx==1.2
-
-[testenv:py37-install-wheel]
-commands = make test-install-wheel
-skip_install = True
-whitelist_externals = make
-deps =
-    virtualenv
-
-[testenv:py37-install-wheel-no-conda]
-commands = make test-install-wheel-no-conda
-skip_install = True
-whitelist_externals = make
-deps =
-    virtualenv
+whitelist_externals =
+    docs,dist,install-wheel,install-wheel-no-conda: make


### PR DESCRIPTION
Make tox environment structured like gxformat2 and planemo - it is more concise and allow less repetition when adding tasks for multiple Python versions. 