### PR TITLE
avoid using getcwd() in cli module pattern matching

### DIFF
--- a/pulsar/managers/util/cli/__init__.py
+++ b/pulsar/managers/util/cli/__init__.py
@@ -24,7 +24,7 @@ class CliInterface(object):
         """
         """
         def __load(module_path, d):
-            module_pattern = join(join(getcwd(), code_dir, *module_path.split('.')), '*.py')
+            module_pattern = join(join(dirname(__file__), module_path.split('.')[-1]), '*.py')
             for file in glob(module_pattern):
                 if basename(file).startswith('_'):
                     continue


### PR DESCRIPTION
I think this did not work in most of the cases due to the getcwd() call.