### PR TITLE
Remove Python <=3.5 code

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,7 +19,6 @@ flake8
 mypy
 types-paramiko
 types-pkg-resources
-types-six
 types-PyYAML
 types-pycurl
 types-requests

--- a/docker/coexecutor/Dockerfile
+++ b/docker/coexecutor/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     # Install Pulsar Python requirements
     && pip install --no-cache-dir -U pip \
     && pip install --no-cache-dir drmaa wheel kombu pykube pycurl \
-            webob psutil PasteDeploy six pyyaml paramiko \
+            webob psutil PasteDeploy pyyaml paramiko \
     # Remove build deps and cleanup
     && apt-get -y remove gcc wget lsb-release \
     && apt-get -y autoremove \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Pulsar documentation build configuration file, created by
 # sphinx-quickstart on Sun Dec 16 23:16:23 2012.
@@ -42,8 +41,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Pulsar'
-copyright = u'2014, Galaxy Project'
+project = 'Pulsar'
+copyright = '2014, Galaxy Project'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -185,8 +184,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Pulsar.tex', u'Pulsar Documentation',
-   u'The Galaxy Project', 'manual'),
+  ('index', 'Pulsar.tex', 'Pulsar Documentation',
+   'The Galaxy Project', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -215,8 +214,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'pulsar', u'Pulsar Documentation',
-     [u'Galaxy Project'], 1)
+    ('index', 'pulsar', 'Pulsar Documentation',
+     ['Galaxy Project'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -229,8 +228,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'Pulsar', u'Pulsar Documentation',
-   u'Galaxy Project', 'Pulsar', 'One line description of project.',
+  ('index', 'Pulsar', 'Pulsar Documentation',
+   'Galaxy Project', 'Pulsar', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 __version__ = '0.15.0.dev0'
 
 PROJECT_NAME = "pulsar"
@@ -7,7 +5,7 @@ PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"
 PROJECT_AUTHOR = 'Galaxy Project and Community'
 PROJECT_EMAIL = 'jmchilton@gmail.com'
 
-PROJECT_URL = "https://github.com/%s/%s" % (PROJECT_OWNER, PROJECT_NAME)
-RAW_CONTENT_URL = "https://raw.github.com/%s/%s/master/" % (
+PROJECT_URL = "https://github.com/{}/{}".format(PROJECT_OWNER, PROJECT_NAME)
+RAW_CONTENT_URL = "https://raw.github.com/{}/{}/master/".format(
     PROJECT_USERAME, PROJECT_NAME
 )

--- a/pulsar/cache/__init__.py
+++ b/pulsar/cache/__init__.py
@@ -1,4 +1,3 @@
-
 from hashlib import sha256
 from os.path import exists, join
 
@@ -7,7 +6,7 @@ from .util import atomicish_move
 from .util import Time
 
 
-class CacheFileMapper(object):
+class CacheFileMapper:
 
     def __init__(self, directory):
         self.directory = directory
@@ -22,7 +21,7 @@ class Cache(PersistenceStore):
     """
 
     def __init__(self, cache_directory="file_cache"):
-        super(Cache, self).__init__(join(cache_directory, "cache_shelf"))
+        super().__init__(join(cache_directory, "cache_shelf"))
         self.file_mapper = CacheFileMapper(cache_directory)
         self.time = Time
 
@@ -58,7 +57,7 @@ class Cache(PersistenceStore):
         return self.destination(token)
 
     def __token(self, ip, path):
-        for_hash = "IP:%s:%s" % (ip, path)
+        for_hash = "IP:{}:{}".format(ip, path)
         return sha256(for_hash.encode('UTF-8')).hexdigest()
 
 

--- a/pulsar/cache/persistence.py
+++ b/pulsar/cache/persistence.py
@@ -1,11 +1,10 @@
-
 import shelve
 import traceback
 
 from threading import Lock
 
 
-class PersistenceStore(object):
+class PersistenceStore:
 
     def __init__(self, filename, require_sync=True):
         self.shelf_filename = filename

--- a/pulsar/cache/util.py
+++ b/pulsar/cache/util.py
@@ -1,4 +1,3 @@
-
 import os
 import shutil
 
@@ -22,7 +21,7 @@ def atomicish_move(source, destination, tmp_suffix="_TMP"):
     """
     destination_dir = os.path.dirname(destination)
     destination_name = os.path.basename(destination)
-    temp_destination = os.path.join(destination_dir, "%s%s" % (destination_name, tmp_suffix))
+    temp_destination = os.path.join(destination_dir, "{}{}".format(destination_name, tmp_suffix))
     shutil.move(source, temp_destination)
     os.rename(temp_destination, destination)
 

--- a/pulsar/client/action_mapper.py
+++ b/pulsar/client/action_mapper.py
@@ -86,7 +86,7 @@ MISSING_FILES_ENDPOINT_ERROR = "Attempted to use remote_transfer action without 
 MISSING_SSH_KEY_ERROR = "Attempt to use file transfer action requiring an SSH key without specifying a ssh_key."
 
 
-class FileActionMapper(object):
+class FileActionMapper:
     """
     Objects of this class define how paths are mapped to actions.
 
@@ -263,7 +263,7 @@ class FileActionMapper(object):
         if "?" not in url_base:
             url_base = "%s?" % url_base
         # TODO: URL encode path.
-        url = "%s&path=%s&file_type=%s" % (url_base, action.path, file_type)
+        url = "{}&path={}&file_type={}".format(url_base, action.path, file_type)
         action.url = url
 
     def __inject_ssh_properties(self, action):
@@ -281,7 +281,7 @@ REQUIRED_ACTION_KWD = object()
 UNSET_ACTION_KWD = "__UNSET__"
 
 
-class BaseAction(object):
+class BaseAction:
     whole_directory_transfer_supported = False
     action_spec: Dict[str, Any] = {}
     action_type: str
@@ -341,7 +341,7 @@ class BaseAction(object):
                 first = False
             else:
                 attribute_str += ","
-            attribute_str += "%s=%s" % (key, value)
+            attribute_str += "{}={}".format(key, value)
         return "FileAction[%s]" % attribute_str
 
 
@@ -376,7 +376,7 @@ class RewriteAction(BaseAction):
     staging = STAGING_ACTION_NONE
 
     def __init__(self, source, file_lister=None, source_directory=None, destination_directory=None):
-        super(RewriteAction, self).__init__(source, file_lister=file_lister)
+        super().__init__(source, file_lister=file_lister)
         self.source_directory = source_directory
         self.destination_directory = destination_directory
 
@@ -453,7 +453,7 @@ class RemoteTransferAction(BaseAction):
     staging = STAGING_ACTION_REMOTE
 
     def __init__(self, source, file_lister=None, url=None):
-        super(RemoteTransferAction, self).__init__(source, file_lister=file_lister)
+        super().__init__(source, file_lister=file_lister)
         self.url = url
 
     def to_dict(self):
@@ -511,7 +511,7 @@ class PubkeyAuthenticatedTransferAction(BaseAction):
 
     def __init__(self, source, file_lister=None, ssh_user=UNSET_ACTION_KWD,
                  ssh_host=UNSET_ACTION_KWD, ssh_port=UNSET_ACTION_KWD, ssh_key=UNSET_ACTION_KWD):
-        super(PubkeyAuthenticatedTransferAction, self).__init__(source, file_lister=file_lister)
+        super().__init__(source, file_lister=file_lister)
         self.ssh_user = ssh_user
         self.ssh_host = ssh_host
         self.ssh_port = ssh_port
@@ -587,7 +587,7 @@ class ScpTransferAction(PubkeyAuthenticatedTransferAction):
                           self.ssh_port, key_file)
 
 
-class MessageAction(object):
+class MessageAction:
     """ Sort of pseudo action describing "files" store in memory and
     transferred via message (HTTP, Python-call, MQ, etc...)
     """
@@ -649,7 +649,7 @@ def from_dict(action_dict):
     return target_class.from_dict(action_dict)
 
 
-class BasePathMapper(object):
+class BasePathMapper:
     match_type: str
 
     def __init__(self, config):
@@ -697,7 +697,7 @@ class PathTypeOnlyMapper(BasePathMapper):
     match_type = 'path_type_only'
 
     def __init__(self, config):
-        super(PathTypeOnlyMapper, self).__init__(config)
+        super().__init__(config)
 
     def _path_matches(self, path):
         return True
@@ -710,14 +710,14 @@ class PrefixPathMapper(BasePathMapper):
     match_type = 'prefix'
 
     def __init__(self, config):
-        super(PrefixPathMapper, self).__init__(config)
+        super().__init__(config)
         self.prefix_path = abspath(config['path'])
 
     def _path_matches(self, path):
         return path is not None and path.startswith(self.prefix_path)
 
     def to_pattern(self):
-        pattern_str = r"(%s%s[^\s,\"\']+)" % (escape(self.prefix_path), escape(sep))
+        pattern_str = r"({}{}[^\s,\"\']+)".format(escape(self.prefix_path), escape(sep))
         return compile(pattern_str)
 
     def to_dict(self):
@@ -728,7 +728,7 @@ class GlobPathMapper(BasePathMapper):
     match_type = 'glob'
 
     def __init__(self, config):
-        super(GlobPathMapper, self).__init__(config)
+        super().__init__(config)
         self.glob_path = config['path']
 
     def _path_matches(self, path):
@@ -745,7 +745,7 @@ class RegexPathMapper(BasePathMapper):
     match_type = 'regex'
 
     def __init__(self, config):
-        super(RegexPathMapper, self).__init__(config)
+        super().__init__(config)
         self.pattern_raw = config['path']
         self.pattern = compile(self.pattern_raw)
 
@@ -775,7 +775,7 @@ def _mappper_from_dict(mapper_dict):
     return MAPPER_CLASS_DICT[map_type](mapper_dict)
 
 
-class FileLister(object):
+class FileLister:
 
     def __init__(self, config):
         self.depth = int(config.get("depth", "0"))
@@ -793,7 +793,7 @@ class FileLister(object):
             while depth > 0:
                 path = dirname(path)
                 depth -= 1
-            return dict([(join(path, f), f) for f in directory_files(path)])
+            return {join(path, f): f for f in directory_files(path)}
 
 
 DEFAULT_FILE_LISTER = FileLister(dict(depth=0))
@@ -809,7 +809,7 @@ ACTION_CLASSES: List[Type[BaseAction]] = [
     RsyncTransferAction,
     ScpTransferAction,
 ]
-actions = dict([(clazz.action_type, clazz) for clazz in ACTION_CLASSES])
+actions = {clazz.action_type: clazz for clazz in ACTION_CLASSES}
 
 
 __all__ = (

--- a/pulsar/client/amqp_exchange.py
+++ b/pulsar/client/amqp_exchange.py
@@ -37,7 +37,7 @@ DEFAULT_ACK_MANAGER_SLEEP = 15
 DEFAULT_REPUBLISH_TIME = 30
 
 
-class PulsarExchange(object):
+class PulsarExchange:
     """ Utility for publishing and consuming structured Pulsar queues using kombu.
     This is shared between the server and client - an exchange should be setup
     for each manager (or in the case of the client, each manager one wished to
@@ -115,7 +115,7 @@ class PulsarExchange(object):
                                 connection.drain_events(timeout=self.__timeout)
                             except socket.timeout:
                                 pass
-            except (IOError, socket.error) as exc:
+            except OSError as exc:
                 self.__handle_io_error(exc, heartbeat_thread)
             except BaseException:
                 log.exception("Problem consuming queue, consumer quitting in problematic fashion!")
@@ -287,7 +287,7 @@ class PulsarExchange(object):
 
     def __queue_name(self, name):
         key_prefix = self.__key_prefix()
-        queue_name = '%s_%s' % (key_prefix, name)
+        queue_name = '{}_{}'.format(key_prefix, name)
         return queue_name
 
     def __key_prefix(self):

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -128,7 +128,7 @@ class JobClient(BaseJobClient):
         super().__init__(destination_params, job_id)
         self.job_manager_interface = job_manager_interface
 
-    def launch(self, command_line, dependencies_description=None, env=[], remote_staging=[], job_config=None, dynamic_file_sources=None):
+    def launch(self, command_line, dependencies_description=None, env=None, remote_staging=None, job_config=None, dynamic_file_sources=None):
         """
         Queue up the execution of the supplied `command_line` on the remote
         server. Called launch for historical reasons, should be renamed to
@@ -250,7 +250,9 @@ class JobClient(BaseJobClient):
         else:
             raise Exception("Unknown output_type %s" % output_type)
 
-    def _raw_execute(self, command, args={}, data=None, input_path=None, output_path=None):
+    def _raw_execute(self, command, args=None, data=None, input_path=None, output_path=None):
+        if args is None:
+            args = {}
         return self.job_manager_interface.execute(command, args, data, input_path, output_path)
 
     def _fetch_output(self, path, name=None, check_exists_remotely=False, action_type='transfer'):
@@ -346,7 +348,7 @@ class BaseMessageJobClient(BaseJobClient):
 
 class MessageJobClient(BaseMessageJobClient):
 
-    def launch(self, command_line, dependencies_description=None, env=[], remote_staging=[], job_config=None, dynamic_file_sources=None):
+    def launch(self, command_line, dependencies_description=None, env=None, remote_staging=None, job_config=None, dynamic_file_sources=None):
         """
         """
         launch_params = self._build_setup_message(
@@ -378,7 +380,7 @@ class MessageCLIJobClient(BaseMessageJobClient):
         self.remote_pulsar_path = destination_params["remote_pulsar_path"]
         self.shell = shell
 
-    def launch(self, command_line, dependencies_description=None, env=[], remote_staging=[], job_config=None, dynamic_file_sources=None):
+    def launch(self, command_line, dependencies_description=None, env=None, remote_staging=None, job_config=None, dynamic_file_sources=None):
         """
         """
         launch_params = self._build_setup_message(
@@ -412,8 +414,8 @@ class MessageCoexecutionPodJobClient(BaseMessageJobClient):
         self,
         command_line,
         dependencies_description=None,
-        env=[],
-        remote_staging=[],
+        env=None,
+        remote_staging=None,
         job_config=None,
         dynamic_file_sources=None,
         container_info=None,

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -1,8 +1,6 @@
 import logging
 import os
 
-from six import string_types
-
 from pulsar.managers.util.pykube_util import (
     ensure_pykube,
     find_job_object_by_name,
@@ -53,7 +51,7 @@ class OutputNotFoundException(Exception):
         return "No remote output found for path %s" % self.path
 
 
-class BaseJobClient(object):
+class BaseJobClient:
 
     def __init__(self, destination_params, job_id):
         destination_params = destination_params or {}
@@ -127,7 +125,7 @@ class JobClient(BaseJobClient):
     """
 
     def __init__(self, destination_params, job_id, job_manager_interface):
-        super(JobClient, self).__init__(destination_params, job_id)
+        super().__init__(destination_params, job_id)
         self.job_manager_interface = job_manager_interface
 
     def launch(self, command_line, dependencies_description=None, env=[], remote_staging=[], job_config=None, dynamic_file_sources=None):
@@ -215,7 +213,7 @@ class JobClient(BaseJobClient):
         # action type == 'message' should either copy or transfer
         # depending on default not just fallback to transfer.
         if action_type in ['transfer', 'message']:
-            if isinstance(contents, string_types):
+            if isinstance(contents, str):
                 contents = contents.encode("utf-8")
             message = "Uploading path [%s] (action_type: [%s])"
             log.debug(message, path, action_type)
@@ -298,7 +296,7 @@ class JobClient(BaseJobClient):
 class BaseMessageJobClient(BaseJobClient):
 
     def __init__(self, destination_params, job_id, client_manager):
-        super(BaseMessageJobClient, self).__init__(destination_params, job_id)
+        super().__init__(destination_params, job_id)
         if not self.job_directory:
             error_message = "Message-queue based Pulsar client requires destination define a remote job_directory to stage files into."
             raise Exception(error_message)
@@ -376,7 +374,7 @@ class MessageJobClient(BaseMessageJobClient):
 class MessageCLIJobClient(BaseMessageJobClient):
 
     def __init__(self, destination_params, job_id, client_manager, shell):
-        super(MessageCLIJobClient, self).__init__(destination_params, job_id, client_manager)
+        super().__init__(destination_params, job_id, client_manager)
         self.remote_pulsar_path = destination_params["remote_pulsar_path"]
         self.shell = shell
 
@@ -394,7 +392,7 @@ class MessageCLIJobClient(BaseMessageJobClient):
         base64_message = to_base64_json(launch_params)
         submit_command = os.path.join(self.remote_pulsar_path, "scripts", "submit.bash")
         # TODO: Allow configuration of manager, app, and ini path...
-        self.shell.execute("nohup %s --base64 %s &" % (submit_command, base64_message))
+        self.shell.execute("nohup {} --base64 {} &".format(submit_command, base64_message))
 
     def kill(self):
         # TODO
@@ -405,7 +403,7 @@ class MessageCoexecutionPodJobClient(BaseMessageJobClient):
 
     def __init__(self, destination_params, job_id, client_manager):
         ensure_pykube()
-        super(MessageCoexecutionPodJobClient, self).__init__(destination_params, job_id, client_manager)
+        super().__init__(destination_params, job_id, client_manager)
         self.instance_id = galaxy_instance_id(destination_params)
         self.pulsar_container_image = destination_params.get("pulsar_container_image", "galaxy/pulsar-pod-staging:0.13.0")
         self._default_pull_policy = pull_policy(destination_params)
@@ -601,7 +599,7 @@ class InputCachingJobClient(JobClient):
     """
 
     def __init__(self, destination_params, job_id, job_manager_interface, client_cacher):
-        super(InputCachingJobClient, self).__init__(destination_params, job_id, job_manager_interface)
+        super().__init__(destination_params, job_id, job_manager_interface)
         self.client_cacher = client_cacher
 
     @parseJson()

--- a/pulsar/client/decorators.py
+++ b/pulsar/client/decorators.py
@@ -6,7 +6,7 @@ MAX_RETRY_COUNT = 5
 RETRY_SLEEP_TIME = 0.1
 
 
-class parseJson(object):
+class parseJson:
 
     def __call__(self, func):
         def replacement(*args, **kwargs):
@@ -15,7 +15,7 @@ class parseJson(object):
         return replacement
 
 
-class retry(object):
+class retry:
 
     def __call__(self, func):
 

--- a/pulsar/client/destination.py
+++ b/pulsar/client/destination.py
@@ -1,4 +1,3 @@
-
 from re import match
 
 from .util import filter_destination_params

--- a/pulsar/client/job_directory.py
+++ b/pulsar/client/job_directory.py
@@ -28,7 +28,7 @@ TYPES_TO_METHOD = dict(
 )
 
 
-class RemoteJobDirectory(object):
+class RemoteJobDirectory:
     """ Representation of a (potentially) remote Pulsar-style staging directory.
     """
 
@@ -155,5 +155,5 @@ def __posix_to_local_path(path, local_path_module=os.path):
 def verify_is_in_directory(path, directory, local_path_module=os.path):
     if not in_directory(path, directory, local_path_module):
         msg = "Attempt to read or write file outside an authorized directory."
-        log.warn("%s Attempted path: %s, valid directory: %s" % (msg, path, directory))
+        log.warn("{} Attempted path: {}, valid directory: {}".format(msg, path, directory))
         raise Exception(msg)

--- a/pulsar/client/manager.py
+++ b/pulsar/client/manager.py
@@ -68,7 +68,7 @@ class ClientManager(ClientManagerInterface):
         else:
             self.job_manager_interface_class = HttpPulsarInterface
             transport_type = kwds.get('transport', None)
-            transport_params = dict([(p.replace('transport_', '', 1), v) for p, v in kwds.items() if p.startswith('transport_')])
+            transport_params = {p.replace('transport_', '', 1): v for p, v in kwds.items() if p.startswith('transport_')}
             transport = get_transport(transport_type, transport_params=transport_params)
             self.job_manager_interface_args = dict(transport=transport)
         cache = kwds.get('cache', None)
@@ -191,7 +191,7 @@ class MessageQueueClientManager(ClientManagerInterface):
 
                 run = functools.partial(self.ack_consumer, name)
                 thread = threading.Thread(
-                    name="pulsar_client_%s_%s_ack" % (self.manager_name, name),
+                    name="pulsar_client_{}_{}_ack".format(self.manager_name, name),
                     target=run
                 )
                 thread.daemon = False  # Lets not interrupt processing of this.
@@ -234,7 +234,7 @@ def build_client_manager(**kwargs: Dict[str, Any]) -> ClientManagerInterface:
         return ClientManager(**kwargs)
 
 
-class ObjectStoreClientManager(object):
+class ObjectStoreClientManager:
 
     def __init__(self, **kwds):
         if 'object_store' in kwds:
@@ -254,7 +254,7 @@ class ObjectStoreClientManager(object):
         return ObjectStoreClient(interface)
 
 
-class ClientCacher(object):
+class ClientCacher:
 
     def __init__(self, **kwds):
         self.event_manager = TransferEventManager()

--- a/pulsar/client/object_client.py
+++ b/pulsar/client/object_client.py
@@ -1,7 +1,7 @@
 from .decorators import parseJson
 
 
-class ObjectStoreClient(object):
+class ObjectStoreClient:
 
     def __init__(self, pulsar_interface):
         self.pulsar_interface = pulsar_interface

--- a/pulsar/client/path_mapper.py
+++ b/pulsar/client/path_mapper.py
@@ -8,7 +8,7 @@ from .staging import CLIENT_INPUT_PATH_TYPES
 from .util import PathHelper
 
 
-class PathMapper(object):
+class PathMapper:
     """ Ties together a FileActionMapper and remote job configuration returned
     by the Pulsar setup method to pre-determine the location of files for staging
     on the remote Pulsar server.

--- a/pulsar/client/server_interface.py
+++ b/pulsar/client/server_interface.py
@@ -21,7 +21,7 @@ class PulsarInterface(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def execute(self, command, args={}, data=None, input_path=None, output_path=None):
+    def execute(self, command, args=None, data=None, input_path=None, output_path=None):
         """
         Execute the correspond command against configured Pulsar job manager. Arguments are
         method parameters and data or input_path describe essentially POST bodies. If command
@@ -94,13 +94,15 @@ class HttpPulsarInterface(PulsarInterface):
         self.remote_host = remote_host
         self.private_token = destination_params.get("private_token", None)
 
-    def execute(self, command, args={}, data=None, input_path=None, output_path=None):
+    def execute(self, command, args=None, data=None, input_path=None, output_path=None):
         url = self.__build_url(command, args)
         method = COMMAND_TO_METHOD.get(command, None)  # Default to GET is no data, POST otherwise
         response = self.transport.execute(url, method=method, data=data, input_path=input_path, output_path=output_path)
         return response
 
     def __build_url(self, command, args):
+        if args is None:
+            args = {}
         path = COMMAND_TO_PATH.get(command, Template(command)).safe_substitute(args)
         if self.private_token:
             args["private_token"] = self.private_token
@@ -133,7 +135,9 @@ class LocalPulsarInterface(PulsarInterface):
             'ip': None
         }
 
-    def execute(self, command, args={}, data=None, input_path=None, output_path=None):
+    def execute(self, command, args=None, data=None, input_path=None, output_path=None):
+        if args is None:
+            args = {}
         # If data set, should be unicode (on Python 2) or str (on Python 3).
         from pulsar.web import routes
         from pulsar.web.framework import build_func_args

--- a/pulsar/client/server_interface.py
+++ b/pulsar/client/server_interface.py
@@ -1,12 +1,9 @@
 import logging
-
 from abc import ABCMeta
 from abc import abstractmethod
+from io import BytesIO
 from string import Template
-
-from six import BytesIO
-from six.moves.urllib.parse import urlencode
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urlencode, urljoin
 
 from galaxy.util import unicodify
 
@@ -15,14 +12,13 @@ from .util import copy_to_path
 log = logging.getLogger(__name__)
 
 
-class PulsarInterface(object):
+class PulsarInterface(metaclass=ABCMeta):
     """
     Abstract base class describes how synchronous client communicates with
     (potentially remote) Pulsar procedures. Obvious implementation is HTTP based
     but Pulsar objects wrapped in routes can also be directly communicated with
     if in memory.
     """
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def execute(self, command, args={}, data=None, input_path=None, output_path=None):
@@ -108,7 +104,7 @@ class HttpPulsarInterface(PulsarInterface):
         path = COMMAND_TO_PATH.get(command, Template(command)).safe_substitute(args)
         if self.private_token:
             args["private_token"] = self.private_token
-        arg_bytes = dict([(k, unicodify(args[k]).encode('utf-8')) for k in args])
+        arg_bytes = {k: unicodify(args[k]).encode('utf-8') for k in args}
         data = urlencode(arg_bytes)
         url = self.remote_host + path + "?" + data
         return url

--- a/pulsar/client/setup_handler.py
+++ b/pulsar/client/setup_handler.py
@@ -19,7 +19,7 @@ def build(client, destination_args):
     return handler
 
 
-class LocalSetupHandler(object):
+class LocalSetupHandler:
     """ Parse destination params to infer job setup parameters (input/output
     directories, etc...). Default is to get this configuration data from the
     remote Pulsar server.
@@ -68,7 +68,7 @@ class LocalSetupHandler(object):
         return filter_destination_params(destination_params, REMOTE_SYSTEM_PROPERTY_PREFIX)
 
 
-class RemoteSetupHandler(object):
+class RemoteSetupHandler:
     """ Default behavior. Fetch setup information from remote Pulsar server.
     """
     def __init__(self, client):

--- a/pulsar/client/staging/__init__.py
+++ b/pulsar/client/staging/__init__.py
@@ -44,7 +44,7 @@ class DynamicFileSourceType(str, Enum):
     # TODO: cwl outputs file, etc...
 
 
-class ClientJobDescription(object):
+class ClientJobDescription:
     """ A description of how client views job - command_line, inputs, etc..
 
     **Parameters**
@@ -156,7 +156,7 @@ class ClientJobDescription(object):
         )
 
 
-class ClientInputs(object):
+class ClientInputs:
     """Abstraction describing input datasets for a job."""
 
     def __init__(self, client_inputs):
@@ -186,7 +186,7 @@ CLIENT_INPUT_PATH_TYPES = Bunch(
 )
 
 
-class ClientInput(object):
+class ClientInput:
 
     def __init__(self, path, input_type, object_store_ref=None):
         self.path = path
@@ -198,7 +198,7 @@ class ClientInput(object):
         return {"path": self.path, "object_store_ref": self.object_store_ref}
 
 
-class ClientOutputs(object):
+class ClientOutputs:
     """ Abstraction describing the output datasets EXPECTED by the Galaxy job
     runner client.
     """
@@ -253,7 +253,7 @@ class ClientOutputs(object):
         return any(map(lambda pattern: pattern.match(filename), self.__dynamic_patterns))
 
 
-class PulsarOutputs(object):
+class PulsarOutputs:
     """ Abstraction describing the output files PRODUCED by the remote Pulsar
     server. """
 
@@ -307,6 +307,6 @@ class PulsarOutputs(object):
         def local_path(name):
             return join(output_directory, self.path_helper.local_name(name))
 
-        files_directory = "%s_files%s" % (basename(output_file)[0:-len(".dat")], self.path_helper.separator)
+        files_directory = "{}_files{}".format(basename(output_file)[0:-len(".dat")], self.path_helper.separator)
         names = filter(lambda o: o.startswith(files_directory), self.output_directory_contents)
         return dict(map(lambda name: (local_path(name), name), names))

--- a/pulsar/client/staging/down.py
+++ b/pulsar/client/staging/down.py
@@ -27,7 +27,7 @@ def finish_job(client, cleanup_job, job_completed_normally, client_outputs, puls
     return collection_failure_exceptions
 
 
-class ClientOutputCollector(object):
+class ClientOutputCollector:
 
     def __init__(self, client):
         self.client = client
@@ -48,7 +48,7 @@ class ClientOutputCollector(object):
         return True
 
 
-class ResultsCollector(object):
+class ResultsCollector:
 
     def __init__(self, output_collector, action_mapper, client_outputs, pulsar_outputs):
         self.output_collector = output_collector
@@ -83,7 +83,7 @@ class ResultsCollector(object):
             try:
                 self.output_files.remove(output_file)
             except ValueError:
-                raise Exception("Failed to remove %s from %s" % (output_file, self.output_files))
+                raise Exception("Failed to remove {} from {}".format(output_file, self.output_files))
 
     def __collect_outputs(self):
         # Legacy Pulsar not returning list of files, iterate over the list of
@@ -177,7 +177,7 @@ class ResultsCollector(object):
                 collect = True
 
             if collect:
-                log.debug("collecting dynamic %s file %s" % (output_type, name))
+                log.debug("collecting dynamic {} file {}".format(output_type, name))
                 output_file = join(directory, self.pulsar_outputs.path_helper.local_name(name))
                 if self._attempt_collect_output(output_type=output_type, path=output_file, name=name):
                     self.downloaded_working_directory_files.append(name)
@@ -195,7 +195,7 @@ class ResultsCollector(object):
         return collected
 
     def _collect_output(self, output_type, action, name):
-        log.info("collecting output %s with action %s" % (name, action))
+        log.info("collecting output {} with action {}".format(name, action))
         try:
             return self.output_collector.collect_output(self, output_type, action, name)
         except Exception as e:
@@ -207,7 +207,7 @@ class ResultsCollector(object):
                 raise
 
 
-class DownloadExceptionTracker(object):
+class DownloadExceptionTracker:
 
     def __init__(self):
         self.collection_failure_exceptions = []

--- a/pulsar/client/staging/up.py
+++ b/pulsar/client/staging/up.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from io import open
 from logging import getLogger
 from os import sep
 from os.path import (
@@ -70,7 +69,7 @@ class StageDirectoryType(Enum):
     WHOLE_DIRECTORY = 2  # transfer the whole directory into the target, preserve name
 
 
-class FileStager(object):
+class FileStager:
     """
     Objects of the FileStager class interact with an Pulsar client object to
     stage the files required to run jobs on a remote Pulsar server.
@@ -334,7 +333,7 @@ class FileStager(object):
         return self.job_inputs.path_referenced(source['path'])
 
 
-class JobInputs(object):
+class JobInputs:
     """
     Abstractions over dynamic inputs created for a given job (namely the command to
     execute and created configfiles).
@@ -403,7 +402,7 @@ class JobInputs(object):
         if directory is None:
             return []
 
-        pattern = r'''[\'\"]?(%s%s[^\s\'\"]+)[\'\"]?''' % (escape(directory), escape(sep))
+        pattern = r'''[\'\"]?({}{}[^\s\'\"]+)[\'\"]?'''.format(escape(directory), escape(sep))
         return self.find_pattern_references(pattern)
 
     def path_referenced(self, path):
@@ -435,7 +434,7 @@ class JobInputs(object):
         return items
 
 
-class TransferTracker(object):
+class TransferTracker:
 
     def __init__(self, client, path_helper, action_mapper, job_inputs, rewrite_paths, job_directory):
         self.client = client
@@ -565,7 +564,7 @@ def _read(path):
     Utility method to quickly read small files (config files and tool
     wrappers) into memory as bytes.
     """
-    input = open(path, "r", encoding="utf-8")
+    input = open(path, encoding="utf-8")
     try:
         return input.read()
     finally:

--- a/pulsar/client/test/check.py
+++ b/pulsar/client/test/check.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Script used to run an example job against a running Pulsar server.
 
 Exercises various features both the Pulsar client and server.
@@ -14,26 +13,22 @@ import tempfile
 import threading
 import time
 import traceback
-
 from collections import namedtuple
-from io import open
 
 from galaxy.tool_util.deps.dependencies import DependenciesDescription
 from galaxy.tool_util.deps.requirements import ToolRequirement
-from six import binary_type
 
 from pulsar.client import (
     build_client_manager,
-    ClientJobDescription,
-    ClientInputs,
-    ClientInput,
-    ClientOutputs,
     CLIENT_INPUT_PATH_TYPES,
+    ClientInput,
+    ClientInputs,
+    ClientJobDescription,
+    ClientOutputs,
     finish_job,
     PulsarOutputs,
     submit_job,
 )
-
 from .test_common import write_config
 
 TEST_SCRIPT = b"""# -*- coding: utf-8 -*-
@@ -130,14 +125,14 @@ HELP_JOB_ID = "Submit the Pulsar job with this 'external' id."
 HELP_DEBUG = "Enable debug log output from Pulsar client"
 
 EXPECTED_OUTPUT = b"hello world output"
-EXAMPLE_UNICODE_TEXT = u'єχαмρℓє συтρυт'
+EXAMPLE_UNICODE_TEXT = 'єχαмρℓє συтρυт'
 TEST_REQUIREMENT = ToolRequirement(name="dep1", version="1.1", type="package")
 TEST_DEPENDENCIES = DependenciesDescription(requirements=[TEST_REQUIREMENT])
 
 ClientInfo = namedtuple("ClientInfo", ["client", "client_manager"])
 
 
-class MockTool(object):
+class MockTool:
 
     def __init__(self, tool_dir):
         self.id = "client_test"
@@ -211,7 +206,7 @@ def run(options):
         __write_to_file("%s.fai" % temp_index_path, b"AGTC")
         __write_to_file(os.path.join(temp_index_dir_sibbling, "human_full_seqs"), b"AGTC")
 
-        empty_input = u"/foo/bar/x"
+        empty_input = "/foo/bar/x"
 
         test_unicode = getattr(options, "test_unicode", False)  # TODO Switch this in integration tests
         legacy_galaxy_json = getattr(options, "legacy_galaxy_json", False)
@@ -236,7 +231,7 @@ def run(options):
             "1" if legacy_galaxy_json else "0",
         )
         assert os.path.exists(temp_index_path)
-        command_line = u'python %s "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s"' % command_line_params
+        command_line = 'python %s "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s" "%s"' % command_line_params
         config_files = [temp_config_path]
         client_inputs = []
         client_inputs.append(ClientInput(temp_input_path, CLIENT_INPUT_PATH_TYPES.INPUT_PATH))
@@ -329,7 +324,7 @@ def run(options):
             shutil.rmtree(temp_directory)
 
 
-class Waiter(object):
+class Waiter:
 
     def __init__(self, client, client_manager):
         self.client = client
@@ -376,16 +371,16 @@ class Waiter(object):
 
 def __assert_contents(path, expected_contents, pulsar_state):
     if not os.path.exists(path):
-        raise AssertionError("File %s not created. Final Pulsar response state [%s]" % (path, pulsar_state))
-    if isinstance(expected_contents, binary_type):
+        raise AssertionError("File {} not created. Final Pulsar response state [{}]".format(path, pulsar_state))
+    if isinstance(expected_contents, bytes):
         file = open(path, 'rb')
     else:
-        file = open(path, 'r', encoding="utf-8")
+        file = open(path, encoding="utf-8")
     try:
         contents = file.read()
         if contents != expected_contents:
-            message = "File (%s) contained invalid contents [%s]." % (path, contents)
-            message = "%s Expected contents [%s]. Final Pulsar response state [%s]" % (message, expected_contents, pulsar_state)
+            message = "File ({}) contained invalid contents [{}].".format(path, contents)
+            message = "{} Expected contents [{}]. Final Pulsar response state [{}]".format(message, expected_contents, pulsar_state)
             raise AssertionError(message)
     finally:
         file.close()
@@ -393,7 +388,7 @@ def __assert_contents(path, expected_contents, pulsar_state):
 
 def __assert_has_rewritten_bwa_path(client, temp_output4_path):
     if client.default_file_action != "none":
-        rewritten_index_path = open(temp_output4_path, 'r', encoding='utf-8').read()
+        rewritten_index_path = open(temp_output4_path, encoding='utf-8').read()
         # Path written to this file will differ between Windows and Linux.
         if re.search(r"%s[/\\]unstructured[/\\]\w+[/\\]bwa[/\\]human.fa" % client.job_id, rewritten_index_path) is None:
             raise AssertionError("[%s] does not contain rewritten path." % rewritten_index_path)
@@ -433,7 +428,7 @@ def __client(temp_directory, options):
     if default_file_action in ["remote_scp_transfer", "remote_rsync_transfer"]:
         test_key = os.environ["PULSAR_TEST_KEY"]
         if not test_key.startswith("----"):
-            test_key = open(test_key, "r").read()
+            test_key = open(test_key).read()
         client_options["ssh_key"] = test_key
         client_options["ssh_user"] = os.environ.get("USER")
         client_options["ssh_port"] = 22
@@ -499,8 +494,8 @@ def __write_to_file(path, contents):
     if not os.path.exists(dirname):
         os.makedirs(dirname)
     with open(path, "wb") as f:
-        if not isinstance(contents, binary_type):
-            contents = binary_type(contents, "UTF-8")
+        if not isinstance(contents, bytes):
+            contents = bytes(contents, "UTF-8")
         f.write(contents)
 
 

--- a/pulsar/client/test/check.py
+++ b/pulsar/client/test/check.py
@@ -454,13 +454,13 @@ def extract_client_options(options):
     if default_file_action:
         client_options["default_file_action"] = default_file_action
     if hasattr(options, "jobs_directory"):
-        client_options["jobs_directory"] = getattr(options, "jobs_directory")
+        client_options["jobs_directory"] = options.jobs_directory
     if hasattr(options, "files_endpoint"):
-        client_options["files_endpoint"] = getattr(options, "files_endpoint")
+        client_options["files_endpoint"] = options.files_endpoint
     if hasattr(options, "k8s_enabled"):
-        client_options["k8s_enabled"] = getattr(options, "k8s_enabled")
+        client_options["k8s_enabled"] = options.k8s_enabled
     if hasattr(options, "container"):
-        client_options["container"] = getattr(options, "container")
+        client_options["container"] = options.container
     return client_options
 
 
@@ -538,7 +538,7 @@ def __finish(options, client, client_outputs, result_status):
     if failed:
         failed_message_template = "Failed to complete job correctly, final status %s, finish exceptions %s."
         failed_message = failed_message_template % (result_status, failed)
-        assert False, failed_message
+        raise AssertionError(failed_message)
 
 
 def main(argv=None):

--- a/pulsar/client/transport/curl.py
+++ b/pulsar/client/transport/curl.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os.path
 
@@ -7,8 +8,6 @@ try:
     curl_available = True
 except ImportError:
     curl_available = False
-from six import string_types
-from six import BytesIO
 
 from ..exceptions import PulsarClientTransportError
 
@@ -23,7 +22,7 @@ GET_FAILED_MESSAGE = "Failed to get_file properly for url %s, remote server retu
 log = logging.getLogger(__name__)
 
 
-class PycurlTransport(object):
+class PycurlTransport:
 
     def __init__(self, timeout=None, **kwrgs):
         self.timeout = timeout
@@ -42,7 +41,7 @@ class PycurlTransport(object):
                 c.setopt(c.INFILESIZE, filesize)
             if data:
                 c.setopt(c.POST, 1)
-                if isinstance(data, string_types):
+                if isinstance(data, str):
                     data = data.encode('UTF-8')
                 c.setopt(c.POSTFIELDS, data)
             if self.timeout:
@@ -100,7 +99,7 @@ def get_file(url, path):
 
 
 def _open_output(output_path, mode='wb'):
-    return open(output_path, mode) if output_path else BytesIO()
+    return open(output_path, mode) if output_path else io.BytesIO()
 
 
 def _new_curl_object_for_url(url):

--- a/pulsar/client/transport/poster.py
+++ b/pulsar/client/transport/poster.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 
 try:

--- a/pulsar/client/transport/requests.py
+++ b/pulsar/client/transport/requests.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 
 try:

--- a/pulsar/client/transport/ssh.py
+++ b/pulsar/client/transport/ssh.py
@@ -8,8 +8,8 @@ def rsync_get_file(uri_from, uri_to, user, host, port, key):
     cmd = [
         'rsync',
         '-e',
-        'ssh -i %s -p %s %s' % (key, port, ' '.join(SSH_OPTIONS)),
-        '%s@%s:%s' % (user, host, uri_from),
+        'ssh -i {} -p {} {}'.format(key, port, ' '.join(SSH_OPTIONS)),
+        '{}@{}:{}'.format(user, host, uri_from),
         uri_to,
     ]
     _call(cmd)
@@ -20,9 +20,9 @@ def rsync_post_file(uri_from, uri_to, user, host, port, key):
     cmd = [
         'rsync',
         '-e',
-        'ssh -i %s -p %s %s' % (key, port, ' '.join(SSH_OPTIONS)),
+        'ssh -i {} -p {} {}'.format(key, port, ' '.join(SSH_OPTIONS)),
         uri_from,
-        '%s@%s:%s' % (user, host, uri_to),
+        '{}@{}:{}'.format(user, host, uri_to),
     ]
     _call(cmd)
 
@@ -33,7 +33,7 @@ def scp_get_file(uri_from, uri_to, user, host, port, key):
         '-P', str(port),
         '-i', key
     ] + SSH_OPTIONS + [
-        '%s@%s:%s' % (user, host, uri_from),
+        '{}@{}:{}'.format(user, host, uri_from),
         uri_to,
     ]
     _call(cmd)
@@ -47,7 +47,7 @@ def scp_post_file(uri_from, uri_to, user, host, port, key):
         '-i', key,
     ] + SSH_OPTIONS + [
         uri_from,
-        '%s@%s:%s' % (user, host, uri_to),
+        '{}@{}:{}'.format(user, host, uri_to),
     ]
     _call(cmd)
 
@@ -59,7 +59,7 @@ def _ensure_dir(uri_to, key, port, user, host):
         '-i', key,
         '-p', str(port),
     ] + SSH_OPTIONS + [
-        '%s@%s' % (user, host),
+        '{}@{}'.format(user, host),
         'mkdir', '-p', directory,
     ]
     _call(cmd)
@@ -68,7 +68,7 @@ def _ensure_dir(uri_to, key, port, user, host):
 def _call(cmd):
     exit_code = subprocess.check_call(cmd)
     if exit_code != 0:
-        raise Exception("%s exited with code %s" % (cmd[0], exit_code))
+        raise Exception("{} exited with code {}".format(cmd[0], exit_code))
 
 
 ___all__ = [

--- a/pulsar/client/transport/standard.py
+++ b/pulsar/client/transport/standard.py
@@ -2,7 +2,6 @@
 Pulsar HTTP Client layer based on Python Standard Library (urllib)
 """
 
-from __future__ import with_statement
 
 import mmap
 import socket
@@ -14,7 +13,7 @@ from urllib.error import URLError
 from ..exceptions import PulsarClientTransportError
 
 
-class UrllibTransport(object):
+class UrllibTransport:
 
     def __init__(self, timeout=None, **kwrgs):
         self.timeout = timeout

--- a/pulsar/core.py
+++ b/pulsar/core.py
@@ -27,7 +27,7 @@ NOT_WHITELIST_WARNING = "Starting the Pulsar without a toolbox to white-list." +
 MULTIPLE_MANAGERS_MESSAGE = "app.only_manager accessed with multiple managers configured"
 
 
-class PulsarApp(object):
+class PulsarApp:
 
     def __init__(self, **conf):
         if conf is None:

--- a/pulsar/main.py
+++ b/pulsar/main.py
@@ -217,7 +217,7 @@ def load_app_configuration(ini_path=None, app_conf_path=None, app_name=None, loc
         if yaml is None:
             raise Exception("Cannot load configuration from file %s, pyyaml is not available." % app_conf_path)
 
-        with open(app_conf_path, "r") as f:
+        with open(app_conf_path) as f:
             app_conf = yaml.safe_load(f) or {}
             local_conf.update(app_conf)
 
@@ -238,7 +238,7 @@ def find_ini(supplied_ini, config_dir):
     return guess
 
 
-class PulsarConfigBuilder(object):
+class PulsarConfigBuilder:
     """ Generate paste-like configuration from supplied command-line arguments.
     """
 
@@ -320,11 +320,11 @@ class PulsarConfigBuilder(object):
 class PulsarManagerConfigBuilder(PulsarConfigBuilder):
 
     def __init__(self, args=None, **kwds):
-        super(PulsarManagerConfigBuilder, self).__init__(args=args, **kwds)
+        super().__init__(args=args, **kwds)
         self.manager = kwds.get("manager", None) or (args and args.manager) or DEFAULT_MANAGER
 
     def to_dict(self):
-        as_dict = super(PulsarManagerConfigBuilder, self).to_dict()
+        as_dict = super().to_dict()
         as_dict["manager"] = self.manager
         return as_dict
 

--- a/pulsar/manager_factory.py
+++ b/pulsar/manager_factory.py
@@ -131,7 +131,7 @@ def _get_managers_dict():
     for manager_module in _load_manager_modules():
         for _, obj in inspect.getmembers(manager_module):
             if inspect.isclass(obj) and hasattr(obj, 'manager_type'):
-                managers[getattr(obj, 'manager_type')] = obj
+                managers[obj.manager_type] = obj
 
     return managers
 

--- a/pulsar/manager_factory.py
+++ b/pulsar/manager_factory.py
@@ -1,10 +1,10 @@
+import configparser
 import inspect
 import logging
 import os
 
 import pulsar.managers
 from pulsar.managers import stateful
-from six.moves import configparser
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ def _load_manager_modules():
             modules.append(module)
         except BaseException as exception:
             exception_str = str(exception)
-            message = "%s manager module could not be loaded: %s" % (manager_module_name, exception_str)
+            message = "{} manager module could not be loaded: {}".format(manager_module_name, exception_str)
             log.warn(message)
             continue
 
@@ -136,7 +136,7 @@ def _get_managers_dict():
     return managers
 
 
-class ManagerDescriptions(object):
+class ManagerDescriptions:
 
     def __init__(self):
         self.descriptions = {}
@@ -148,7 +148,7 @@ class ManagerDescriptions(object):
         self.descriptions[manager_name] = manager_description
 
 
-class ManagerDescription(object):
+class ManagerDescription:
 
     def __init__(self, manager_type=DEFAULT_MANAGER_TYPE, manager_name=DEFAULT_MANAGER_NAME, manager_options={}):
         self.manager_type = manager_type
@@ -157,7 +157,7 @@ class ManagerDescription(object):
 
     @staticmethod
     def from_ini_config(config, manager_name):
-        section_name = '%s%s' % (MANAGER_PREFIX, manager_name)
+        section_name = '{}{}'.format(MANAGER_PREFIX, manager_name)
         try:
             manager_type = config.get(section_name, 'type')
         except ValueError:

--- a/pulsar/managers/__init__.py
+++ b/pulsar/managers/__init__.py
@@ -5,7 +5,7 @@ from abc import ABCMeta, abstractmethod
 PULSAR_UNKNOWN_RETURN_CODE = '__unknown__'
 
 
-class ManagerInterface(object):
+class ManagerInterface:
     """
     Defines the interface to various job managers.
     """
@@ -74,7 +74,7 @@ class ManagerInterface(object):
         """
 
 
-class ManagerProxy(object):
+class ManagerProxy:
     """
     Subclass to build override proxy a manager and override specific
     functionality.

--- a/pulsar/managers/base/base_drmaa.py
+++ b/pulsar/managers/base/base_drmaa.py
@@ -22,7 +22,7 @@ class BaseDrmaaManager(ExternalBaseManager):
 
     def __init__(self, name, app, **kwds):
         """Setup native specification and drmaa session factory."""
-        super(BaseDrmaaManager, self).__init__(name, app, **kwds)
+        super().__init__(name, app, **kwds)
         self.native_specification = kwds.get('native_specification', None)
         drmaa_session_factory_class = kwds.get('drmaa_session_factory_class', DrmaaSessionFactory)
         drmaa_session_factory = drmaa_session_factory_class()
@@ -31,7 +31,7 @@ class BaseDrmaaManager(ExternalBaseManager):
     def shutdown(self, timeout=None):
         """Cleanup DRMAA session and call shutdown of parent."""
         try:
-            super(BaseDrmaaManager, self).shutdown(timeout)
+            super().shutdown(timeout)
         except Exception:
             pass
         self.drmaa_session.close()

--- a/pulsar/managers/base/external.py
+++ b/pulsar/managers/base/external.py
@@ -1,10 +1,9 @@
 import logging
-
 from string import Template
 
 from pulsar.managers import status
+
 from .directory import DirectoryBaseManager
-from six import binary_type
 
 DEFAULT_JOB_NAME_TEMPLATE = "pulsar_$job_id"
 JOB_FILE_EXTERNAL_ID = "external_id"
@@ -19,12 +18,12 @@ class ExternalBaseManager(DirectoryBaseManager):
     """
 
     def __init__(self, name, app, **kwds):
-        super(ExternalBaseManager, self).__init__(name, app, **kwds)
+        super().__init__(name, app, **kwds)
         self._external_ids = {}
         self.job_name_template = kwds.get('job_name_template', DEFAULT_JOB_NAME_TEMPLATE)
 
     def clean(self, job_id):
-        super(ExternalBaseManager, self).clean(job_id)
+        super().clean(job_id)
 
     def kill(self, job_id):
         self._record_cancel(job_id)
@@ -45,7 +44,7 @@ class ExternalBaseManager(DirectoryBaseManager):
         return self._get_status_external(external_id)
 
     def _register_external_id(self, job_id, external_id):
-        if isinstance(external_id, binary_type):
+        if isinstance(external_id, bytes):
             external_id = external_id.decode("utf-8")
         self._job_directory(job_id).store_metadata(JOB_FILE_EXTERNAL_ID, external_id)
         self._external_ids[job_id] = external_id

--- a/pulsar/managers/queued.py
+++ b/pulsar/managers/queued.py
@@ -1,12 +1,12 @@
-import os
 import multiprocessing
-from six.moves import queue
+import os
+import queue
 import threading
 import traceback
+from logging import getLogger
 
 from pulsar.managers.unqueued import Manager
 
-from logging import getLogger
 log = getLogger(__name__)
 
 STOP_SIGNAL = object()
@@ -26,7 +26,7 @@ class QueueManager(Manager):
     manager_type = "queued_python"
 
     def __init__(self, name, app, **kwds):
-        super(QueueManager, self).__init__(name, app, **kwds)
+        super().__init__(name, app, **kwds)
 
         num_concurrent_jobs = kwds.get('num_concurrent_jobs', DEFAULT_NUM_CONCURRENT_JOBS)
         if num_concurrent_jobs == '*':

--- a/pulsar/managers/queued.py
+++ b/pulsar/managers/queued.py
@@ -39,13 +39,13 @@ class QueueManager(Manager):
     def _init_worker_threads(self, num_concurrent_jobs):
         self.work_queue = queue.Queue()
         self.work_threads = []
-        for i in range(num_concurrent_jobs):
+        for _ in range(num_concurrent_jobs):
             worker = threading.Thread(target=self.run_next)
             worker.daemon = True
             worker.start()
             self.work_threads.append(worker)
 
-    def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
+    def launch(self, job_id, command_line, submit_params=None, dependencies_description=None, env=[], setup_params=None):
         command_line = self._prepare_run(
             job_id,
             command_line,
@@ -67,7 +67,7 @@ class QueueManager(Manager):
             raise Exception("Cannot recover job with id %s" % job_id)
 
     def shutdown(self, timeout=None):
-        for i in range(len(self.work_threads)):
+        for _ in range(len(self.work_threads)):
             self.work_queue.put((STOP_SIGNAL, None))
         for worker in self.work_threads:
             worker.join(timeout)

--- a/pulsar/managers/queued_cli.py
+++ b/pulsar/managers/queued_cli.py
@@ -16,7 +16,7 @@ class CliQueueManager(ExternalBaseManager):
     manager_type = "queued_cli"
 
     def __init__(self, name, app, **kwds):
-        super(CliQueueManager, self).__init__(name, app, **kwds)
+        super().__init__(name, app, **kwds)
         self.cli_interface = CliInterface(code_dir='.')
         self.shell_params, self.job_params = split_params(kwds)
 

--- a/pulsar/managers/queued_condor.py
+++ b/pulsar/managers/queued_condor.py
@@ -21,7 +21,7 @@ class CondorQueueManager(ExternalBaseManager):
     manager_type = "queued_condor"
 
     def __init__(self, name, app, **kwds):
-        super(CondorQueueManager, self).__init__(name, app, **kwds)
+        super().__init__(name, app, **kwds)
         self.submission_params = submission_params(**kwds)
         self.user_log_sizes = {}
         self.state_cache = {}
@@ -59,7 +59,7 @@ class CondorQueueManager(ExternalBaseManager):
     def _kill_external(self, external_id):
         failure_message = condor_stop(external_id)
         if failure_message:
-            log.warn("Failed to stop condor job with id %s - %s" % (external_id, failure_message))
+            log.warn("Failed to stop condor job with id {} - {}".format(external_id, failure_message))
 
     def get_status(self, job_id):
         external_id = self._external_id(job_id)

--- a/pulsar/managers/queued_drmaa_xsede.py
+++ b/pulsar/managers/queued_drmaa_xsede.py
@@ -17,7 +17,7 @@ class XsedeDrmaaQueueManager(DrmaaQueueManager):
     manager_type = "queued_drmaa_xsede"
 
     def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
-        super(XsedeDrmaaQueueManager, self).launch(
+        super().launch(
             job_id,
             command_line,
             submit_params=submit_params,
@@ -35,7 +35,7 @@ class XsedeDrmaaQueueManager(DrmaaQueueManager):
                 '-jobid',
                 self._external_ids[job_id]
             ])
-        except (OSError, IOError, CalledProcessError):
+        except (OSError, CalledProcessError):
             log.exception('Failed to call gateway_submit_attributes:')
 
 

--- a/pulsar/managers/queued_external_drmaa.py
+++ b/pulsar/managers/queued_external_drmaa.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from json import dumps
 from getpass import getuser
 
@@ -26,7 +25,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
     manager_type = "queued_external_drmaa"
 
     def __init__(self, name, app, **kwds):
-        super(ExternalDrmaaQueueManager, self).__init__(name, app, **kwds)
+        super().__init__(name, app, **kwds)
         self.chown_working_directory_script = _handle_default(kwds.get('chown_working_directory_script', None), "chown_working_directory")
         self.drmaa_kill_script = _handle_default(kwds.get('drmaa_kill_script', None), "drmaa_kill")
         self.drmaa_launch_script = _handle_default(kwds.get('drmaa_launch_script', None), "drmaa_launch")
@@ -44,7 +43,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
             submit_params=submit_params,
             setup_params=setup_params,
         )
-        print(open(attributes['remoteCommand'], 'r').read())
+        print(open(attributes['remoteCommand']).read())
         job_attributes_file = self._write_job_file(job_id, 'jt.json', dumps(attributes))
         user = submit_params.get('user', None)
         log.info("Submit as user %s" % user)
@@ -63,7 +62,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
         external_id = self._external_id(job_id)
         if not external_id:
             raise KeyError("Failed to find external id for job_id %s" % job_id)
-        external_status = super(ExternalDrmaaQueueManager, self)._get_status_external(external_id)
+        external_status = super()._get_status_external(external_id)
         if external_status == status.COMPLETE and job_id not in self.reclaimed:
             self.reclaimed[job_id] = True
             self.__change_ownership(job_id, getuser())
@@ -87,7 +86,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
     def __sudo(self, *cmds, **kwargs):
         p = sudo_popen(*cmds, **kwargs)
         stdout, stderr = p.communicate()
-        assert p.returncode == 0, "%s, %s" % (stdout, stderr)
+        assert p.returncode == 0, "{}, {}".format(stdout, stderr)
         return stdout
 
 

--- a/pulsar/managers/queued_pbs.py
+++ b/pulsar/managers/queued_pbs.py
@@ -1,4 +1,3 @@
-
 from pulsar.managers.base import BaseManager
 
 # try:
@@ -16,5 +15,5 @@ class PbsQueueManager(BaseManager):
     manager_type = "queued_pbs"
 
     def __init__(self, name, app, **kwds):
-        super(PbsQueueManager, self).__init__(name, app, **kwds)
+        super().__init__(name, app, **kwds)
         raise NotImplementedError()

--- a/pulsar/managers/staging/post.py
+++ b/pulsar/managers/staging/post.py
@@ -55,7 +55,7 @@ def realized_dynamic_file_sources(job_directory):
     return realized_dynamic_file_sources
 
 
-class PulsarServerOutputCollector(object):
+class PulsarServerOutputCollector:
 
     def __init__(self, job_directory, action_executor):
         self.job_directory = job_directory
@@ -73,7 +73,7 @@ class PulsarServerOutputCollector(object):
             name = os.path.basename(action.path)
 
         pulsar_path = self.job_directory.calculate_path(name, output_type)
-        description = "staging out file %s via %s" % (pulsar_path, action)
+        description = "staging out file {} via {}".format(pulsar_path, action)
         self.action_executor.execute(lambda: action.write_from_path(pulsar_path), description)
 
 

--- a/pulsar/managers/staging/pre.py
+++ b/pulsar/managers/staging/pre.py
@@ -14,7 +14,7 @@ def preprocess(job_directory, setup_actions, action_executor, object_store=None)
         if getattr(action, "inject_object_store", False):
             action.object_store = object_store
         path = job_directory.calculate_path(name, input_type)
-        description = "Staging %s '%s' via %s to %s" % (input_type, name, action, path)
+        description = "Staging {} '{}' via {} to {}".format(input_type, name, action, path)
         log.debug(description)
         action_executor.execute(lambda: action.write_to_path(path), "action[%s]" % description)
 

--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import contextlib
 import datetime
 import os
@@ -45,7 +43,7 @@ class StatefulManagerProxy(ManagerProxy):
     """
 
     def __init__(self, manager, **manager_options):
-        super(StatefulManagerProxy, self).__init__(manager)
+        super().__init__(manager)
         min_polling_interval = float(manager_options.get("min_polling_interval", DEFAULT_MIN_POLLING_INTERVAL))
         preprocess_retry_action_kwds = filter_destination_params(manager_options, "preprocess_action_")
         postprocess_retry_action_kwds = filter_destination_params(manager_options, "postprocess_action_")
@@ -61,7 +59,7 @@ class StatefulManagerProxy(ManagerProxy):
         self.__monitor = ManagerMonitor(self)
 
     def _default_status_change_callback(self, status, job_id):
-        log.info("Status of job [%s] changed to [%s]. No callbacks enabled." % (job_id, status))
+        log.info("Status of job [{}] changed to [{}]. No callbacks enabled.".format(job_id, status))
 
     def trigger_state_change_callback(self, job_id):
         proxy_status = self.get_status(job_id)
@@ -232,7 +230,7 @@ class StatefulManagerProxy(ManagerProxy):
                 self.__monitor.shutdown(timeout)
             except Exception:
                 log.exception("Failed to shutdown job monitor for manager %s" % self.name)
-        super(StatefulManagerProxy, self).shutdown(timeout)
+        super().shutdown(timeout)
 
     def recover_active_jobs(self):
         unqueue_preprocessing_ids = []
@@ -271,7 +269,7 @@ class StatefulManagerProxy(ManagerProxy):
         self.__state_change_callback(status.LOST, job_id)
 
 
-class ActiveJobs(object):
+class ActiveJobs:
     """ Keeps track of active jobs (those that are not yet "complete").
     Current implementation is file based, but could easily be made
     database-based instead.
@@ -337,7 +335,7 @@ class ActiveJobs(object):
         return os.path.join(self._active_job_directory(active_status), job_id)
 
 
-class ManagerMonitor(object):
+class ManagerMonitor:
     """ Monitors active jobs of a StatefulManagerProxy.
     """
 
@@ -385,12 +383,12 @@ class ManagerMonitor(object):
 
 
 def new_thread_for_job(manager, action, job_id, target, daemon):
-    name = "[action=%s]-[job=%s]" % (action, job_id)
+    name = "[action={}]-[job={}]".format(action, job_id)
     return new_thread_for_manager(manager, name, target, daemon)
 
 
 def new_thread_for_manager(manager, name, target, daemon):
-    thread_name = "[manager=%s]-%s" % (manager.name, name)
+    thread_name = "[manager={}]-{}".format(manager.name, name)
     thread = threading.Thread(name=thread_name, target=target)
     thread.daemon = daemon
     thread.start()

--- a/pulsar/managers/unqueued.py
+++ b/pulsar/managers/unqueued.py
@@ -77,7 +77,7 @@ class Manager(BaseUnqueuedManager):
     manager_type = "unqueued"
 
     def __init__(self, name, app, **kwds):
-        super(Manager, self).__init__(name, app, **kwds)
+        super().__init__(name, app, **kwds)
 
     def __get_pid(self, job_id):
         pid = None
@@ -120,16 +120,16 @@ class Manager(BaseUnqueuedManager):
 
     # with job lock
     def _finish_execution(self, job_id):
-        super(Manager, self)._finish_execution(job_id)
+        super()._finish_execution(job_id)
         self._job_directory(job_id).remove_metadata(JOB_FILE_PID)
 
     # with job lock
     def _get_status(self, job_id):
-        return super(Manager, self)._get_status(job_id)
+        return super()._get_status(job_id)
 
     # with job lock
     def _was_cancelled(self, job_id):
-        return super(Manager, self)._was_cancelled(job_id)
+        return super()._was_cancelled(job_id)
 
     # with job lock
     def _record_pid(self, job_id, pid):
@@ -181,7 +181,7 @@ class CoexecutionManager(BaseUnqueuedManager):
     manager_type = "coexecution"
 
     def __init__(self, name, app, **kwds):
-        super(CoexecutionManager, self).__init__(name, app, **kwds)
+        super().__init__(name, app, **kwds)
 
     def get_status(self, job_id):
         return self._get_status(job_id)
@@ -208,11 +208,11 @@ class CoexecutionManager(BaseUnqueuedManager):
         command_line = self._prepare_run(job_id, command_line, dependencies_description=dependencies_description, env=env, setup_params=setup_params)
         job_directory = self.job_directory(job_id)
         working_directory = job_directory.working_directory()
-        command_line += " > '%s' 2> '%s'" % (
+        command_line += " > '{}' 2> '{}'".format(
             self._stdout_path(job_id),
             self._stderr_path(job_id),
         )
-        command_line = "cd '%s'; sh %s" % (working_directory, command_line)
+        command_line = "cd '{}'; sh {}".format(working_directory, command_line)
         self._write_command_line(job_id, command_line)
         self._start_monitor(job_id)
 

--- a/pulsar/managers/util/cli/__init__.py
+++ b/pulsar/managers/util/cli/__init__.py
@@ -14,7 +14,7 @@ ERROR_MESSAGE_NO_JOB_PLUGIN = "No job plugin parameter found, cannot create CLI 
 ERROR_MESSAGE_NO_SUCH_JOB_PLUGIN = "Failed to find job_plugin of type %s, available types include %s"
 
 
-class CliInterface(object):
+class CliInterface:
     """
     High-level interface for loading shell and job plugins and matching
     them to specified parameters.
@@ -28,7 +28,7 @@ class CliInterface(object):
             for file in glob(module_pattern):
                 if basename(file).startswith('_'):
                     continue
-                module_name = '%s.%s' % (module_path, basename(file).rsplit('.py', 1)[0])
+                module_name = '{}.{}'.format(module_path, basename(file).rsplit('.py', 1)[0])
                 module = __import__(module_name)
                 for comp in module_name.split(".")[1:]:
                     module = getattr(module, comp)
@@ -75,6 +75,6 @@ class CliInterface(object):
 
 
 def split_params(params):
-    shell_params = dict((k.replace('shell_', '', 1), v) for k, v in params.items() if k.startswith('shell_'))
-    job_params = dict((k.replace('job_', '', 1), v) for k, v in params.items() if k.startswith('job_'))
+    shell_params = {k.replace('shell_', '', 1): v for k, v in params.items() if k.startswith('shell_')}
+    job_params = {k.replace('job_', '', 1): v for k, v in params.items() if k.startswith('job_')}
     return shell_params, job_params

--- a/pulsar/managers/util/cli/job/__init__.py
+++ b/pulsar/managers/util/cli/job/__init__.py
@@ -6,11 +6,8 @@ from abc import (
     abstractmethod
 )
 
-import six
 
-
-@six.add_metaclass(ABCMeta)
-class BaseJobExec(object):
+class BaseJobExec(metaclass=ABCMeta):
 
     @abstractmethod
     def __init__(self, **params):

--- a/pulsar/managers/util/cli/job/lsf.py
+++ b/pulsar/managers/util/cli/job/lsf.py
@@ -51,7 +51,7 @@ class LSF(BaseJobExec):
         # Generated template.
         template_scriptargs = ''
         for k, v in scriptargs.items():
-            template_scriptargs += '#BSUB %s %s\n' % (k, v)
+            template_scriptargs += '#BSUB {} {}\n'.format(k, v)
         return dict(headers=template_scriptargs)
 
     def submit(self, script_file):

--- a/pulsar/managers/util/cli/job/slurm.py
+++ b/pulsar/managers/util/cli/job/slurm.py
@@ -47,7 +47,7 @@ class Slurm(BaseJobExec):
         # Generated template.
         template_scriptargs = ''
         for k, v in scriptargs.items():
-            template_scriptargs += '#SBATCH %s %s\n' % (k, v)
+            template_scriptargs += '#SBATCH {} {}\n'.format(k, v)
         return dict(headers=template_scriptargs)
 
     def submit(self, script_file):

--- a/pulsar/managers/util/cli/job/torque.py
+++ b/pulsar/managers/util/cli/job/torque.py
@@ -1,8 +1,5 @@
+import xml.etree.ElementTree as et
 from logging import getLogger
-try:
-    import xml.etree.cElementTree as et
-except ImportError:
-    import xml.etree.ElementTree as et  # type: ignore
 
 try:
     from galaxy.model import Job
@@ -62,7 +59,7 @@ class Torque(BaseJobExec):
                 log.warning(ERROR_MESSAGE_UNRECOGNIZED_ARG % k)
         template_pbsargs = ''
         for k, v in pbsargs.items():
-            template_pbsargs += '#PBS %s %s\n' % (k, v)
+            template_pbsargs += '#PBS {} {}\n'.format(k, v)
         return dict(headers=template_pbsargs)
 
     def submit(self, script_file):

--- a/pulsar/managers/util/cli/shell/__init__.py
+++ b/pulsar/managers/util/cli/shell/__init__.py
@@ -6,11 +6,8 @@ from abc import (
     abstractmethod
 )
 
-import six
 
-
-@six.add_metaclass(ABCMeta)
-class BaseShellExec(object):
+class BaseShellExec(metaclass=ABCMeta):
 
     @abstractmethod
     def __init__(self, *args, **kwargs):

--- a/pulsar/managers/util/cli/shell/local.py
+++ b/pulsar/managers/util/cli/shell/local.py
@@ -6,8 +6,6 @@ from subprocess import (
 from tempfile import TemporaryFile
 from time import sleep
 
-import six
-
 from ..shell import BaseShellExec
 from ....util import (
     Bunch,
@@ -16,7 +14,7 @@ from ....util import (
 
 log = getLogger(__name__)
 
-TIMEOUT_ERROR_MESSAGE = u'Execution timed out'
+TIMEOUT_ERROR_MESSAGE = 'Execution timed out'
 TIMEOUT_RETURN_CODE = -1
 DEFAULT_TIMEOUT = 60
 DEFAULT_TIMEOUT_CHECK_INTERVAL = 3
@@ -47,12 +45,12 @@ class LocalShell(BaseShellExec):
         pass
 
     def execute(self, cmd, persist=False, timeout=DEFAULT_TIMEOUT, timeout_check_interval=DEFAULT_TIMEOUT_CHECK_INTERVAL, **kwds):
-        is_cmd_string = isinstance(cmd, six.string_types)
+        is_cmd_string = isinstance(cmd, str)
         outf = TemporaryFile()
         p = Popen(cmd, stdin=None, stdout=outf, stderr=PIPE, shell=is_cmd_string)
         # poll until timeout
 
-        for i in range(int(timeout / timeout_check_interval)):
+        for _ in range(int(timeout / timeout_check_interval)):
             sleep(0.1)  # For fast returning commands
             r = p.poll()
             if r is not None:
@@ -60,7 +58,7 @@ class LocalShell(BaseShellExec):
             sleep(timeout_check_interval)
         else:
             kill_pid(p.pid)
-            return Bunch(stdout=u'', stderr=TIMEOUT_ERROR_MESSAGE, returncode=TIMEOUT_RETURN_CODE)
+            return Bunch(stdout='', stderr=TIMEOUT_ERROR_MESSAGE, returncode=TIMEOUT_RETURN_CODE)
         outf.seek(0)
         return Bunch(stdout=_read_str(outf), stderr=_read_str(p.stderr), returncode=p.returncode)
 

--- a/pulsar/managers/util/cli/shell/rsh.py
+++ b/pulsar/managers/util/cli/shell/rsh.py
@@ -20,7 +20,7 @@ __all__ = ('RemoteShell', 'SecureShell', 'GlobusSecureShell', 'ParamikoShell')
 class RemoteShell(LocalShell):
 
     def __init__(self, rsh='rsh', rcp='rcp', hostname='localhost', username=None, options=None, **kwargs):
-        super(RemoteShell, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.rsh = rsh
         self.rcp = rcp
         self.hostname = hostname
@@ -36,7 +36,7 @@ class RemoteShell(LocalShell):
         if self.username:
             fullcmd.extend(["-l", self.username])
         fullcmd.extend([self.hostname, cmd])
-        return super(RemoteShell, self).execute(fullcmd, persist, timeout)
+        return super().execute(fullcmd, persist, timeout)
 
 
 class SecureShell(RemoteShell):
@@ -50,10 +50,10 @@ class SecureShell(RemoteShell):
             options.extend(['-i', private_key])
         if port:
             options.extend(['-p', str(port)])
-        super(SecureShell, self).__init__(rsh=rsh, rcp=rcp, options=options, **kwargs)
+        super().__init__(rsh=rsh, rcp=rcp, options=options, **kwargs)
 
 
-class ParamikoShell(object):
+class ParamikoShell:
 
     def __init__(self, username, hostname, password=None, private_key=None, port=22, timeout=60, **kwargs):
         self.username = username
@@ -100,4 +100,4 @@ class ParamikoShell(object):
 class GlobusSecureShell(SecureShell):
 
     def __init__(self, rsh='gsissh', rcp='gsiscp', **kwargs):
-        super(GlobusSecureShell, self).__init__(rsh=rsh, rcp=rcp, **kwargs)
+        super().__init__(rsh=rsh, rcp=rcp, **kwargs)

--- a/pulsar/managers/util/condor/__init__.py
+++ b/pulsar/managers/util/condor/__init__.py
@@ -60,7 +60,7 @@ def build_submit_description(executable, output, error, user_log, query_params):
 
     submit_description = []
     for key, value in all_query_params.items():
-        submit_description.append('%s = %s' % (key, value))
+        submit_description.append('{} = {}'.format(key, value))
     submit_description.append('executable = ' + executable)
     submit_description.append('output = ' + output)
     submit_description.append('error = ' + error)
@@ -83,7 +83,7 @@ def condor_submit(submit_file):
         if submit.returncode == 0:
             external_id = parse_external_id(condor_message, type='condor')
         else:
-            failure_message = "%s: %s" % (PROBLEM_PARSING_EXTERNAL_ID, condor_message)
+            failure_message = "{}: {}".format(PROBLEM_PARSING_EXTERNAL_ID, condor_message)
     except Exception as e:
         failure_message = str(e)
     return external_id, failure_message
@@ -109,7 +109,7 @@ def summarize_condor_log(log_file, external_id):
     """
     log_job_id = external_id.zfill(3)
     s1 = s4 = s7 = s5 = s9 = False
-    with open(log_file, 'r') as log_handle:
+    with open(log_file) as log_handle:
         for line in log_handle:
             if '001 (' + log_job_id + '.' in line:
                 s1 = True

--- a/pulsar/managers/util/drmaa/__init__.py
+++ b/pulsar/managers/util/drmaa/__init__.py
@@ -20,7 +20,7 @@ NO_DRMAA_MESSAGE = "Attempt to use DRMAA, but DRMAA Python library cannot be loa
 log = logging.getLogger(__name__)
 
 
-class DrmaaSessionFactory(object):
+class DrmaaSessionFactory:
     """
     Abstraction used to production DrmaaSession wrappers.
     """
@@ -34,7 +34,7 @@ class DrmaaSessionFactory(object):
         return DrmaaSession(session_constructor, **kwds)
 
 
-class DrmaaSession(object):
+class DrmaaSession:
     """
     Abstraction around `drmaa` module `Session` objects.
     """

--- a/pulsar/managers/util/env.py
+++ b/pulsar/managers/util/env.py
@@ -1,4 +1,3 @@
-
 RAW_VALUE_BY_DEFAULT = False
 
 
@@ -30,7 +29,7 @@ def env_to_statement(env):
         return execute
     name = env['name']
     value = __escape(env['value'], env)
-    return '%s=%s; export %s' % (name, value, name)
+    return '{}={}; export {}'.format(name, value, name)
 
 
 def __escape(value, env):

--- a/pulsar/managers/util/job_script/__init__.py
+++ b/pulsar/managers/util/job_script/__init__.py
@@ -1,4 +1,3 @@
-import io
 import logging
 import os
 import subprocess
@@ -6,9 +5,8 @@ import time
 from string import Template
 from typing import Any, Dict
 
-from pkg_resources import resource_string
-
 from galaxy.util import unicodify
+from pkg_resources import resource_string
 
 log = logging.getLogger(__name__)
 DEFAULT_SHELL = '/bin/bash'
@@ -114,7 +112,7 @@ def write_script(path, contents, config, mode=0o755):
     if not os.path.exists(dir):
         os.makedirs(dir)
 
-    with io.open(path, 'w', encoding='utf-8') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         f.write(unicodify(contents))
     os.chmod(path, mode)
     _handle_script_integrity(path, config)
@@ -127,7 +125,7 @@ def _handle_script_integrity(path, config):
     script_integrity_verified = False
     count = getattr(config, "check_job_script_integrity_count", DEFAULT_INTEGRITY_COUNT)
     sleep_amt = getattr(config, "check_job_script_integrity_sleep", DEFAULT_INTEGRITY_SLEEP)
-    for i in range(count):
+    for _ in range(count):
         try:
             returncode = subprocess.call([path], env={"ABC_TEST_JOB_SCRIPT_INTEGRITY_XYZ": "1"})
             if returncode == 42:

--- a/pulsar/managers/util/retry.py
+++ b/pulsar/managers/util/retry.py
@@ -13,7 +13,7 @@ DEFAULT_CATCH = (Exception,)
 DEFAULT_DESCRIPTION = "action"
 
 
-class RetryActionExecutor(object):
+class RetryActionExecutor:
 
     def __init__(self, **kwds):
         # Use variables that match kombu to keep things consistent across

--- a/pulsar/messaging/__init__.py
+++ b/pulsar/messaging/__init__.py
@@ -5,8 +5,6 @@ submodules of ``pulsar.client``.
 
 import logging
 
-from six import itervalues
-
 from ..messaging import bind_amqp
 
 log = logging.getLogger(__name__)
@@ -15,12 +13,12 @@ log = logging.getLogger(__name__)
 def bind_app(app, queue_id, connect_ssl=None):
     connection_string = __id_to_connection_string(app, queue_id)
     queue_state = QueueState()
-    for manager in itervalues(app.managers):
+    for manager in app.managers.values():
         bind_amqp.bind_manager_to_queue(manager, queue_state, connection_string, connect_ssl)
     return queue_state
 
 
-class QueueState(object):
+class QueueState:
     """ Passed through to event loops, should be "non-zero" while queues should
     be active.
     """

--- a/pulsar/messaging/bind_amqp.py
+++ b/pulsar/messaging/bind_amqp.py
@@ -38,7 +38,7 @@ def get_exchange(connection_string, manager_name, conf):
 
 def bind_manager_to_queue(manager, queue_state, connection_string, conf):
     manager_name = manager.name
-    log.info("bind_manager_to_queue called for [%s] and manager [%s]" % (mask_password_from_url(connection_string), manager_name))
+    log.info("bind_manager_to_queue called for [{}] and manager [{}]".format(mask_password_from_url(connection_string), manager_name))
     pulsar_exchange = get_exchange(connection_string, manager_name, conf)
 
     process_setup_messages = functools.partial(__process_setup_message, manager)
@@ -64,7 +64,7 @@ def bind_manager_to_queue(manager, queue_state, connection_string, conf):
     def bind_on_status_change(new_status, job_id):
         job_id = job_id or 'unknown'
         try:
-            message = "Publishing Pulsar state change with status %s for job_id %s" % (new_status, job_id)
+            message = "Publishing Pulsar state change with status {} for job_id {}".format(new_status, job_id)
             log.debug(message)
             payload = manager_endpoint_util.full_status(manager, new_status, job_id)
             pulsar_exchange.publish("status_update", payload)
@@ -78,7 +78,7 @@ def bind_manager_to_queue(manager, queue_state, connection_string, conf):
 
 def __start_consumer(name, exchange, target):
     exchange_url = mask_password_from_url(exchange.url)
-    thread_name = "consume-%s-%s" % (name, exchange_url)
+    thread_name = "consume-{}-{}".format(name, exchange_url)
     thread = threading.Thread(name=thread_name, target=target)
     # TODO: If the shutdown code is actually called make this
     # not a daemon.
@@ -112,7 +112,7 @@ def __processes_message(f):
             f(manager, body, job_id)
         except Exception:
             job_id = job_id or 'unknown'
-            log.exception("Failed to process message with function %s for job_id %s" % (f.__name__, job_id))
+            log.exception("Failed to process message with function {} for job_id {}".format(f.__name__, job_id))
         message.ack()
 
     return process_message

--- a/pulsar/scripts/chown_working_directory.py
+++ b/pulsar/scripts/chown_working_directory.py
@@ -29,7 +29,7 @@ def main(argv=None):
     else:
         job_directory = abspath(args.job_directory)
         assert job_directory
-    command = "chown -Rh '%s' '%s'" % (user, job_directory)
+    command = "chown -Rh '{}' '{}'".format(user, job_directory)
     system(command)
 
 

--- a/pulsar/scripts/config.py
+++ b/pulsar/scripts/config.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 
 import os
 import string
@@ -260,7 +259,7 @@ def _print_pulsar_check(args, mode):
         return
 
     print("Run a test job against your Pulsar server using the command:")
-    command = "pulsar-check --url http://%s:%s" % (args.host, args.port)
+    command = "pulsar-check --url http://{}:{}".format(args.host, args.port)
     if args.private_token:
         command += '--private_token %s' % args.private_token
     print("  %s" % command)

--- a/pulsar/scripts/drmaa_launch.py
+++ b/pulsar/scripts/drmaa_launch.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from json import load
 from pulsar.managers.util.drmaa import DrmaaSessionFactory
 from pulsar.main import ArgumentParser
@@ -11,7 +10,7 @@ def main(argv=None):
     arg_parser = ArgumentParser(description=DESCRIPTION)
     arg_parser.add_argument("--job_attributes", required=True)
     args = arg_parser.parse_args(argv)
-    job_attributes = load(open(args.job_attributes, "r"))
+    job_attributes = load(open(args.job_attributes))
     session = DrmaaSessionFactory().get()
     external_id = session.run_job(**job_attributes)
     print(external_id)

--- a/pulsar/scripts/submit_util.py
+++ b/pulsar/scripts/submit_util.py
@@ -50,7 +50,7 @@ def _load_job_config(args):
         base64_job_config = args.base64
         job_config = from_base64_json(base64_job_config)
     else:
-        job_config = json.load(open(args.file, "r"))
+        job_config = json.load(open(args.file))
     return job_config
 
 

--- a/pulsar/tools/authorization.py
+++ b/pulsar/tools/authorization.py
@@ -1,7 +1,7 @@
 from os.path import join
 
 
-class AllowAnyAuthorization(object):
+class AllowAnyAuthorization:
 
     def authorize_setup(self):
         pass
@@ -16,7 +16,7 @@ class AllowAnyAuthorization(object):
         pass
 
 
-class AllowAnyAuthorizer(object):
+class AllowAnyAuthorizer:
     """
     Allow any, by default Pulsar is assumed to be secured
     using a firewall or private_token.
@@ -60,7 +60,7 @@ class ToolBasedAuthorization(AllowAnyAuthorization):
         return self.tool.inputs_validator
 
 
-class ToolBasedAuthorizer(object):
+class ToolBasedAuthorizer:
     """
     Work In Progress: Implement tool based white-listing
     of what jobs can run and what those jobs can do.

--- a/pulsar/tools/toolbox.py
+++ b/pulsar/tools/toolbox.py
@@ -1,4 +1,3 @@
-from io import open
 from logging import getLogger
 from os.path import abspath, dirname, join
 from xml.etree import ElementTree
@@ -9,7 +8,7 @@ from pulsar.tools.validator import ExpressionValidator
 log = getLogger(__name__)
 
 
-class ToolBox(object):
+class ToolBox:
     """
     Abstraction over a tool config file largely modelled after
     Galaxy's shed_tool_conf.xml. Hopefully over time this toolbox
@@ -53,7 +52,7 @@ class ToolBox(object):
         return [tool for tool in self.tool_configs if tool.id == id]
 
 
-class InputsValidator(object):
+class InputsValidator:
 
     def __init__(self, command_validator, config_validators):
         self.command_validator = command_validator
@@ -66,18 +65,18 @@ class InputsValidator(object):
         config_validator = self.config_validators.get(name, None)
         valid = True
         if config_validator:
-            contents = open(path, "r", encoding="UTF-8").read()
+            contents = open(path, encoding="UTF-8").read()
             valid = config_validator.validate(job_directory, contents)
         return valid
 
 
-class ToolConfig(object):
+class ToolConfig:
     """
     Abstract description of a Galaxy tool.
     """
 
     def __init__(self):
-        super(ToolConfig, self).__init__()
+        super().__init__()
 
     def get_tool_dir(self):
         return abspath(dirname(self.path))
@@ -109,7 +108,7 @@ class SimpleToolConfig(ToolConfig):
     """
 
     def __init__(self, tool_el, tool_path):
-        super(SimpleToolConfig, self).__init__()
+        super().__init__()
         rel_path = tool_el.get('file')
         assert tool_path, "tool_path not set, toolbox XML files must be configured with a tool_path directory."
         assert rel_path, "file not set on tool, each tool element must define a file attribute pointing to a valid tool XML file."
@@ -141,7 +140,7 @@ class ToolShedToolConfig(SimpleToolConfig):
     """
 
     def __init__(self, tool_el, tool_path):
-        super(ToolShedToolConfig, self).__init__(tool_el, tool_path)
+        super().__init__(tool_el, tool_path)
         self.guid = tool_el.get("guid")
         # Override id in file for tool shed tools. Use GUID instead.
         self.id = self.guid

--- a/pulsar/tools/validator.py
+++ b/pulsar/tools/validator.py
@@ -5,7 +5,7 @@ from xml.etree.ElementTree import fromstring
 from galaxy.util import in_directory
 
 
-class ExpressionValidator(object):
+class ExpressionValidator:
 
     def __init__(self, xml_el):
         if type(xml_el) == str:
@@ -51,9 +51,9 @@ class ExpressionValidator(object):
         assert max_count > 0
         if min_count != 1 or max_count != 1:
             single_regex = r"(?:%s)" % regex
-            first = "%s%s" % (single_regex, "?" if min_count == 0 else "")
+            first = "{}{}".format(single_regex, "?" if min_count == 0 else "")
             rest = r"(?:%s%s){%d,%d}" % (join_on, regex, max(min_count - 1, 0), max_count - 1)
-            regex = "%s%s" % (first, rest)
+            regex = "{}{}".format(first, rest)
         return regex
 
     def __is_true(self, str):
@@ -68,7 +68,7 @@ class ExpressionValidator(object):
     def _parameter_to_regex(self, element, job_directory):
         parameter_name = element.get('name')
         value_regex = self._expression_to_regex(job_directory, element)
-        return r"%s(?:=|\s+)%s" % (parameter_name, value_regex)
+        return r"{}(?:=|\s+){}".format(parameter_name, value_regex)
 
     def _integer_to_regex(self, element, job_directory):
         return r"\d+"

--- a/pulsar/util/pastescript/loadwsgi.py
+++ b/pulsar/util/pastescript/loadwsgi.py
@@ -11,8 +11,6 @@ from typing import Callable, Dict, List, Optional, Union
 from urllib.parse import unquote
 
 import pkg_resources
-
-from galaxy.util.getargspec import getfullargspec
 from galaxy.util.properties import NicerConfigParser
 
 
@@ -59,7 +57,7 @@ def fix_type_error(exc_info, callable, varargs, kwargs):
             or getattr(exc_info[1], '_type_error_fixed', False)):
         return exc_info
     exc_info[1]._type_error_fixed = True
-    argspec = inspect.formatargspec(*getfullargspec(callable))
+    argspec = inspect.formatargspec(*inspect.getfullargspec(callable))
     args = ', '.join(map(_short_repr, varargs))
     if kwargs and args:
         args += ', '

--- a/pulsar/util/pastescript/serve.py
+++ b/pulsar/util/pastescript/serve.py
@@ -372,7 +372,7 @@ class NotFoundCommand(Command):
             print('(try running python setup.py develop)')
             return 2
         print('Known commands:')
-        longest = max([len(n) for n, c in commands])
+        longest = max(len(n) for n, c in commands)
         for name, command in commands:
             print('  {}  {}'.format(self.pad(name, length=longest),
                                 command.load().summary))

--- a/pulsar/web/framework.py
+++ b/pulsar/web/framework.py
@@ -2,19 +2,18 @@
 Tiny framework used to power Pulsar application, nothing in here is specific to running
 or staging jobs. Mostly deals with routing web traffic and parsing parameters.
 """
+import inspect
+import re
+from os.path import exists
+
 from webob import Request
 from webob import Response
 from webob import exc
 
-import inspect
-from os.path import exists
-import re
-
 from pulsar.client.util import json_dumps
-from six import Iterator
 
 
-class RoutingApp(object):
+class RoutingApp:
     """
     Abstract definition for a python web application.
     """
@@ -52,7 +51,7 @@ class RoutingApp(object):
             regex += re.escape(template[last_pos:match.start()])
             var_name = match.group(1)
             expr = match.group(2) or '[^/]+'
-            expr = '(?P<%s>%s)' % (var_name, expr)
+            expr = '(?P<{}>{})'.format(var_name, expr)
             regex += expr
             last_pos = match.end()
         regex += re.escape(template[last_pos:])
@@ -75,7 +74,7 @@ def build_func_args(func, *arg_dicts):
     return args
 
 
-class Controller(object):
+class Controller:
     """
     Wraps python functions into controller methods.
     """
@@ -174,7 +173,7 @@ def file_response(path):
     return resp
 
 
-class FileIterator(Iterator):
+class FileIterator:
 
     def __init__(self, path):
         self.input = open(path, 'rb')

--- a/pulsar/web/routes.py
+++ b/pulsar/web/routes.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 class PulsarController(Controller):
 
     def __init__(self, **kwargs):
-        super(PulsarController, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _check_access(self, req, environ, start_response):
         if req.app.private_token:
@@ -225,7 +225,7 @@ def object_store_get_store_usage_percent(object_store):
     return object_store.get_store_usage_percent()
 
 
-class PulsarDataset(object):
+class PulsarDataset:
     """Intermediary between Pulsar and objectstore."""
 
     def __init__(self, id):
@@ -238,6 +238,6 @@ def _handle_upload(file_cache, path, body, cache_token=None):
     if cache_token:
         cached_file = file_cache.destination(cache_token)
         source = open(cached_file, 'rb')
-        log.info("Copying cached file %s to %s" % (cached_file, path))
+        log.info("Copying cached file {} to {}".format(cached_file, path))
     copy_to_path(source, path)
     return {"path": path}

--- a/pulsar/web/wsgi.py
+++ b/pulsar/web/wsgi.py
@@ -34,7 +34,7 @@ class PulsarWebApp(RoutingApp):
     """
 
     def __init__(self, pulsar_app):
-        super(PulsarWebApp, self).__init__()
+        super().__init__()
         self.pulsar_app = pulsar_app
         self.__setup_routes()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 webob
 psutil
 PasteDeploy
-six
 pyyaml
 galaxy-job-metrics>=19.9.0.dev1
 galaxy-objectstore>=19.9.0.dev1

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ logging-level=INFO
 max-line-length = 150
 max-complexity = 14
 exclude = pulsar/util/pastescript
+import-order-style = smarkets
+application-import-names = pulsar
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
+import ast
 import os
 import re
-import ast
-import sys
 
 try:
     from distutils.util import get_platform
@@ -25,19 +24,12 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 if os.path.exists("requirements.txt"):
     requirements = [r for r in open("requirements.txt").read().split("\n") if ";" not in r]
-    py27_requirements = [r.split(";", 1)[0].strip() for r in open("requirements.txt").read().split("\n") if ";" in r]
 else:
     # In tox, it will cover them anyway.
     requirements = []
-    py27_requirements = []
 
 if PULSAR_GALAXY_LIB:
     requirements = [r for r in requirements if not r.startswith("galaxy-")]
-
-# TODO: use extra_requires here to be more correct.
-if sys.version_info[0] == 2:
-    requirements.append('PasteScript')
-    requirements.append('paste')
 
 test_requirements = [
     # TODO: put package test requirements here
@@ -116,7 +108,6 @@ setup(
     install_requires=requirements,
     extras_require={
         'web': ['Paste', 'PasteScript'],
-        ':python_version=="2.7"': py27_requirements,
         'galaxy_extended_metadata': ['galaxy-job-execution>=19.9.0.dev0', 'galaxy-util[template]'],
     },
     license="Apache License 2.0",

--- a/test/amqp_test.py
+++ b/test/amqp_test.py
@@ -26,19 +26,19 @@ def test_amqp():
     thread2.start()
     thread3.start()
     time.sleep(0.5)
-    manager1_exchange.publish("manager_test", u"cow1")
-    manager2_exchange.publish("manager2_test", u"cow2")
-    manager3_exchange.publish("manager3_test", u"cow3")
+    manager1_exchange.publish("manager_test", "cow1")
+    manager2_exchange.publish("manager2_test", "cow2")
+    manager3_exchange.publish("manager3_test", "cow3")
     time.sleep(0.1)
-    thread1.wait_for_message(u"cow1")
-    thread2.wait_for_message(u"cow2")
-    thread3.wait_for_message(u"cow3")
+    thread1.wait_for_message("cow1")
+    thread2.wait_for_message("cow2")
+    thread3.wait_for_message("cow3")
 
 
 class TestThread(threading.Thread):
 
     def __init__(self, queue_name, exchange):
-        super(TestThread, self).__init__(target=self.run)
+        super().__init__(target=self.run)
         self.queue_name = queue_name
         self.daemon = True
         self.exchange = exchange
@@ -60,7 +60,7 @@ class TestThread(threading.Thread):
         while self:
             time.sleep(.05)
         if self.message != expected_message:
-            msg = "Expected [%s], got [%s]." % (expected_message, self.message)
+            msg = "Expected [{}], got [{}].".format(expected_message, self.message)
             raise AssertionError(msg)
 
         self.join(2)

--- a/test/client_staging_test.py
+++ b/test/client_staging_test.py
@@ -16,7 +16,7 @@ TEST_ENV_1 = dict(name="x", value="y")
 class TestStager(TempDirectoryTestCase):
 
     def setUp(self):
-        super(TestStager, self).setUp()
+        super().setUp()
         from .test_utils import get_test_tool
         self.tool = get_test_tool()
         self.client = MockClient(self.temp_directory, self.tool)
@@ -145,7 +145,7 @@ class TestStager(TempDirectoryTestCase):
         return submit_job(self.client, self.client_job_description, self.job_config)
 
 
-class MockClient(object):
+class MockClient:
 
     def __init__(self, temp_directory, tool):
         self.temp_directory = temp_directory
@@ -178,7 +178,7 @@ class MockClient(object):
 
     def launch(self, command_line, dependencies_description, job_config={}, remote_staging={}, env=[], dynamic_file_sources=None):
         if self.expected_command_line is not None:
-            message = "Excepected command line %s, got %s" % (self.expected_command_line, command_line)
+            message = "Excepected command line {}, got {}".format(self.expected_command_line, command_line)
             assert self.expected_command_line == command_line, message
         assert dependencies_description.requirements == [TEST_REQUIREMENT_1, TEST_REQUIREMENT_2]
         assert env == [TEST_ENV_1]

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -68,7 +68,9 @@ class TestClient(JobClient):
 class RequestChecker:
     """ Class that tests request objects produced by the Client class.
     """
-    def __init__(self, action, args={}, data=None):
+    def __init__(self, action, args=None, data=None):
+        if args is None:
+            args = {}
         args['job_id'] = "543"
         self.action = action
         self.expected_args = args

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -1,13 +1,11 @@
-from collections import deque
-import tempfile
 import os
-
-from six import text_type, binary_type
+import tempfile
+from collections import deque
 
 from pulsar.client.client import JobClient
+from pulsar.client.decorators import MAX_RETRY_COUNT, retry
 from pulsar.client.manager import HttpPulsarInterface
 from pulsar.client.transport import UrllibTransport
-from pulsar.client.decorators import retry, MAX_RETRY_COUNT
 
 
 def test_with_retry():
@@ -26,7 +24,7 @@ def test_with_retry():
     assert len(i) == MAX_RETRY_COUNT, len(i)
 
 
-class FakeResponse(object):
+class FakeResponse:
     """ Object meant to simulate a Response object as returned by
     urllib.open """
 
@@ -67,7 +65,7 @@ class TestClient(JobClient):
         self.expects.appendleft((checker, response))
 
 
-class RequestChecker(object):
+class RequestChecker:
     """ Class that tests request objects produced by the Client class.
     """
     def __init__(self, action, args={}, data=None):
@@ -82,17 +80,17 @@ class RequestChecker(object):
         assert opened_url.startswith(expected_url_prefix)
         url_suffix = opened_url[len(expected_url_prefix):]
         actual_args = dict([key_val_combo.split("=") for key_val_combo in url_suffix.split("&")])
-        statement = "Expected args %s, obtained %s" % (self.expected_args, actual_args)
+        statement = "Expected args {}, obtained {}".format(self.expected_args, actual_args)
         assert self.expected_args == actual_args, statement
 
     def check_data(self, data):
         if data is None:
             assert self.data is None
-        elif type(data) in (binary_type, text_type):
+        elif type(data) in (bytes, str):
             assert self.data == data
         else:
             data_read = data.read(1024)
-            assert data_read == self.data, "data_read %s is not expected data %s" % (data_read, self.data)
+            assert data_read == self.data, "data_read {} is not expected data {}".format(data_read, self.data)
 
     def __call__(self, request, data=None):
         self.called = True
@@ -178,7 +176,7 @@ def test_download_output():
     client.expect_open(request_checker, b"test output contents")
     client._fetch_output(temp_file.name)
 
-    with open(temp_file.name, "r") as f:
+    with open(temp_file.name) as f:
         contents = f.read(1024)
         assert contents == "test output contents", "Unxpected contents %s" % contents
 

--- a/test/client_transport_test.py
+++ b/test/client_transport_test.py
@@ -26,7 +26,7 @@ def _test_transport(transport):
         open(path, "w").write(" Test123 ")
 
         server_url = server.application_url
-        request_url = u"%s?path=%s" % (server_url, path)
+        request_url = "{}?path={}".format(server_url, path)
 
         # Testing simple get
         response = transport.execute(request_url, data=None)
@@ -37,7 +37,7 @@ def _test_transport(transport):
         output_path = temp_file.name
         temp_file.close()
         response = transport.execute(request_url, data=None, output_path=output_path)
-        assert open(output_path, 'r').read().find("Test123") >= 0
+        assert open(output_path).read().find("Test123") >= 0
 
 
 @skip_unless_module("pycurl")
@@ -45,22 +45,22 @@ def test_curl_put_get():
     with files_server() as (server, directory):
         server_url = server.application_url
         path = os.path.join(directory, "test_for_GET")
-        request_url = u"%s?path=%s" % (server_url, path)
+        request_url = "{}?path={}".format(server_url, path)
 
         input = os.path.join(directory, "input")
         output = os.path.join(directory, "output")
-        open(input, "w").write(u"helloworld")
+        open(input, "w").write("helloworld")
 
         post_file(request_url, input)
         get_file(request_url, output)
-        assert open(output, "r").read() == u"helloworld"
+        assert open(output).read() == "helloworld"
 
 
 def test_curl_status_code():
     with files_server() as (server, directory):
         server_url = server.application_url
         path = os.path.join(directory, "test_for_GET")
-        request_url = u"%s?path=%s" % (server_url, path)
+        request_url = "{}?path={}".format(server_url, path)
         # Verify curl doesn't just silently swallow errors.
         exception_raised = False
         try:
@@ -69,7 +69,7 @@ def test_curl_status_code():
             exception_raised = True
         assert exception_raised
 
-        post_request_url = u"%s?path=%s" % (server_url, "/usr/bin/cow")
+        post_request_url = "{}?path={}".format(server_url, "/usr/bin/cow")
         exception_raised = False
         try:
             post_file(post_request_url, os.path.join(directory, "test"))
@@ -83,7 +83,7 @@ def test_curl_problems():
     with files_server() as (server, directory):
         server_url = server.application_url
         path = os.path.join(directory, "test_for_GET")
-        request_url = u"%s?path=%s" % (server_url, path)
+        request_url = "{}?path={}".format(server_url, path)
         exception_raised = False
         try:
             # Valid destination but the file to post doesn't exist.
@@ -101,7 +101,7 @@ def test_get_transport():
     assert type(get_transport('curl', FakeOsModule("TRUE"))) == PycurlTransport
 
 
-class FakeOsModule(object):
+class FakeOsModule:
 
     def __init__(self, env_val):
         self.env_val = env_val

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -1,24 +1,22 @@
-from __future__ import print_function
-from os.path import join
+import configparser
 from os import environ, makedirs, system
-from six import next, itervalues
-from six.moves import configparser
-from .test_utils import (
-    TempDirectoryTestCase,
-    skip_unless_executable,
-    skip_unless_module,
-    skip_unless_any_module,
-    skip_unless_environ,
-    skip_without_drmaa,
-)
-
-from .test_utils import integration_test
-from .test_utils import test_pulsar_app
-from .test_utils import test_pulsar_server
-from .test_utils import files_server
+from os.path import join
 
 from galaxy.util.bunch import Bunch
+
 from pulsar.client.test.check import run
+from .test_utils import (
+    files_server,
+    integration_test,
+    skip_unless_any_module,
+    skip_unless_environ,
+    skip_unless_executable,
+    skip_unless_module,
+    skip_without_drmaa,
+    TempDirectoryTestCase,
+    test_pulsar_app,
+    test_pulsar_server,
+)
 
 
 class BaseIntegrationTest(TempDirectoryTestCase):
@@ -64,7 +62,7 @@ class BaseIntegrationTest(TempDirectoryTestCase):
 
     def _run_direct(self, app_conf, **kwds):
         with test_pulsar_app({}, app_conf, {}) as app:
-            options = Bunch(job_manager=next(itervalues(app.app.managers)), file_cache=app.app.file_cache, **kwds)
+            options = Bunch(job_manager=next(iter(app.app.managers.values())), file_cache=app.app.file_cache, **kwds)
             self._update_options_for_app(options, app.app, **kwds)
             run(options)
 

--- a/test/integration_test_cli_submit.py
+++ b/test/integration_test_cli_submit.py
@@ -31,7 +31,7 @@ class BaseCliTestCase(TempDirectoryTestCase):
                 output_files=[os.path.join(galaxy_working, output_name)],
             )
             launch_params = dict(
-                command_line="cat '%s' > '%s'" % (pulsar_input, pulsar_output),
+                command_line="cat '{}' > '{}'".format(pulsar_input, pulsar_output),
                 job_id=job_id,
                 setup_params=dict(
                     job_id=job_id,
@@ -50,7 +50,7 @@ class BaseCliTestCase(TempDirectoryTestCase):
             assert not os.path.exists(galaxy_output)
             submit.main(["--base64", base64] + self._encode_application())
             assert os.path.exists(galaxy_output)
-            out_contents = open(galaxy_output, "r").read()
+            out_contents = open(galaxy_output).read()
             assert out_contents == "cow file contents\n", out_contents
 
     @property

--- a/test/integration_test_state.py
+++ b/test/integration_test_state.py
@@ -238,7 +238,7 @@ class StateIntegrationTestCase(TempDirectoryTestCase):
         exchange.publish("status", params)
 
 
-class SimpleConsumer(object):
+class SimpleConsumer:
 
     def __init__(self, queue, url, manager="_default_"):
         self.queue = queue

--- a/test/job_directory_test.py
+++ b/test/job_directory_test.py
@@ -8,7 +8,7 @@ TEST_JOB_ID = "1234"
 class JobDirectoryTestCase(TempDirectoryTestCase):
 
     def setUp(self):
-        super(JobDirectoryTestCase, self).setUp()
+        super().setUp()
         self.job_directory = JobDirectory(self.temp_directory, TEST_JOB_ID)
 
     def test_setup(self):

--- a/test/main_util_test.py
+++ b/test/main_util_test.py
@@ -78,7 +78,7 @@ def test_pulsar_manager_config_builder_overrides():
         assert as_dict["app"] == "cool1"
 
 
-class MockArgs(object):
+class MockArgs:
 
     def __init__(self, ini_path, app):
         self.ini_path = ini_path
@@ -94,8 +94,8 @@ def __write_mock_ini(path, **kwds):
 
 def __mock_ini_contents(app="main", extra=""):
     return """
-[app:%s]
+[app:{}]
 paste.app_factory = pulsar.web.wsgi:app_factory
 foo=bar1
-%s
-""" % (app, extra)
+{}
+""".format(app, extra)

--- a/test/manager_coexecution_test.py
+++ b/test/manager_coexecution_test.py
@@ -8,7 +8,7 @@ from .test_utils import (
 from pulsar.managers.unqueued import CoexecutionManager
 
 
-class Coexecutor(object):
+class Coexecutor:
     """Mimic shell script in other container of coexecutor pod-like environment."""
 
     def __init__(self, manager):
@@ -20,7 +20,7 @@ class Coexecutor(object):
         while not self.has_command_line:
             try:
                 command_line = self.manager.read_command_line("123")
-            except (IOError, ValueError):
+            except (OSError, ValueError):
                 continue
             if not command_line:
                 # might be partially written... need to be make this atomic I think.
@@ -36,11 +36,11 @@ class Coexecutor(object):
 class CoexecutionManagerTest(BaseManagerTestCase):
 
     def setUp(self):
-        super(CoexecutionManagerTest, self).setUp()
+        super().setUp()
         self._set_manager()
 
     def tearDown(self):
-        super(CoexecutionManagerTest, self).setUp()
+        super().setUp()
 
     def _set_manager(self, **kwds):
         self.manager = CoexecutionManager('_default_', self.app, **kwds)

--- a/test/manager_drmaa_test.py
+++ b/test/manager_drmaa_test.py
@@ -9,11 +9,11 @@ from pulsar.managers.queued_drmaa import DrmaaQueueManager
 class DrmaaManagerTest(BaseManagerTestCase):
 
     def setUp(self):
-        super(DrmaaManagerTest, self).setUp()
+        super().setUp()
         self._set_manager()
 
     def tearDown(self):
-        super(DrmaaManagerTest, self).setUp()
+        super().setUp()
         self.manager.shutdown()
 
     def _set_manager(self, **kwds):

--- a/test/manager_queued_test.py
+++ b/test/manager_queued_test.py
@@ -16,11 +16,11 @@ time.sleep(10000)
 class PythonQueuedManagerTest(BaseManagerTestCase):
 
     def setUp(self):
-        super(PythonQueuedManagerTest, self).setUp()
+        super().setUp()
         self._set_manager(num_concurrent_jobs=1)
 
     def tearDown(self):
-        super(PythonQueuedManagerTest, self).setUp()
+        super().setUp()
         self.manager.shutdown()
 
     def _set_manager(self, **kwds):

--- a/test/manager_test.py
+++ b/test/manager_test.py
@@ -8,7 +8,7 @@ from .test_utils import BaseManagerTestCase
 class ManagerTest(BaseManagerTestCase):
 
     def setUp(self):
-        super(ManagerTest, self).setUp()
+        super().setUp()
         self._set_manager()
 
     def _set_manager(self, **kwds):

--- a/test/path_mapper_test.py
+++ b/test/path_mapper_test.py
@@ -66,7 +66,7 @@ class PathMapperTestCase(TempDirectoryTestCase):
         )
 
 
-class TestActionMapper(object):
+class TestActionMapper:
 
     def __init__(self, expected_path, expected_type, staging_needed):
         self.expected_path = expected_path

--- a/test/pulsar_objectstore_test.py
+++ b/test/pulsar_objectstore_test.py
@@ -8,7 +8,7 @@ from .test_utils import TempDirectoryTestCase
 from .test_utils import skip
 
 
-class MockDataset(object):
+class MockDataset:
 
     def __init__(self, id):
         self.id = id

--- a/test/retry_action_test.py
+++ b/test/retry_action_test.py
@@ -29,7 +29,7 @@ def test_third_execution_fine():
     assert not exception_raised
 
 
-class ActionTracker(object):
+class ActionTracker:
 
     def __init__(self, fail_count=0, fail_how=Exception):
         self.fail_count = fail_count

--- a/test/script_run_test.py
+++ b/test/script_run_test.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 from .test_utils import (
     TempDirectoryTestCase,
@@ -10,7 +9,7 @@ from pulsar.scripts import run
 class ScriptRunTestCase(TempDirectoryTestCase):
 
     def setUp(self):
-        super(ScriptRunTestCase, self).setUp()
+        super().setUp()
         input1 = os.path.join(self._working_directory, "input1")
         open(input1, "w").write("Hello World!")
         self.input1 = input1
@@ -36,7 +35,7 @@ class ScriptRunTestCase(TempDirectoryTestCase):
         ])
         exit_code = run.main(run_args)
         if os.path.exists(self._result):
-            print(open(self._result, "r").read())
+            print(open(self._result).read())
         else:
             assert False, "No result json file found"
         assert exit_code == 0
@@ -45,8 +44,8 @@ class ScriptRunTestCase(TempDirectoryTestCase):
         output1 = os.path.join(self._working_directory, "output1")
         output_test2 = os.path.join(self._working_directory, "output_test2")
         # Prove it went somewhere else :)
-        assert open(output1, "r").read() != self._working_directory
-        assert open(output_test2, "r").read() == "Hello World!"
+        assert open(output1).read() != self._working_directory
+        assert open(output_test2).read() == "Hello World!"
 
     @property
     def _result(self):

--- a/test/scripts_config_test.py
+++ b/test/scripts_config_test.py
@@ -1,19 +1,18 @@
 import collections
+import configparser
 import os
 import subprocess
-import yaml
 import sys
+from io import StringIO
 
-from six.moves import configparser
-from six import StringIO
+import yaml
 
-from pulsar.scripts.config import main
+
 from pulsar.scripts import config
-
-
+from pulsar.scripts.config import main
 from .test_utils import (
-    temp_directory,
     skip_unless_environ,
+    temp_directory,
 )
 
 
@@ -120,7 +119,7 @@ def _check_project_directory(project_dir):
     app_config = None
     app_config_path = path_if_exists("app.yml")
     if app_config_path:
-        app_config = yaml.load(open(app_config_path, "r"))
+        app_config = yaml.load(open(app_config_path))
         assert isinstance(app_config, dict) or (app_config is None)
 
     ini_config = None
@@ -135,7 +134,7 @@ def _check_project_directory(project_dir):
 Project = collections.namedtuple('Project', ['ini_config', 'app_config'])
 
 
-class MockPip(object):
+class MockPip:
 
     def __init__(self):
         self.main_calls = []

--- a/test/scripts_config_test.py
+++ b/test/scripts_config_test.py
@@ -119,7 +119,7 @@ def _check_project_directory(project_dir):
     app_config = None
     app_config_path = path_if_exists("app.yml")
     if app_config_path:
-        app_config = yaml.load(open(app_config_path))
+        app_config = yaml.safe_load(open(app_config_path))
         assert isinstance(app_config, dict) or (app_config is None)
 
     ini_config = None

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,4 @@
 """Utilities allowing for high-level testing throughout Pulsar."""
-from __future__ import print_function
 
 import traceback
 import sys
@@ -83,7 +82,7 @@ def get_test_tool():
     return get_test_toolbox().get_tool("tool1")
 
 
-class TestManager(object):
+class TestManager:
 
     def setup_temp_directory(self):
         self.temp_directory = temp_directory_persist(prefix='test_manager_')
@@ -123,7 +122,7 @@ def test_manager():
     manager.cleanup_temp_directory()
 
 
-class TestAuthorization(object):
+class TestAuthorization:
 
     def __init__(self):
         self.allow_setup = True
@@ -148,7 +147,7 @@ class TestAuthorization(object):
             raise Exception
 
 
-class TestDependencyManager(object):
+class TestDependencyManager:
 
     def dependency_shell_commands(self, requirements, **kwds):
         return []
@@ -221,7 +220,7 @@ def minimal_app_for_managers():
                  object_store=object())
 
 
-class NullJobMetrics(object):
+class NullJobMetrics:
 
     def __init__(self):
         self.default_job_instrumenter = NULL_JOB_INSTRUMENTER
@@ -262,7 +261,7 @@ def test_pulsar_server(global_conf={}, app_conf={}, test_conf={}):
             yield test_pulsar_server
 
 
-class RestartablePulsarAppProvider(object):
+class RestartablePulsarAppProvider:
 
     def __init__(self, global_conf={}, app_conf={}, test_conf={}, web=True):
         self.staging_directory = temp_directory_persist(prefix='staging_')
@@ -427,7 +426,7 @@ def _which(program):
     return None
 
 
-class TestAuthorizer(object):
+class TestAuthorizer:
 
     def __init__(self):
         self.authorization = TestAuthorization()
@@ -436,7 +435,7 @@ class TestAuthorizer(object):
         return self.authorization
 
 
-class JobFilesApp(object):
+class JobFilesApp:
 
     def __init__(self, root_directory=None, allow_multiple_downloads=False):
         self.root_directory = root_directory
@@ -458,7 +457,7 @@ class JobFilesApp(object):
     def _post(self, request, params):
         path = params['path']
         if not galaxy.util.in_directory(path, self.root_directory):
-            assert False, "%s not in %s" % (path, self.root_directory)
+            assert False, "{} not in {}".format(path, self.root_directory)
         parent_directory = dirname(path)
         if not exists(parent_directory):
             makedirs(parent_directory)
@@ -470,7 +469,7 @@ class JobFilesApp(object):
         if path in self.served_files and not self.allow_multiple_downloads:  # emulate Galaxy not allowing the same request twice...
             raise Exception("Same file copied multiple times...")
         if not galaxy.util.in_directory(path, self.root_directory):
-            assert False, "%s not in %s" % (path, self.root_directory)
+            assert False, "{} not in {}".format(path, self.root_directory)
         self.served_files.append(path)
         return file_response(path)
 
@@ -502,7 +501,7 @@ def dump_other_threads():
 
 # Extracted from: https://github.com/python/cpython/blob/
 # 937ee9e745d7ff3c2010b927903c0e2a83623324/Lib/test/support/__init__.py
-class EnvironmentVarGuard(object):
+class EnvironmentVarGuard:
 
     """Class to help protect the environment variable properly.  Can be used as
     a context manager."""

--- a/test/validator_test.py
+++ b/test/validator_test.py
@@ -1,9 +1,8 @@
-from .test_utils import TempDirectoryTestCase
+from os.path import join
 
 from pulsar.managers.base import JobDirectory
 from pulsar.tools.validator import ExpressionValidator
-
-from os.path import join
+from .test_utils import TempDirectoryTestCase
 
 
 class ValidatorTest(TempDirectoryTestCase):
@@ -104,11 +103,15 @@ class ValidatorTest(TempDirectoryTestCase):
             <input />
         </command_validator>
         """
-        self.__assertValid(xml, "tophat2 %s %s" % (self.__job_file("inputs", "dataset_23412.dat"),
-                                                   self.__job_file("inputs", "dataset_1.dat")))
+        self.__assertValid(xml, "tophat2 {} {}".format(
+            self.__job_file("inputs", "dataset_23412.dat"),
+            self.__job_file("inputs", "dataset_1.dat")
+        ))
 
-        self.__assertInvalid(xml, "tophat2 %s ../%s" % (self.__job_file("inputs", "dataset_23412.dat"),
-                                                        self.__job_file("inputs", "dataset_1.dat")))
+        self.__assertInvalid(xml, "tophat2 {} ../{}".format(
+            self.__job_file("inputs", "dataset_23412.dat"),
+            self.__job_file("inputs", "dataset_1.dat")
+        ))
 
     def test_outputs_file(self):
         xml = """
@@ -118,11 +121,15 @@ class ValidatorTest(TempDirectoryTestCase):
             <output />
         </command_validator>
         """
-        self.__assertValid(xml, "tophat2 %s %s" % (self.__job_file("outputs", "dataset_23412.dat"),
-                                                   self.__job_file("outputs", "dataset_1.dat")))
+        self.__assertValid(xml, "tophat2 {} {}".format(
+            self.__job_file("outputs", "dataset_23412.dat"),
+            self.__job_file("outputs", "dataset_1.dat")
+        ))
 
-        self.__assertInvalid(xml, "tophat2 %s ../%s" % (self.__job_file("outputs", "dataset_23412.dat"),
-                                                        self.__job_file("outputs", "dataset_1.dat")))
+        self.__assertInvalid(xml, "tophat2 {} ../{}".format(
+            self.__job_file("outputs", "dataset_23412.dat"),
+            self.__job_file("outputs", "dataset_1.dat")
+        ))
 
     def test_outputs_from_work_dir(self):
         xml = """
@@ -132,11 +139,15 @@ class ValidatorTest(TempDirectoryTestCase):
             <output from_work_dir="junctions.bed" />
         </command_validator>
         """
-        self.__assertValid(xml, "tophat2 %s %s" % (self.__job_file("outputs", "dataset_23412.dat"),
-                                                   self.__job_file("working", "junctions.bed")))
+        self.__assertValid(xml, "tophat2 {} {}".format(
+            self.__job_file("outputs", "dataset_23412.dat"),
+            self.__job_file("working", "junctions.bed")
+        ))
 
-        self.__assertInvalid(xml, "tophat2 %s ../%s" % (self.__job_file("outputs", "dataset_23412.dat"),
-                                                        self.__job_file("working", "..", "junctions.bed")))
+        self.__assertInvalid(xml, "tophat2 {} ../{}".format(
+            self.__job_file("outputs", "dataset_23412.dat"),
+            self.__job_file("working", "..", "junctions.bed")
+        ))
 
     def test_single_quotes(self):
         xml = """
@@ -230,7 +241,7 @@ class ValidatorTest(TempDirectoryTestCase):
         return self.__validator(xml).validate(self.job_directory, contents)
 
     def __assertValid(self, xml, contents):
-        self.assertTrue(self.__is_valid(xml, contents), "%s did not validate against %s" % (contents, xml))
+        self.assertTrue(self.__is_valid(xml, contents), "{} did not validate against {}".format(contents, xml))
 
     def __assertInvalid(self, xml, contents):
-        self.assertFalse(self.__is_valid(xml, contents), "%s falsely validated against %s" % (contents, xml))
+        self.assertFalse(self.__is_valid(xml, contents), "{} falsely validated against {}".format(contents, xml))

--- a/test/wsgi_app_test.py
+++ b/test/wsgi_app_test.py
@@ -43,7 +43,7 @@ def test_standard_requests():
 
         try:
             app.get("/jobs/%s/files?name=test_output2&type=output" % job_id)
-            assert False  # Should throw exception
+            raise AssertionError()  # Should throw exception
         except Exception:
             pass
 

--- a/test/wsgi_app_test.py
+++ b/test/wsgi_app_test.py
@@ -1,8 +1,7 @@
-import os
 import json
+import os
 import time
-
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 
 
 def test_standard_requests():
@@ -22,11 +21,11 @@ def test_standard_requests():
         job_id = setup_config["job_id"]
 
         def test_upload(upload_type):
-            url = "/jobs/%s/files?name=input1&type=%s" % (job_id, upload_type)
+            url = "/jobs/{}/files?name=input1&type={}".format(job_id, upload_type)
             upload_input_response = app.post(url, "Test Contents")
             upload_input_config = json.loads(upload_input_response.body.decode("utf-8"))
             staged_input_path = upload_input_config["path"]
-            staged_input = open(staged_input_path, "r")
+            staged_input = open(staged_input_path)
             try:
                 assert staged_input.read() == "Test Contents"
             finally:
@@ -49,7 +48,7 @@ def test_standard_requests():
             pass
 
         command_line = quote("""python -c "import sys; sys.stdout.write('test_out')" """)
-        launch_response = app.post("/jobs/%s/submit?command_line=%s" % (job_id, command_line))
+        launch_response = app.post("/jobs/{}/submit?command_line={}".format(job_id, command_line))
         assert launch_response.body.decode("utf-8") == 'OK'
 
         # Hack: Call twice to ensure postprocessing occurs and has time to

--- a/tools/bootstrap_history.py
+++ b/tools/bootstrap_history.py
@@ -19,14 +19,14 @@ import pulsar as project
 
 PROJECT_OWNER = project.PROJECT_OWNER
 PROJECT_NAME = project.PROJECT_NAME
-PROJECT_URL = "https://github.com/%s/%s" % (PROJECT_OWNER, PROJECT_NAME)
-PROJECT_API = "https://api.github.com/repos/%s/%s/" % (PROJECT_OWNER, PROJECT_NAME)
+PROJECT_URL = "https://github.com/{}/{}".format(PROJECT_OWNER, PROJECT_NAME)
+PROJECT_API = "https://api.github.com/repos/{}/{}/".format(PROJECT_OWNER, PROJECT_NAME)
 AUTHORS_SKIP_CREDIT = ["jmchilton"]
 
 
 def main(argv):
     history_path = os.path.join(PROJECT_DIRECTORY, "HISTORY.rst")
-    history = open(history_path, "r", encoding="utf-8").read()
+    history = open(history_path, encoding="utf-8").read()
 
     def extend(from_str, line):
         from_str += "\n"
@@ -66,17 +66,17 @@ def main(argv):
         pull_request = ident[len("pr"):]
         text = ".. _Pull Request {0}: {1}/pull/{0}".format(pull_request, PROJECT_URL)
         history = extend(".. github_links", text)
-        to_doc += "`Pull Request {0}`_".format(pull_request)
+        to_doc += "`Pull Request {}`_".format(pull_request)
     elif ident.startswith("issue"):
         issue = ident[len("issue"):]
         text = ".. _Issue {0}: {1}/issues/{0}".format(issue, PROJECT_URL)
         history = extend(".. github_links", text)
-        to_doc += "`Issue {0}`_".format(issue)
+        to_doc += "`Issue {}`_".format(issue)
     else:
         short_rev = ident[:7]
         text = ".. _{0}: {1}/commit/{0}".format(short_rev, PROJECT_URL)
         history = extend(".. github_links", text)
-        to_doc += "{0}_".format(short_rev)
+        to_doc += "{}_".format(short_rev)
 
     to_doc = wrap(to_doc)
     history = extend(".. to_doc", to_doc)

--- a/tools/commit_version.py
+++ b/tools/commit_version.py
@@ -17,7 +17,7 @@ def main(argv):
     mod_path = os.path.join(PROJECT_DIRECTORY, source_dir, "__init__.py")
     if not DEV_RELEASE:
         history_path = os.path.join(PROJECT_DIRECTORY, "HISTORY.rst")
-        history = open(history_path, "r").read()
+        history = open(history_path).read()
         today = datetime.datetime.today()
         today_str = today.strftime('%Y-%m-%d')
         history = re.sub(r"^[\d\.]+\.dev\d*",
@@ -26,7 +26,7 @@ def main(argv):
                          flags=re.MULTILINE)
         open(history_path, "w").write(history)
 
-        mod = open(mod_path, "r").read()
+        mod = open(mod_path).read()
         mod = re.sub(r"__version__ = '[\d\.]+\.dev\d*'",
                      "__version__ = '{}'".format(version),
                      mod,

--- a/tools/new_version.py
+++ b/tools/new_version.py
@@ -29,11 +29,11 @@ def main(argv):
 
     history_path = os.path.join(PROJECT_DIRECTORY, "HISTORY.rst")
     if not DEV_RELEASE:
-        history = open(history_path, "r").read()
+        history = open(history_path).read()
 
         def extend(from_str, line):
             from_str += "\n"
-            return history.replace(from_str, from_str + line + "\n" )
+            return history.replace(from_str, from_str + line + "\n")
 
         history = extend(".. to_doc", """
 ---------------------
@@ -44,15 +44,21 @@ def main(argv):
         open(history_path, "w").write(history)
 
     mod_path = os.path.join(PROJECT_DIRECTORY, source_dir, "__init__.py")
-    mod = open(mod_path, "r").read()
+    mod = open(mod_path).read()
     if not DEV_RELEASE:
-        mod = re.sub("__version__ = '[\d\.]+'",
-                    "__version__ = '%s.dev0'" % new_version,
-                    mod, 1)
+        mod = re.sub(
+            r"__version__ = '[\d\.]+'",
+            "__version__ = '%s.dev0'" % new_version,
+            mod,
+            1
+        )
     else:
-        mod = re.sub("dev%s" % dev_version,
-                    "dev%s" % new_dev_version,
-                    mod, 1)
+        mod = re.sub(
+            "dev%s" % dev_version,
+            "dev%s" % new_dev_version,
+            mod,
+            1
+        )
     mod = open(mod_path, "w").write(mod)
     shell(["git", "commit", "-m", "Starting work on %s" % new_version,
            "HISTORY.rst", "%s/__init__.py" % source_dir])

--- a/tools/print_version_for_release.py
+++ b/tools/print_version_for_release.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from distutils.version import LooseVersion
 import ast
 import os

--- a/tools/replace_galaxy_requirements_for_ci.py
+++ b/tools/replace_galaxy_requirements_for_ci.py
@@ -16,7 +16,7 @@ print(f"Replacing Galaxy pulsar-galaxy-lib requirements in {GALAXY_DIR} with {li
 
 for req in ["lib/galaxy/dependencies/pinned-requirements.txt", "lib/galaxy/dependencies/dev-requirements.txt"]:
     req_abs_path = os.path.join(GALAXY_DIR, req)
-    with open(req_abs_path, "r") as f:
+    with open(req_abs_path) as f:
         lines = f.read()
     new_lines = []
     for line in lines.splitlines():


### PR DESCRIPTION
Using `ack --type=python -f | xargs pyupgrade --py3-plus`

Also:
- Remove dependency on `six`
- Fix some issues reported by flake8-bugbear
- Import `getfullargspec` directly from `inspect`