### PR TITLE
Test and mypy fixes. Add support for 3.11

### DIFF
--- a/.github/workflows/pulsar.yaml
+++ b/.github/workflows/pulsar.yaml
@@ -61,9 +61,9 @@ jobs:
           python: 3.9
         - tox-env: py39-test-unit
           python: 3.9
-        - tox-env: py39-install-wheel-no-conda
+        - tox-env: py39-install_wheel-no_conda
           python: 3.9
-        - tox-env: py37-install-wheel
+        - tox-env: py37-install_wheel
           python: 3.7
     services:
       job-files:
@@ -94,7 +94,7 @@ jobs:
   ## connect to the host running the Pulsar server for file transfers in stage out/in.
   # tes-test:
   #   name: Run Tests
-  # runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-20.04
   #   strategy:
   #     matrix:
   #       include:

--- a/.github/workflows/pulsar.yaml
+++ b/.github/workflows/pulsar.yaml
@@ -24,10 +24,8 @@ jobs:
         include:
         - tox-env: py36-mypy
           python: 3.6
-        - tox-env: py37-mypy
-          python: 3.7
-        - tox-env: py38-mypy
-          python: 3.8
+        - tox-env: py311-mypy
+          python: 3.11
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v3
@@ -36,7 +34,7 @@ jobs:
     - name: Install tox
       run: pip install tox
     - name: Setup pycurl
-      run: sudo apt update; sudo apt install -y libxml2-dev libxslt1-dev libcurl4-openssl-dev python-pycurl openssh-server
+      run: sudo apt update; sudo apt install -y libxml2-dev libxslt1-dev libcurl4-openssl-dev openssh-server
     - name: Run tox
       run: tox -e ${{ matrix.tox-env }}
   test:
@@ -49,18 +47,10 @@ jobs:
           python: 3.6
         - tox-env: py36-test-unit
           python: 3.6
-        - tox-env: py37-test-ci
-          python: 3.7
-        - tox-env: py37-test-unit
-          python: 3.7
-        - tox-env: py38-test-ci
-          python: 3.8
-        - tox-env: py38-test-unit
-          python: 3.8
-        - tox-env: py39-test-ci
-          python: 3.9
-        - tox-env: py39-test-unit
-          python: 3.9
+        - tox-env: py311-test-ci
+          python: 3.11
+        - tox-env: py311-test-unit
+          python: 3.11
         - tox-env: py39-install_wheel-no_conda
           python: 3.9
         - tox-env: py37-install_wheel

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,7 @@
+[mypy]
+show_error_codes = True
+pretty = True
+
 [mypy-galaxy.*]
 ignore_missing_imports = True
 

--- a/pulsar/client/manager.py
+++ b/pulsar/client/manager.py
@@ -52,6 +52,7 @@ class ClientManagerInterface(Protocol):
 
     def shutdown(self, ensure_cleanup=False) -> None:
         """Mark client manager's work as complete and clean up resources it managed."""
+        return
 
 
 class ClientManager(ClientManagerInterface):
@@ -103,10 +104,6 @@ class ClientManager(ClientManagerInterface):
         job_manager_interface_args = dict(destination_params=destination_params, **self.job_manager_interface_args)
         job_manager_interface = job_manager_interface_class(**job_manager_interface_args)
         return self.client_class(destination_params, job_id, job_manager_interface, **self.extra_client_kwds)
-
-    def shutdown(self, ensure_cleanup=False):
-        """Mark client manager's work as complete and clean up resources it managed."""
-        pass
 
 
 try:
@@ -336,7 +333,7 @@ class ClientCacher:
     def __init_transfer_threads(self, num_transfer_threads):
         self.num_transfer_threads = num_transfer_threads
         self.transfer_queue = Queue()
-        for i in range(num_transfer_threads):
+        for _ in range(num_transfer_threads):
             t = threading.Thread(target=self._transfer_worker)
             t.daemon = True
             t.start()

--- a/pulsar/web/framework.py
+++ b/pulsar/web/framework.py
@@ -69,7 +69,7 @@ def build_func_args(func, *arg_dicts):
             if func_arg not in args and func_arg in arg_values:
                 args[func_arg] = arg_values[func_arg]
 
-    func_args = inspect.getargspec(func).args
+    func_args = inspect.getfullargspec(func).args
     for arg_dict in arg_dicts:
         add_args(func_args, arg_dict)
 
@@ -108,7 +108,7 @@ class Controller:
 
     def __build_args(self, func, args, req, environ):
         args = build_func_args(func, args, req.GET, self._app_args(args, req))
-        func_args = inspect.getargspec(func).args
+        func_args = inspect.getfullargspec(func).args
 
         for func_arg in func_args:
             if func_arg == "ip":

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ webob
 psutil
 PasteDeploy
 pyyaml
-galaxy-job-metrics
-galaxy-objectstore
-galaxy-tool-util
+galaxy-job-metrics>=19.9.0
+galaxy-objectstore>=19.9.0
+galaxy-tool-util>=19.9.0
 galaxy-util>=22.1.2
 paramiko
 typing-extensions

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,6 @@ else:
 if PULSAR_GALAXY_LIB:
     requirements = [r for r in requirements if not r.startswith("galaxy-")]
 
-test_requirements = [
-    # TODO: put package test requirements here
-]
-
 
 _version_re = re.compile(r'__version__\s+=\s+(.*)')
 
@@ -128,7 +124,6 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
-    test_suite='test',
-    tests_require=test_requirements
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-lint, py{36,37,38,39}-docs, py{36,37,38,39}-dist, py{36,37,38,39}-test-unit, py{36,37,38,39}-test, py{36,37,38,39}-install-wheel, py{36,37,38,39}-install-wheel-no-conda
+envlist = py{36,37,38,39}-lint, py{36,37,38,39}-docs, py{36,37,38,39}-dist, py{36,37,38,39}-test-unit, py{36,37,38,39}-test, py{36,37,38,39}-install_wheel, py{36,37,38,39}-install_wheel-no_conda
 toxworkdir={env:TOX_WORK_DIR:.tox}
 source_dir = pulsar
 test_dir = test
@@ -11,18 +11,18 @@ commands =
     lint: flake8 --ignore W504 {[tox]source_dir} {[tox]test_dir}
     dist: make lint-dist
     docs: make lint-docs
-    install-wheel: make test-install-wheel
-    install-wheel-no-conda: make test-install-wheel-no-conda
+    install_wheel-!no_conda: make test-install-wheel
+    install_wheel-no_conda: make test-install-wheel-no-conda
     mypy: mypy {[tox]source_dir} {[tox]test_dir}
 
 deps =
     test,docs,mypy: -rrequirements.txt
-    test,test-install-wheel,test-install-wheel-no-conda,mypy: -rdev-requirements.txt
+    test,install_wheel,mypy: -rdev-requirements.txt
     test: drmaa
     lint: flake8
     docs: sphinx==1.2
     dist: twine
-    install-wheel,install-wheel-no-conda: virtualenv
+    install_wheel: virtualenv
 
 setenv =
     # tests ready to go after setup_tests.sh
@@ -40,10 +40,10 @@ passenv =
     DRMAA_LIBRARY_PATH
 
 skip_install =
-    lint,dist,install-wheel,install-wheel-no-conda: True
+    lint,dist,install_wheel: True
 
 skipsdist = 
     docs: True
 
 allowlist_externals =
-    docs,dist,install-wheel,install-wheel-no-conda: make
+    docs,dist,install_wheel: make

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-lint, py{36,37,38,39}-docs, py{36,37,38,39}-dist, py{36,37,38,39}-test-unit, py{36,37,38,39}-test, py{36,37,38,39}-install_wheel, py{36,37,38,39}-install_wheel-no_conda
+envlist = lint, docs, dist, test-unit, test, install_wheel, install_wheel-no_conda
 toxworkdir={env:TOX_WORK_DIR:.tox}
 source_dir = pulsar
 test_dir = test


### PR DESCRIPTION
Planemo tests still fail on the py37-install_wheel build, but I don't know enough about those to fix it.

I think these are still good fixes and could probably be merged nonetheless?