### PR TITLE
If `manager` is specified in the app conf and --manager is supplied, make the single manager have the supplied name

### DIFF
--- a/pulsar/main.py
+++ b/pulsar/main.py
@@ -334,6 +334,16 @@ class PulsarManagerConfigBuilder(PulsarConfigBuilder):
         PulsarConfigBuilder.populate_options(arg_parser)
         arg_parser.add_argument("--manager", default=DEFAULT_MANAGER)
 
+    def load(self):
+        app_conf = super().load()
+        if self.manager != DEFAULT_MANAGER and "manager" in app_conf and "name" not in app_conf["manager"]:
+            log.info(
+                "Default manager not in app conf is not named but `--manager` is supplied, applying supplied manager "
+                f"name '{self.manager}' to default manager"
+            )
+            app_conf["manager"]["name"] = self.manager
+        return app_conf
+
 
 def main(argv=None, config_env=False):
     mod_docstring = sys.modules[__name__].__doc__

--- a/pulsar/manager_factory.py
+++ b/pulsar/manager_factory.py
@@ -32,7 +32,8 @@ def build_managers(app, conf):
             manager_description = ManagerDescription.from_dict(manager_options, manager_name)
             manager_descriptions.add(manager_description)
     elif "manager" in conf:
-        manager_description = ManagerDescription.from_dict(conf["manager"])
+        manager_name = conf["manager"].pop("name", DEFAULT_MANAGER_NAME)
+        manager_description = ManagerDescription.from_dict(conf["manager"], manager_name=manager_name)
         manager_descriptions.add(manager_description)
     else:
         manager_descriptions.add(ManagerDescription())


### PR DESCRIPTION
Potentially fixes #313 but I haven't actually fully tested it, just verified that it resolves the exception. And it's not my favorite. @jmchilton?