### PR TITLE
Allow recovery from rabbitmq restart

### DIFF
--- a/app.yml.sample
+++ b/app.yml.sample
@@ -89,6 +89,10 @@
 ## kombu.Connection's drain_events() method.
 #amqp_consumer_timeout: 0.2
 
+## publishing messages to the queue may hang if the connection becomes invalid.
+## this value is used as the timeout argument to the producer.publish function.
+#amqp_publish_timeout: 2.0
+
 # AMQP does not guarantee that a published message is received by the AMQP
 # server, so Pulsar can request that the consumer acknowledge messages and will
 # resend them if acknowledgement is not received after a configurable timeout

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # Optional requirements used by test cases
 pycurl
-kombu>=5.2.3
+kombu
 pykube
 boto3
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # Optional requirements used by test cases
 pycurl
-kombu
+kombu>=5.2.3
 pykube
 boto3
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,6 +35,9 @@ ignore_missing_imports = True
 [mypy-kombu.*]
 ignore_missing_imports = True
 
+[mypy-amqp.*]
+ignore_missing_imports = True
+
 [mypy-requests_toolbelt.*]
 ignore_missing_imports = True
 

--- a/pulsar/client/amqp_exchange.py
+++ b/pulsar/client/amqp_exchange.py
@@ -9,6 +9,7 @@ from time import (
 )
 from typing import Optional
 
+from packaging.version import parse as parse_version
 try:
     import kombu
     import kombu.exceptions
@@ -46,6 +47,7 @@ ACK_UUID_RESPONSE_KEY = 'acknowledge_uuid_response'
 ACK_FORCE_NOACK_KEY = 'force_noack'
 DEFAULT_ACK_MANAGER_SLEEP = 15
 DEFAULT_REPUBLISH_TIME = 30
+MINIMUM_KOMBU_VERSION_PUBLISH_TIMEOUT = parse_version("5.2.0")
 
 
 class PulsarExchange:
@@ -87,6 +89,7 @@ class PulsarExchange:
             amqp.exceptions.RecoverableChannelError,  # publish time out
             kombu.exceptions.OperationalError,  # ConnectionRefusedError, e.g. when getting a new connection while rabbitmq is down
         )
+        self.__kombu_version = parse_version(kombu.__version__)
         self.__url = url
         self.__manager_name = manager_name
         self.__amqp_key_prefix = amqp_key_prefix
@@ -291,6 +294,9 @@ class PulsarExchange:
             publish_kwds["retry_policy"]["errback"] = errback
         else:
             publish_kwds = self.__publish_kwds
+        if self.__kombu_version < MINIMUM_KOMBU_VERSION_PUBLISH_TIMEOUT:
+            log.warning(f"kombu version {kombu.__version__} does not support timeout argument to publish. Consider updating to 5.2.0 or newer")
+            publish_kwds.pop("timeout", None)
         return publish_kwds
 
     def __publish_log_prefex(self, transaction_uuid=None):

--- a/pulsar/client/amqp_exchange.py
+++ b/pulsar/client/amqp_exchange.py
@@ -10,6 +10,7 @@ from time import (
 
 try:
     import kombu
+    import kombu.exceptions
     from kombu import pools
 except ImportError:
     kombu = None
@@ -128,7 +129,11 @@ class PulsarExchange:
                                 connection.drain_events(timeout=self.__timeout)
                             except socket.timeout:
                                 pass
-            except (OSError, amqp.exceptions.ConnectionForced, amqp.exceptions.RecoverableChannelError, amqp.exceptions.RecoverableConnectionError) as exc:
+            except (
+                OSError,
+                amqp.exceptions.ConnectionForced,
+                kombu.exceptions.OperationalError,
+            ) as exc:
                 self.__handle_io_error(exc, heartbeat_thread)
             except BaseException:
                 log.exception("Problem consuming queue, consumer quitting in problematic fashion!")

--- a/pulsar/client/amqp_exchange_factory.py
+++ b/pulsar/client/amqp_exchange_factory.py
@@ -11,7 +11,7 @@ def get_exchange(url, manager_name, params):
         manager_name=manager_name,
         amqp_key_prefix=params.get("amqp_key_prefix"),
         connect_ssl=connect_ssl,
-        publish_kwds=parse_amqp_publish_kwds(params)
+        publish_kwds=parse_amqp_publish_kwds(params),
     )
     if params.get('amqp_acknowledge', False):
         exchange_kwds.update(parse_ack_kwds(params, manager_name))

--- a/pulsar/messaging/bind_amqp.py
+++ b/pulsar/messaging/bind_amqp.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 TYPED_PARAMS = {
     "amqp_consumer_timeout": lambda val: None if str(val) == "None" else float(val),
+    "amqp_publish_timeout": lambda val: None if str(val) == "None" else float(val),
     "amqp_publish_retry": asbool,
     "amqp_publish_retry_max_retries": int,
     "amqp_publish_retry_interval_start": int,

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'amqp': ['kombu>=5.2.3'],
+        'amqp': ['kombu'],
         'web': ['Paste', 'PasteScript'],
         'galaxy_extended_metadata': ['galaxy-job-execution', 'galaxy-util[template]'],
     },

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
+        'amqp': ['kombu>=5.2.3'],
         'web': ['Paste', 'PasteScript'],
         'galaxy_extended_metadata': ['galaxy-job-execution', 'galaxy-util[template]'],
     },


### PR DESCRIPTION
`ConnectionForced` seems very deliberate and may not fix all of https://github.com/galaxyproject/pulsar/issues/316, but a controlled restart of a rabbitmq server results in:

```
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]: Exception in thread consume-kill-pyamqp://pulsar_au:********@gat-4.eu.galaxy.training:5671//pulsar/pulsar_au?ssl=1:
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]: Traceback (most recent call last):
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     self.run()
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/usr/lib/python3.10/threading.py", line 953, in run
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     self._target(*self._args, **self._kwargs)
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/pulsar/messaging/bind_amqp.py", line 52, in drain
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     __drain(name, queue_state, pulsar_exchange, callback)
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/pulsar/messaging/bind_amqp.py", line 100, in __drain
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     pulsar_exchange.consume(name, callback=callback, check=queue_state)
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/pulsar/client/amqp_exchange.py", line 119, in consume
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     connection.drain_events(timeout=self.__timeout)
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/kombu/connection.py", line 318, in drain_events
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     return self.transport.drain_events(self.connection, **kwargs)
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/kombu/transport/pyamqp.py", line 101, in drain_events
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     return connection.drain_events(**kwargs)
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/amqp/connection.py", line 522, in drain_events
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     while not self.blocking_read(timeout):
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/amqp/connection.py", line 528, in blocking_read
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     return self.on_inbound_frame(frame)
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/amqp/method_framing.py", line 53, in on_frame
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     callback(channel, method_sig, buf, None)
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/amqp/connection.py", line 534, in on_inbound_method
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     return self.channels[channel_id].dispatch_method(
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/amqp/abstract_channel.py", line 143, in dispatch_method
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     listener(*args)
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:   File "/mnt/pulsar/venv/lib/python3.10/site-packages/amqp/connection.py", line 664, in _on_close
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]:     raise error_for_code(reply_code, reply_text,
Apr 20 09:20:12 gat-24.oz.galaxy.training pulsar[71616]: amqp.exceptions.ConnectionForced: (0, 0): (320) CONNECTION_FORCED - broker forced connection closure with reason 'shutdown'
```
and this fixes that.