### PR TITLE
Catch drain timeout without verbose log message

### DIFF
--- a/pulsar/client/amqp_exchange.py
+++ b/pulsar/client/amqp_exchange.py
@@ -137,7 +137,10 @@ class PulsarExchange:
                     with kombu.Consumer(connection, queues=[queue], callbacks=callbacks, accept=['json']):
                         heartbeat_thread = self.__start_heartbeat(queue_name, connection)
                         while check and connection.connected:
-                            connection.drain_events(timeout=self.__timeout)
+                            try:
+                                connection.drain_events(timeout=self.__timeout)
+                            except socket.timeout:
+                                pass
             except self.recoverable_exceptions as exc:
                 self.__handle_io_error(exc, heartbeat_thread)
             except BaseException:


### PR DESCRIPTION
Avoids verbose log messages like
```
2023-04-28 16:07:36,784 WARNI [pulsar.client.amqp_exchange][consume-setup-amqp://guest:********@localhost:5672] Got TimeoutError, will retry: timed out
2023-04-28 16:07:36,784 WARNI [pulsar.client.amqp_exchange][consume-status-amqp://guest:********@localhost:5672] Got TimeoutError, will retry: timed out
2023-04-28 16:07:36,784 WARNI [pulsar.client.amqp_exchange][consume-kill-amqp://guest:********@localhost:5672] Got TimeoutError, will retry: timed out
2023-04-28 16:07:37,578 DEBUG [pulsar.client.amqp_exchange][consume-heartbeat-pulsar__status] AMQP heartbeat thread exiting
2023-04-28 16:07:37,579 DEBUG [pulsar.client.amqp_exchange][consume-heartbeat-pulsar__kill] AMQP heartbeat thread exiting
2023-04-28 16:07:37,579 DEBUG [pulsar.client.amqp_exchange][consume-heartbeat-pulsar__setup] AMQP heartbeat thread exiting
2023-04-28 16:07:38,600 DEBUG [pulsar.client.amqp_exchange][consume-heartbeat-pulsar__status] AMQP heartbeat thread alive
2023-04-28 16:07:38,602 DEBUG [pulsar.client.amqp_exchange][consume-heartbeat-pulsar__kill] AMQP heartbeat thread alive
2023-04-28 16:07:38,603 DEBUG [pulsar.client.amqp_exchange][consume-heartbeat-pulsar__setup] AMQP heartbeat thread alive
```