### PR TITLE
Drop nose

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -97,7 +97,7 @@ available (given the need to test commands with DRMAA, condor, sudo, etc...).::
 This will mount your copy of `pulsar` in a Docker container preconfigured with all
 optional dependencies needed to run a wide range of integration tests. If Docker
 is to much of an ordeal many of Pulsar's tests can be executed by simply running 
-``nosetests`` from within an ``virtualenv`` configured as explained above.::
+``pytest`` from within an ``virtualenv`` configured as explained above.::
 
     $ make tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Default tests run with make test
-NOSE_TESTS?=test pulsar
+PYTEST_TESTS?=test pulsar
 # Default environment for make tox
 ENV?=py27
 # Extra arguments supplied to tox command
@@ -81,7 +81,7 @@ _lint-dist:
 lint-dist: dist _lint-dist
 
 tests:
-	$(IN_VENV) nosetests $(NOSE_TESTS)
+	$(IN_VENV) pytest $(PYTEST_TESTS)
 
 test-install-pypi:
 	bash install_test/test_install.bash

--- a/docker/testing/tox_wrapper.sh
+++ b/docker/testing/tox_wrapper.sh
@@ -25,5 +25,4 @@ export USER=root
 export HOME=/tmp
 
 # Old hard-coded tests.
-#cd /pulsar; pyflakes pulsar test && flake8 --exclude test_tool_deps.py --max-complexity 9 pulsar test && nosetests
 cd /pulsar; tox "$@"

--- a/mypy.ini
+++ b/mypy.ini
@@ -55,6 +55,3 @@ ignore_missing_imports = True
 
 [mypy-webtest.*]
 ignore_missing_imports = True
-
-[mypy-nose.*]
-ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,3 @@
-[nosetests]
-verbosity=1
-detailed-errors=1
-with-doctest=1
-with-coverage=1
-logging-filter=pulsar,paste
-logging-level=INFO
-
 [flake8]
 max-line-length = 150
 max-complexity = 14

--- a/test/routes_test.py
+++ b/test/routes_test.py
@@ -1,11 +1,11 @@
 from os.path import join
 
 from pulsar.web.routes import _output_path
-from .test_utils import test_manager
+from .test_utils import get_test_manager
 
 
 def test_output_path():
-    with test_manager() as manager:
+    with get_test_manager() as manager:
         path = _output_path(manager, '1', 'moo', 'direct')
         assert path == join(manager.job_directory('1').outputs_directory(), 'moo')
 
@@ -15,7 +15,7 @@ def test_output_path_security():
     Attempt to download a file outside of a valid result directory,
     ensure it fails.
     """
-    with test_manager() as manager:
+    with get_test_manager() as manager:
         raised_exception = False
         try:
             _output_path(manager, '1', '../moo', 'direct')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -36,12 +36,6 @@ from pulsar.user_auth.manager import UserAuthManager
 
 from unittest import TestCase, skip
 
-try:
-    from nose.tools import nottest
-except ImportError:
-    def nottest(x):
-        return x
-
 import stopit
 from functools import wraps
 
@@ -109,7 +103,7 @@ class TestManager:
 
 
 @contextmanager
-def test_job_directory():
+def temp_job_directory():
     with temp_directory(prefix='job_') as directory:
         yield JobDirectory(directory, '1')
 
@@ -128,7 +122,7 @@ def temp_directory_persist(prefix=''):
 
 
 @contextmanager
-def test_manager():
+def get_test_manager():
     manager = TestManager()
     manager.setup_temp_directory()
     yield manager
@@ -177,7 +171,6 @@ class BaseManagerTestCase(TestCase):
     def tearDown(self):
         rmtree(self.staging_directory)
 
-    @nottest
     def _test_simple_execution(self, manager, timeout=None):
         command = """
 python -c "import sys; sys.stdout.write(\'Hello World!\'); sys.stdout.flush(); sys.stderr.write(\'moo\'); sys.stderr.flush()" \
@@ -257,7 +250,6 @@ class NullJobMetrics:
         self.default_job_instrumenter = NULL_JOB_INSTRUMENTER
 
 
-@nottest
 @contextmanager
 def server_for_test_app(test_app):
     app = test_app.app
@@ -278,7 +270,6 @@ def server_for_test_app(test_app):
         time.sleep(int(environ.get("TEST_WEBAPP_POST_SHUTDOWN_SLEEP")))
 
 
-@nottest
 @contextmanager
 def test_pulsar_server(global_conf={}, app_conf={}, test_conf={}):
     with test_pulsar_app(global_conf, app_conf, test_conf) as app:
@@ -325,7 +316,6 @@ def restartable_pulsar_app_provider(**kwds):
         has_app.cleanup()
 
 
-@nottest
 @contextmanager
 def test_pulsar_app(
         global_conf={},

--- a/test/toolbox_test.py
+++ b/test/toolbox_test.py
@@ -1,4 +1,4 @@
-from .test_utils import get_test_toolbox, test_job_directory
+from .test_utils import get_test_toolbox, temp_job_directory
 from os.path import join
 from os import makedirs
 
@@ -12,7 +12,7 @@ def test_load_simple_tool():
 def test_command_validation():
     toolbox = get_test_toolbox()
     tool1 = toolbox.get_tool("tool1")
-    with test_job_directory() as job_directory:
+    with temp_job_directory() as job_directory:
         wrapper_path = join(job_directory.tool_files_directory(), "tool1_wrapper.py")
         config_path = join(job_directory.configs_directory(), "config1")
         valid_command = "python %s --config %s" % \
@@ -23,7 +23,7 @@ def test_command_validation():
 def test_config_validation():
     toolbox = get_test_toolbox()
     tool1 = toolbox.get_tool("tool1")
-    with test_job_directory() as job_directory:
+    with temp_job_directory() as job_directory:
         configs_dir = job_directory.configs_directory()
         config_path = join(configs_dir, "config1")
         makedirs(configs_dir)


### PR DESCRIPTION
Have replaced `nosetests` with `pytest` - may also want to remove entries from mypy.ini and setup.cfg.
Nose is EOL and doesn't work on Python >= 3.10.