### PR TITLE
Update galaxy-job-metrics requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ webob
 psutil
 PasteDeploy
 pyyaml
-galaxy-job-metrics>=19.9.0
+galaxy-job-metrics>=21.9.0
 galaxy-objectstore>=19.9.0
 galaxy-tool-util>=19.9.0
 galaxy-util>=22.1.2


### PR DESCRIPTION
There is a change https://github.com/galaxyproject/galaxy/pull/11393 to the package that fixes cgroup job metric collection.