### PR TITLE
Fail jobs when output files exist but stage out fails

### DIFF
--- a/pulsar/client/exceptions.py
+++ b/pulsar/client/exceptions.py
@@ -6,11 +6,13 @@ Pulsar client exceptions
 class PulsarClientTransportError(Exception):
     TIMEOUT = 'timeout'
     CONNECTION_REFUSED = 'connection_refused'
+    NOT_200 = 'not_200'
     UNKNOWN = 'unknown'
 
     messages = {
         TIMEOUT: 'Connection timed out',
         CONNECTION_REFUSED: 'Connection refused',
+        NOT_200: 'Response code not 200',
         UNKNOWN: 'Unknown transport error'
     }
 

--- a/pulsar/client/staging/down.py
+++ b/pulsar/client/staging/down.py
@@ -9,6 +9,7 @@ from os.path import (
 )
 
 from ..action_mapper import FileActionMapper
+from ..exceptions import PulsarClientTransportError
 from ..staging import COMMAND_VERSION_FILENAME
 
 log = getLogger(__name__)
@@ -207,6 +208,8 @@ class ResultsCollector:
         log.info("collecting output {} with action {}".format(name, action))
         try:
             return self.output_collector.collect_output(self, output_type, action, name)
+        except PulsarClientTransportError:
+            raise
         except Exception as e:
             if _allow_collect_failure(output_type):
                 log.warning(


### PR DESCRIPTION
With #258 we no longer fail jobs when work dir outputs cannot be staged out under any condition. This is good for getting back stdout/stderr when the tool fails for valid reasons and fails to produce workdir output. However, it also masks stage out failures, meaning that successful jobs that fail to stage out data will show up as green/ok in Galaxy but with zero length outputs.

This change still allows the job to succeed if workdir outputs are missing (more correctly, error handling still falls to Galaxy), but if staging out fails due to transport errors, then the job will be failed.

In my testing you still get back both job and tool stdout and stderr.

Draft because I'd like to have a custom client message on the Galaxy side for this if possible. Right now you get our old friend "Remote job server indicated a problem running or monitoring this job."