### PR TITLE
[WIP] Feature: Send stdout and stderr to Galaxy while job is running

### DIFF
--- a/pulsar/manager_endpoint_util.py
+++ b/pulsar/manager_endpoint_util.py
@@ -24,6 +24,10 @@ def status_dict(manager, job_id):
 def full_status(manager, job_status, job_id):
     if status.is_job_done(job_status):
         full_status = __job_complete_dict(job_status, manager, job_id)
+        # Stdout has already been sent, no need to send again.
+        full_status["stdout"] = None
+        full_status["stderr"] = None
+
     else:
         full_status = {"complete": "false", "status": job_status, "job_id": job_id}
     return full_status

--- a/pulsar/manager_endpoint_util.py
+++ b/pulsar/manager_endpoint_util.py
@@ -24,9 +24,10 @@ def status_dict(manager, job_id):
 def full_status(manager, job_status, job_id):
     if status.is_job_done(job_status):
         full_status = __job_complete_dict(job_status, manager, job_id)
-        # Stdout has already been sent, no need to send again.
-        full_status["stdout"] = None
-        full_status["stderr"] = None
+        if manager.is_live_stdout_update():
+            # Stdout has already been sent, no need to send again.
+            full_status["stdout"] = None
+            full_status["stderr"] = None
 
     else:
         full_status = {"complete": "false", "status": job_status, "job_id": job_id}

--- a/pulsar/manager_factory.py
+++ b/pulsar/manager_factory.py
@@ -76,6 +76,12 @@ def _get_default_options(conf):
     options["job_directory_mode"] = None
     if job_directory_mode is not None:
         options["job_directory_mode"] = int(job_directory_mode, 8)
+    stdout_update = conf.get("send_stdout_update", None)
+    if stdout_update is not None:
+        options["send_stdout_update"] = stdout_update
+    stdout_update_interval = conf.get("stdout_update_interval", None)
+    if stdout_update_interval is not None:
+        options["stdout_update_interval"] = stdout_update_interval
     return options
 
 

--- a/pulsar/managers/__init__.py
+++ b/pulsar/managers/__init__.py
@@ -123,6 +123,17 @@ class ManagerProxy:
     def job_stderr_contents(self, *args, **kwargs):
         return self._proxied_manager.job_stderr_contents(*args, **kwargs)
 
+    def is_live_stdout_update(self):
+        """ Optional.
+         Whether this manager is sending Stdout while the job is running (true if so)
+        """
+        try:
+            # only present in stateful manager currently
+            stdout_live_update = self._proxied_manager.is_live_stdout_update()
+            return stdout_live_update
+        except AttributeError:
+            return False
+
     def kill(self, *args, **kwargs):
         return self._proxied_manager.kill(*args, **kwargs)
 


### PR DESCRIPTION
Hey,
So this is related to this pr in the main Galaxy repo: https://github.com/galaxyproject/galaxy/pull/16975.
The changes facilitate sending both stdout and stderr to Galaxy while a job is running for the purposes of displaying said stdout inside of Galaxy while the job is running. 

The main changes include adding two parameters to the `app.yml` config: `send_stdout_update` which is a boolean, and `stdout_update_interval` which is a float. The first controls whether Pulsar will send stdout/stderr or not, the second is the interval (in seconds) between updates. 

The way that the files is sent is through the files endpoint in Galaxy. In order to not send the entire file each time, in a dict I keep track of the position in the stdout/stderr file that the last update read up to. I then only send the new part of the stdout file. 

After the job is finished, I send any stdout/stderr left that has not been sent. In the final status message send over the broker, instead of including stdout there, I set the stdout and stderr fields there to None, so that it doesn't send the whole file again. In Galaxy, there are a couple of changes in the Pulsar job runner that check if those fields are None, and if so load the stdout from the job directory there.

Like with the other pr, this was done mostly with the intent of not messing around with existing functionality, which is why we didn't want to use messages to send it. Also, like the other pr, any feedback is welcome.
