### PR TITLE
Support configuring the AMQP heartbeat interval, or disabling heartbeats

### DIFF
--- a/app.yml.sample
+++ b/app.yml.sample
@@ -93,6 +93,10 @@
 ## this value is used as the timeout argument to the producer.publish function.
 #amqp_publish_timeout: 2.0
 
+# AMQP heartbeat interval (see: https://www.rabbitmq.com/docs/heartbeats). Set
+# to false or 0 to disable heartbeats.
+#amqp_heartbeat: 580
+
 # AMQP does not guarantee that a published message is received by the AMQP
 # server, so Pulsar can request that the consumer acknowledge messages and will
 # resend them if acknowledgement is not received after a configurable timeout

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -222,6 +222,10 @@ In the event that the connection to the AMQP server is lost during message
 publish, the Pulsar server can retry the connection, governed by the
 ``amqp_publish*`` options documented in `app.yml.sample`_.
 
+By default, `AMQP heartbeats`_ are enabled at an interval of 580 seconds. This
+can be adjusted by setting ``amqp_heartbeat`` or disabled by setting it to
+``false`` or ``0``.
+
 Caching (Experimental)
 ----------------------
 
@@ -241,3 +245,4 @@ and future plans and progress can be tracked on `this Trello card <https://trell
 .. _RabbitMQ: https://www.rabbitmq.com/
 .. _app.yml.sample: https://github.com/galaxyproject/pulsar/blob/master/app.yml.sample
 .. _Two Generals Problem: https://en.wikipedia.org/wiki/Two_Generals%27_Problem
+.. _AMQP heartbeats: https://www.rabbitmq.com/docs/heartbeats

--- a/pulsar/client/amqp_exchange_factory.py
+++ b/pulsar/client/amqp_exchange_factory.py
@@ -15,6 +15,8 @@ def get_exchange(url, manager_name, params):
     )
     if params.get('amqp_acknowledge', False):
         exchange_kwds.update(parse_ack_kwds(params, manager_name))
+    if params.get("amqp_heartbeat") is not None:
+        exchange_kwds["heartbeat"] = params.get("amqp_heartbeat")
     timeout = params.get('amqp_consumer_timeout', False)
     if timeout is not False:
         exchange_kwds['timeout'] = timeout


### PR DESCRIPTION
@mvdbeek noticed in https://github.com/celery/celery/issues/1194#issuecomment-14566201 that heartbeats were considered unnecessary and disabled by default back in 2013. I am not sure about this (keeping connections alive across firewalls and so forth is sometimes necessary) but this adds the ability to disable the heartbeat and adjust the interval if so desired.