### PR TITLE
Do not attempt to complete pre- or post-process if jobs are cancelled in the middle of either stage

### DIFF
--- a/pulsar/managers/staging/pre.py
+++ b/pulsar/managers/staging/pre.py
@@ -7,8 +7,11 @@ from pulsar.client.action_mapper import from_dict
 log = logging.getLogger(__name__)
 
 
-def preprocess(job_directory, setup_actions, action_executor, object_store=None):
+def preprocess(job_directory, setup_actions, action_executor, was_cancelled, object_store=None):
     for setup_action in setup_actions:
+        if was_cancelled():
+            log.info("Exiting preprocessing, job is cancelled")
+            return
         name = setup_action["name"]
         input_type = setup_action["type"]
         action = from_dict(setup_action["action"])


### PR DESCRIPTION
Mostly fixes #364. Ideally we would also interrupt any running transfers since those could be exceptionally long running and wasteful, but doing so requires interrupting a thread running a non-looping action.

We are probably better off moving those to more properly managed asynchronous tasks (celery, multiprocessing, etc.).

EDIT: Also fixes #353, although not by caring whether it's a 403.