### PR TITLE
include min_polling_interval in app sample

### DIFF
--- a/app.yml.sample
+++ b/app.yml.sample
@@ -8,6 +8,7 @@
 #  _default_:
 #    type: queued_python
 #    num_concurrent_jobs: 1
+#    min_polling_interval: 0.5
 
 
 ## Mode to create job releated directories with. If unset


### PR DESCRIPTION
this should clarify that this is configurable and that the default is fairly benevolent regarding resources (with ~30 concurrent jobs this will make ~5mil pbs polling requests per day)