### PR TITLE
Add health check endpoint

### DIFF
--- a/pulsar/web/routes.py
+++ b/pulsar/web/routes.py
@@ -4,6 +4,7 @@ from json import loads
 
 from webob import exc
 
+from pulsar import __version__ as pulsar_version
 from pulsar.client.action_mapper import path_type
 from pulsar.client.job_directory import verify_is_in_directory
 from pulsar.manager_endpoint_util import (
@@ -222,6 +223,11 @@ def object_store_update_from_file(object_store, object_id, base_dir=None, extra_
 @PulsarController(path="/object_store_usage_percent", response_type='json')
 def object_store_get_store_usage_percent(object_store):
     return object_store.get_store_usage_percent()
+
+
+@PulsarController(path="/healthz", method="GET", response_type='json')
+def healthz():
+    return {'version': pulsar_version}
 
 
 class PulsarDataset:

--- a/test/wsgi_app_test.py
+++ b/test/wsgi_app_test.py
@@ -3,6 +3,8 @@ import os
 import time
 from urllib.parse import quote
 
+from pulsar import __version__ as pulsar_version
+
 
 def test_standard_requests():
     """ Tests app controller methods. These tests should be
@@ -68,3 +70,8 @@ def test_standard_requests():
         clean_response = app.delete("/jobs/%s" % job_id)
         assert clean_response.body.decode("utf-8") == 'OK'
         assert os.listdir(staging_directory) == []
+
+        # test healthz endpoint
+        healthz_response = app.get("/healthz")
+        healthz_data = json.loads(healthz_response.body.decode("utf-8"))
+        assert healthz_data["version"] == pulsar_version


### PR DESCRIPTION
Currently, there is no endpoint that can be queried to indicate a running pulsar. This makes it difficult for us to add liveness and readiness probes for the pulsar helm chart.