### PR TITLE
BasicAuth for PulsarTesRunner

### DIFF
--- a/pulsar/managers/util/tes.py
+++ b/pulsar/managers/util/tes.py
@@ -1,3 +1,4 @@
+import base64
 from typing import (
     Any,
     cast,
@@ -40,12 +41,19 @@ def ensure_tes_client() -> None:
 
 
 def tes_client_from_dict(destination_params: Dict[str, Any]) -> TesClient:
-    # TODO: implement funnel's basic auth in pydantic-tes and expose it here.
     tes_url = destination_params.get("tes_url")
-    token = destination_params.get("private_token")
+    auth_type = destination_params.get("auth", "none")  # Default to "none"
+
     headers = {}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+
+    if auth_type == "basic":
+        basic_auth = destination_params.get("basic_auth", {})
+        username = basic_auth.get("username")
+        password = basic_auth.get("password")
+        if username and password:
+            auth_string = f"{username}:{password}"
+            auth_base64 = base64.b64encode(auth_string.encode()).decode()
+            headers["Authorization"] = f"Basic {auth_base64}"
 
     return TesClient(url=tes_url, headers=headers)
 

--- a/pulsar/managers/util/tes.py
+++ b/pulsar/managers/util/tes.py
@@ -42,7 +42,7 @@ def ensure_tes_client() -> None:
 
 def tes_client_from_dict(destination_params: Dict[str, Any]) -> TesClient:
     tes_url = destination_params.get("tes_url")
-    auth_type = destination_params.get("auth", "none")  # Default to "none"
+    auth_type = destination_params.get("authorization", "none")  # Default to "none"
 
     headers = {}
 

--- a/pulsar/managers/util/tes.py
+++ b/pulsar/managers/util/tes.py
@@ -41,10 +41,13 @@ def ensure_tes_client() -> None:
 
 def tes_client_from_dict(destination_params: Dict[str, Any]) -> TesClient:
     # TODO: implement funnel's basic auth in pydantic-tes and expose it here.
-    tes_url = destination_params["tes_url"]
-    return TesClient(
-        url=tes_url,
-    )
+    tes_url = destination_params.get("tes_url")
+    token = destination_params.get("private_token")
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    return TesClient(url=tes_url, headers=headers)
 
 
 def tes_resources(destination_params: Dict[str, Any]) -> TesResources:


### PR DESCRIPTION
This PR implements basic authorisation functionality in job submission to TES server.
Job configuration is extended by following options:
```
      authorization: "basic"  # Can be "none" or "basic"
      basic_auth:
        username: "user"
        password: "password"
```
Following this approach the OAuth2 authorisation could be implemented, although it requires an implementation of underlying mechanism that would obtain and refresh service tokens from the configured authority.

This PR is dependent on [PR#5](https://github.com/jmchilton/pydantic-tes/pull/5) in [pydantic-tes](https://github.com/jmchilton/pydantic-tes)