### PR TITLE
Support HTCondor in CLUSTER_SLOTS_STATEMENT.sh

### DIFF
--- a/pulsar/managers/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
+++ b/pulsar/managers/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
@@ -26,6 +26,19 @@ elif [ -n "$LSB_DJOB_NUMPROC" ]; then
 elif [ -n "$GALAXY_SLOTS" ]; then
     # kubernetes runner injects GALAXY_SLOTS into environment
     GALAXY_SLOTS=$GALAXY_SLOTS
+elif [ -n "$ROOT_MAX_THREADS" ]; then
+    # HTCondor sets a couple of environment variables read by various
+    # frameworks to control the number of threads they are allowed to use. A
+    # list can be found in the HTCondor docs (the list itself is configurable,
+    # as it is an HTCondor configuration macro).
+    #
+    # https://htcondor.readthedocs.io/en/24.0/admin-manual/
+    # configuration-macros.html#STARTER_NUM_THREADS_ENV_VARS
+    #
+    # Any of these variables can be used to set GALAXY_SLOTS. Set it using the
+    # variable ROOT_MAX_THREADS (designed to control the ROOT data analysis
+    # framework from CERN).
+    GALAXY_SLOTS="$ROOT_MAX_THREADS"
 else
     GALAXY_SLOTS="1"
     unset GALAXY_SLOTS_CONFIGURED


### PR DESCRIPTION
HTCondor sets a couple of environment variables read by various frameworks to control the number of threads they are allowed to use. A list can be found on the HTCondor docs https://htcondor.readthedocs.io/en/24.0/admin-manual/configuration-macros.html#STARTER_NUM_THREADS_ENV_VARS. The list itself is configurable (it is an HTCondor configuration macro).

Any of these variables can be used to set GALAXY_SLOTS. Set it using the variable ROOT_MAX_THREADS (designed to control the ROOT data analysis framework from CERN).