### PR TITLE
Customizable Pulsar test file server port and files endpoint

### DIFF
--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -450,7 +450,9 @@ def _run_in_app(test_configuration: IntegrationTestConfiguration, direct_interfa
         # server for Pulsar - webtest doesn't seem to like having two test
         # servers alive at same time.
         with files_server("/") as test_files_server:
-            files_endpoint = to_infrastructure_uri(test_files_server.application_url)
+            files_endpoint = to_infrastructure_uri(
+                environ.get("PULSAR_TEST_INTERNAL_JOB_FILES_URL", test_files_server.application_url)
+            )
             if direct_interface:
                 _run_direct(test_configuration, files_endpoint=files_endpoint, **kwds)
             else:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -251,12 +251,15 @@ class NullJobMetrics:
 
 
 @contextmanager
-def server_for_test_app(test_app):
+def server_for_test_app(test_app, host=None, port=None):
     app = test_app.app
-    create_kwds = {
-    }
-    if os.environ.get("PULSAR_TEST_FILE_SERVER_HOST"):
-        create_kwds["host"] = os.environ.get("PULSAR_TEST_FILE_SERVER_HOST")
+
+    create_kwds = {}
+    if host:
+        create_kwds["host"] = host
+    if port:
+        create_kwds["port"] = port
+
     server = StopableWSGIServer.create(app, **create_kwds)
     try:
         server.wait()
@@ -469,14 +472,16 @@ def files_server(directory=None):
         else:
             yield Bunch(application_url=external_url)
     else:
+        host = os.environ.get("PULSAR_TEST_FILE_SERVER_HOST")
+        port = os.environ.get("PULSAR_TEST_FILE_SERVER_PORT")
         if not directory:
             with temp_directory() as directory:
                 app = TestApp(JobFilesApp(directory))
-                with server_for_test_app(app) as server:
+                with server_for_test_app(app, host=host, port=port) as server:
                     yield server, directory
         else:
             app = TestApp(JobFilesApp(directory))
-            with server_for_test_app(app) as server:
+            with server_for_test_app(app, host=host, port=port) as server:
                 yield server
 
 


### PR DESCRIPTION
- Read port at which the Pulsar test file server should listen from `PULSAR_TEST_FILE_SERVER_PORT`.
- Make the files endpoint customizable via a new `PULSAR_TEST_INTERNAL_JOB_FILES_URL` variable.
- Use `PULSAR_TEST_FILE_SERVER_HOST` only for the test file server (rather than also using it for the test Pulsar app).

These changes make it possible to expose the files server via port-forwarding (since the files server port is now predictable). This is useful for testing the [upcoming staging delegation](https://github.com/galaxyproject/pulsar/pull/399) with an [external service (e.g. ARC)](https://github.com/galaxyproject/pulsar/pull/401).