### PR TITLE
Paste to gunicorn

### DIFF
--- a/docker/coexecutor/Dockerfile
+++ b/docker/coexecutor/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     # Install Pulsar Python requirements
     && pip install --no-cache-dir -U pip \
     && pip install --no-cache-dir drmaa wheel kombu pykube pycurl \
-            webob psutil PasteDeploy pyyaml paramiko \
+            webob psutil pyyaml paramiko \
     # Remove build deps and cleanup
     && apt-get -y remove gcc wget lsb-release \
     && apt-get -y autoremove \

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -155,9 +155,9 @@ Finally, install Pulsar's required dependencies into the virtual environment::
 
     $ pip install -r requirements.txt
 
-If using the standard webserver, it can be installed with::
+If using the standard webserver, install gunicorn with::
 
-    $ pip install Paste PasteScript
+    $ pip install gunicorn
 
 Launching Pulsar
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -177,7 +177,7 @@ Pulsar can be launched with::
     $ ./run.sh [--daemon]
 
 This daemon can be stopped using ``./run.sh --stop-daemon``. When run as a
-daemon, Pulsar will log to the file ``paster.log``.  If ``--daemon`` is not
+daemon, Pulsar will log to the file ``pulsar.log``.  If ``--daemon`` is not
 supplied, Pulsar will just run in the foreground.
 
 Under Windows, Pulsar can be started using::
@@ -198,7 +198,7 @@ private token has been configured it can be supplied using
 Pulsar Webservers
 ----------------------
 
-Pulsar's default webserver (if web dependencies are installed) is `Paste`_.
+Pulsar's default webserver (if web dependencies are installed) is `gunicorn`_.
 However, `uWSGI`_ or `circus`_ will be used instead, if found.
 
 A precompiled version of uWSGI can be installed with::
@@ -226,6 +226,6 @@ install <dependency_name>``.
 .. _venv: https://docs.python.org/3/library/venv.html
 .. _pip: https://pip.pypa.io/
 .. _Supervisord: http://supervisord.org/
-.. _Paste: https://pythonpaste.readthedocs.io/en/latest/
+.. _gunicorn: https://gunicorn.org/
 .. _uWSGI: https://uwsgi-docs.readthedocs.io/
 .. _circus: http://circus.readthedocs.org/

--- a/docs/scripts/pulsar.rst
+++ b/docs/scripts/pulsar.rst
@@ -17,15 +17,15 @@ main``) and delegate to that method.
 ``pulsar`` can be passed the ``--mode`` argument to explicitly describe which
 application should be used to run Pulsar. If ``--mode`` unspecified,
 ``pulsar``  will check the ``PATH`` and launch look for (in order) ``uwsgi``,
-``circusd``, ``chaussette``, and finally ``paster`` to determine which mode to
+``circusd``, ``chaussette``, and finally ``gunicorn`` to determine which mode to
 use.
 
 ------------------------
-``paster`` mode
+``gunicorn`` mode
 ------------------------
 
-Paste_ is installed with Pulsar and so is the fallback mode if none of the
-other web servers is available.
+gunicorn_ is installed with Pulsar (via the ``[web]`` extra) and so is the
+fallback mode if none of the other web servers is available.
 
 In this mode, Pulsar can be launched using the command::
 
@@ -38,8 +38,8 @@ the command::
     pulsar --daemon
 
 This will run Pulsar in daemon mode (i.e. run in the background). In daemon
-mode, paster creates a pid file in the current directory called ``paster.pid``
-and a log file ``paster.log``. The daemon can be stopped using the command::
+mode, gunicorn creates a pid file in the current directory called ``pulsar.pid``
+and a log file ``pulsar.log``. The daemon can be stopped using the command::
 
     pulsar --stop-daemon
 
@@ -64,24 +64,19 @@ these servers when ``--mode`` is specified as ``uwsgi``, ``circus``,
 ``chaussette`` respectively.
 
 See the documentation for the respective application for a full description of
-the arguments that can be used to configure that web server. Presumably each
-of these servers is more performant and better maintained than Paste_ but
-Paste_ is cross-platform and makes it trivial to configure SSL and so it
-remains the default for Pulsar for now.
+the arguments that can be used to configure that web server.
 
 ``pulsar`` (Windows)
 ======================================
 
-``pulsar`` is a lightweight wrapper around ``paster serve`` (see `docs
-<http://pythonpaste.org/script/#paster-serve>`__). It will check the current
-directory for a ``server.ini`` file and launch the described Pulsar server using Paste_.
+``pulsar`` is a lightweight wrapper around ``pulsar-serve`` which launches
+Pulsar using gunicorn_. It will check the current directory for a ``server.ini``
+file and launch the described Pulsar server.
 
 
-.. _Paste: http://pythonpaste.org/
+.. _gunicorn: https://gunicorn.org/
 .. _WSGI: http://en.wikipedia.org/wiki/Web_Server_Gateway_Interface
 .. _Cirucs: http://circus.readthedocs.org/
 .. _Chaussette: https://chaussette.readthedocs.org/
 .. _uWSGI: https://uwsgi-docs.readthedocs.org/
 
-
-	

--- a/docs/scripts/pulsar_config.rst
+++ b/docs/scripts/pulsar_config.rst
@@ -5,7 +5,7 @@
 **Usage**::
 
     pulsar-config [-h] [--directory DIRECTORY] [--mq] [--no_logging]
-                  [--supervisor] [--wsgi_server {paster,uwsgi}]
+                  [--supervisor] [--wsgi_server {gunicorn,uwsgi}]
                   [--libdrmaa_path LIBDRMAA_PATH] [--host HOST]
                   [--private_token PRIVATE_TOKEN] [--port PORT] [--install]
                   [--force]
@@ -29,7 +29,7 @@ Initialize a directory with a minimal pulsar config.
                             its logging either.
       --supervisor          Write a supervisord configuration file for managing
                             pulsar out as well.
-      --wsgi_server {paster,uwsgi}
+      --wsgi_server {gunicorn,uwsgi}
                             Web server stack used to host Pulsar wsgi application.
       --libdrmaa_path LIBDRMAA_PATH
                             Configure Pulsar to submit jobs to a cluster via DRMAA
@@ -47,4 +47,4 @@ Initialize a directory with a minimal pulsar config.
       --install             Install optional dependencies required by specified
                             configuration (e.g. drmaa, supervisor, uwsgi, etc...).
       --force               Overwrite existing files if they already exist.
-    
+

--- a/install_test/common_functions.bash
+++ b/install_test/common_functions.bash
@@ -82,7 +82,7 @@ check_pulsar() {
         sleep 1;
     done
     sleep 2
-    cat paster.log
+    cat pulsar.log
 
     cd ..
 }

--- a/mypy.ini
+++ b/mypy.ini
@@ -30,6 +30,9 @@ ignore_missing_imports = True
 [mypy-paste.*]
 ignore_missing_imports = True
 
+[mypy-gunicorn.*]
+ignore_missing_imports = True
+
 [mypy-webob.*]
 ignore_missing_imports = True
 

--- a/pulsar/main.py
+++ b/pulsar/main.py
@@ -197,6 +197,8 @@ def apply_env_overrides_and_defaults(conf):
 
 
 def load_app_configuration(ini_path=None, app_conf_path=None, app_name=None, local_conf=None, config_dir=PULSAR_CONFIG_DIR):
+    if app_name is None:
+        app_name = DEFAULT_INI_APP
     """
     """
     if ini_path and local_conf is None:

--- a/pulsar/scripts/config.py
+++ b/pulsar/scripts/config.py
@@ -89,14 +89,12 @@ autorestart     = true
 """)
 
 SERVER_CONFIG_TEMPLATE = string.Template("""[server:main]
-use = egg:Paste#http
 port = ${port}
 host = ${host}
 ## pem file to use to enable SSL.
 # ssl_pem = host.pem
 
 [app:main]
-paste.app_factory = pulsar.web.wsgi:app_factory
 app_config = %(here)s/app.yml
 
 ## Configure uWSGI (if used).
@@ -165,7 +163,7 @@ def main(argv=None):
                             help=HELP_SUPERVISOR,
                             skip_on_windows=True)
     arg_parser.add_argument("--wsgi_server",
-                            choices=["paster", "uwsgi"],
+                            choices=["gunicorn", "uwsgi"],
                             default=None,
                             help=HELP_WSGI_SERVER,
                             skip_on_windows=True)
@@ -247,7 +245,7 @@ def _print_pulsar_run(mode):
     elif mode == "uwsgi":
         print("    pulsar --mode %s" % mode)
         print("Any extra commands passed to pulsar will be forwarded along to uwsgi.")
-    elif mode != "paster":
+    elif mode != "gunicorn":
         print("    pulsar --mode %s" % mode)
     else:
         print("    pulsar")
@@ -272,7 +270,7 @@ def _determine_mode(args):
     elif args.mq:
         mode = "webless"
     else:
-        mode = "paster"
+        mode = "gunicorn"
     return mode
 
 

--- a/pulsar/scripts/serve.py
+++ b/pulsar/scripts/serve.py
@@ -144,10 +144,6 @@ def _run_gunicorn(config_file, host, port, ssl_pem, daemon, pid_file, log_file):
         options["accesslog"] = log_file
 
     if ssl_pem:
-        if ssl_pem == "*":
-            # Auto-generate a self-signed certificate
-            _generate_ssl_cert("host.pem")
-            ssl_pem = "host.pem"
         if os.path.exists(ssl_pem):
             options["certfile"] = ssl_pem
             options["keyfile"] = ssl_pem
@@ -170,31 +166,6 @@ def _run_gunicorn(config_file, host, port, ssl_pem, daemon, pid_file, log_file):
 
     print("Starting Pulsar on %s" % bind)
     PulsarApplication(options).run()
-
-
-def _generate_ssl_cert(pem_path):
-    """Generate a self-signed SSL certificate (matching old Paste behavior)."""
-    try:
-        from OpenSSL import crypto
-    except ImportError:
-        print("pyOpenSSL is required to auto-generate SSL certificates. "
-              "Install it with: pip install pyOpenSSL", file=sys.stderr)
-        sys.exit(1)
-
-    key = crypto.PKey()
-    key.generate_key(crypto.TYPE_RSA, 2048)
-    cert = crypto.X509()
-    cert.get_subject().CN = "localhost"
-    cert.set_serial_number(1000)
-    cert.gmtime_adj_notBefore(0)
-    cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
-    cert.set_issuer(cert.get_subject())
-    cert.set_pubkey(key)
-    cert.sign(key, "sha256")
-
-    with open(pem_path, "wb") as f:
-        f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
-        f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, key))
 
 
 if __name__ == "__main__":

--- a/pulsar/scripts/serve.py
+++ b/pulsar/scripts/serve.py
@@ -171,6 +171,10 @@ def _run_gunicorn(config_file, host, port, ssl_pem, pid_file, log_file):
         # Allow generous time for app initialization (loading galaxy modules, etc.)
         "timeout": 300,
         "graceful_timeout": 300,
+        # Pulsar sends job parameters as long query strings; disable request
+        # line and field size limits to match the old Paste server behavior.
+        "limit_request_line": 0,
+        "limit_request_field_size": 0,
     }
 
     if log_file:

--- a/pulsar/scripts/serve.py
+++ b/pulsar/scripts/serve.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+"""Launch Pulsar using gunicorn as the WSGI server.
+
+Reads server configuration from a server.ini file and starts
+a gunicorn worker serving the Pulsar WSGI application.
+"""
+
+import argparse
+import configparser
+import os
+import signal
+import ssl
+import sys
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Serve Pulsar with gunicorn.")
+    parser.add_argument("config_file", nargs="?", default=None,
+                        help="Path to server.ini configuration file (default: auto-detect)")
+    parser.add_argument("--daemon", action="store_true", default=False,
+                        help="Run as a daemon process")
+    parser.add_argument("--pid", default=None,
+                        help="Path to PID file (default: pulsar.pid when daemonized)")
+    parser.add_argument("--log-file", default=None,
+                        help="Path to log file (default: pulsar.log when daemonized)")
+    parser.add_argument("--stop-daemon", action="store_true", default=False,
+                        help="Stop a running daemon by reading the PID file")
+    args = parser.parse_args(argv)
+
+    config_file = args.config_file
+    if config_file is None:
+        config_file = _find_config_file()
+    if not os.path.isabs(config_file):
+        config_file = os.path.abspath(config_file)
+
+    pid_file = args.pid
+    log_file = args.log_file
+
+    if args.stop_daemon:
+        return _stop_daemon(pid_file or "pulsar.pid")
+
+    # Read server settings from INI
+    host, port, ssl_pem = _read_server_config(config_file)
+
+    if args.daemon:
+        if pid_file is None:
+            pid_file = "pulsar.pid"
+        if log_file is None:
+            log_file = "pulsar.log"
+
+    _run_gunicorn(config_file, host, port, ssl_pem, args.daemon, pid_file, log_file)
+
+
+def _find_config_file():
+    """Find server.ini, checking PULSAR_CONFIG_DIR then current directory."""
+    config_dir = os.environ.get("PULSAR_CONFIG_DIR", ".")
+    candidates = [
+        os.path.join(config_dir, "server.ini"),
+        "server.ini",
+        "server.ini.sample",
+    ]
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    return "server.ini"
+
+
+def _read_server_config(config_file):
+    """Read host, port, and ssl_pem from [server:main] in the INI file."""
+    config = configparser.ConfigParser()
+    config.read(config_file)
+
+    section = "server:main"
+    host = "localhost"
+    port = "8913"
+    ssl_pem = None
+
+    if config.has_section(section):
+        host = config.get(section, "host", fallback=host)
+        port = config.get(section, "port", fallback=port)
+        ssl_pem = config.get(section, "ssl_pem", fallback=None)
+
+    return host, port, ssl_pem
+
+
+def _stop_daemon(pid_file):
+    """Stop a daemonized pulsar-serve process."""
+    if not os.path.exists(pid_file):
+        print("No PID file found at %s" % pid_file, file=sys.stderr)
+        return 1
+
+    with open(pid_file) as f:
+        pid = int(f.read().strip())
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+        print("Sent SIGTERM to process %d" % pid)
+    except ProcessLookupError:
+        print("Process %d not found, removing stale PID file" % pid, file=sys.stderr)
+    except PermissionError:
+        print("Permission denied sending signal to process %d" % pid, file=sys.stderr)
+        return 1
+
+    try:
+        os.remove(pid_file)
+    except OSError:
+        pass
+
+    return 0
+
+
+def _run_gunicorn(config_file, host, port, ssl_pem, daemon, pid_file, log_file):
+    """Start gunicorn with the Pulsar WSGI app."""
+    try:
+        from gunicorn.app.base import BaseApplication
+    except ImportError:
+        print("gunicorn is not installed. Install it with: pip install 'pulsar-app[web]'",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Set PULSAR_CONFIG_FILE so init_webapp can find it
+    os.environ["PULSAR_CONFIG_FILE"] = config_file
+
+    # On macOS, Objective-C runtime crashes when fork() is called after
+    # certain frameworks are initialized. This is the standard workaround.
+    if sys.platform == "darwin":
+        os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
+
+    bind = "%s:%s" % (host, port)
+
+    options = {
+        "bind": bind,
+        "workers": 1,
+        "threads": 4,
+        "worker_class": "gthread",
+    }
+
+    if daemon:
+        options["daemon"] = True
+    if pid_file:
+        options["pidfile"] = pid_file
+    if log_file:
+        options["errorlog"] = log_file
+        options["accesslog"] = log_file
+
+    if ssl_pem:
+        if ssl_pem == "*":
+            # Auto-generate a self-signed certificate
+            _generate_ssl_cert("host.pem")
+            ssl_pem = "host.pem"
+        if os.path.exists(ssl_pem):
+            options["certfile"] = ssl_pem
+            options["keyfile"] = ssl_pem
+            options["ssl_version"] = ssl.PROTOCOL_TLS
+
+    class PulsarApplication(BaseApplication):
+        def __init__(self, options=None):
+            self.options = options or {}
+            super().__init__()
+
+        def load_config(self):
+            for key, value in self.options.items():
+                if key in self.cfg.settings and value is not None:
+                    self.cfg.set(key.lower(), value)
+
+        def load(self):
+            from pulsar.web.wsgi import init_webapp
+            config_dir = os.path.dirname(os.path.abspath(config_file))
+            return init_webapp(ini_path=config_file, config_dir=config_dir)
+
+    print("Starting Pulsar on %s" % bind)
+    PulsarApplication(options).run()
+
+
+def _generate_ssl_cert(pem_path):
+    """Generate a self-signed SSL certificate (matching old Paste behavior)."""
+    try:
+        from OpenSSL import crypto
+    except ImportError:
+        print("pyOpenSSL is required to auto-generate SSL certificates. "
+              "Install it with: pip install pyOpenSSL", file=sys.stderr)
+        sys.exit(1)
+
+    key = crypto.PKey()
+    key.generate_key(crypto.TYPE_RSA, 2048)
+    cert = crypto.X509()
+    cert.get_subject().CN = "localhost"
+    cert.set_serial_number(1000)
+    cert.gmtime_adj_notBefore(0)
+    cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
+    cert.set_issuer(cert.get_subject())
+    cert.set_pubkey(key)
+    cert.sign(key, "sha256")
+
+    with open(pem_path, "wb") as f:
+        f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+        f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, key))
+
+
+if __name__ == "__main__":
+    main()

--- a/pulsar/scripts/serve.py
+++ b/pulsar/scripts/serve.py
@@ -12,6 +12,12 @@ import signal
 import ssl
 import sys
 
+# On macOS, Objective-C runtime crashes when fork() is called after
+# certain frameworks are initialized. This must be set before any
+# imports that might trigger ObjC initialization.
+if sys.platform == "darwin":
+    os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
+
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Serve Pulsar with gunicorn.")
@@ -47,8 +53,9 @@ def main(argv=None):
             pid_file = "pulsar.pid"
         if log_file is None:
             log_file = "pulsar.log"
+        _daemonize(pid_file, log_file)
 
-    _run_gunicorn(config_file, host, port, ssl_pem, args.daemon, pid_file, log_file)
+    _run_gunicorn(config_file, host, port, ssl_pem, pid_file, log_file)
 
 
 def _find_config_file():
@@ -83,6 +90,39 @@ def _read_server_config(config_file):
     return host, port, ssl_pem
 
 
+def _daemonize(pid_file, log_file):
+    """Double-fork to daemonize, write PID file, redirect stdio to log."""
+    # First fork
+    pid = os.fork()
+    if pid > 0:
+        # Parent waits briefly for child to set up, then exits
+        os._exit(0)
+
+    # Decouple from parent environment
+    os.setsid()
+
+    # Second fork
+    pid = os.fork()
+    if pid > 0:
+        os._exit(0)
+
+    # Write PID file
+    pid_file_abs = os.path.abspath(pid_file)
+    with open(pid_file_abs, "w") as f:
+        f.write(str(os.getpid()))
+
+    # Redirect stdio to log file
+    sys.stdout.flush()
+    sys.stderr.flush()
+    log_fd = os.open(log_file, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    dev_null = os.open(os.devnull, os.O_RDONLY)
+    os.dup2(dev_null, sys.stdin.fileno())
+    os.dup2(log_fd, sys.stdout.fileno())
+    os.dup2(log_fd, sys.stderr.fileno())
+    os.close(dev_null)
+    os.close(log_fd)
+
+
 def _stop_daemon(pid_file):
     """Stop a daemonized pulsar-serve process."""
     if not os.path.exists(pid_file):
@@ -109,7 +149,7 @@ def _stop_daemon(pid_file):
     return 0
 
 
-def _run_gunicorn(config_file, host, port, ssl_pem, daemon, pid_file, log_file):
+def _run_gunicorn(config_file, host, port, ssl_pem, pid_file, log_file):
     """Start gunicorn with the Pulsar WSGI app."""
     try:
         from gunicorn.app.base import BaseApplication
@@ -121,11 +161,6 @@ def _run_gunicorn(config_file, host, port, ssl_pem, daemon, pid_file, log_file):
     # Set PULSAR_CONFIG_FILE so init_webapp can find it
     os.environ["PULSAR_CONFIG_FILE"] = config_file
 
-    # On macOS, Objective-C runtime crashes when fork() is called after
-    # certain frameworks are initialized. This is the standard workaround.
-    if sys.platform == "darwin":
-        os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
-
     bind = "%s:%s" % (host, port)
 
     options = {
@@ -133,12 +168,11 @@ def _run_gunicorn(config_file, host, port, ssl_pem, daemon, pid_file, log_file):
         "workers": 1,
         "threads": 4,
         "worker_class": "gthread",
+        # Allow generous time for app initialization (loading galaxy modules, etc.)
+        "timeout": 300,
+        "graceful_timeout": 300,
     }
 
-    if daemon:
-        options["daemon"] = True
-    if pid_file:
-        options["pidfile"] = pid_file
     if log_file:
         options["errorlog"] = log_file
         options["accesslog"] = log_file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 webob
 psutil
-PasteDeploy
 pyyaml
 galaxy-job-metrics>=21.9.0
 galaxy-objectstore>=19.9.0

--- a/run.bat
+++ b/run.bat
@@ -6,4 +6,4 @@ IF NOT EXIST server.ini (
 	rem Copying new settings file from template.
 	echo f | xcopy server.ini.sample server.ini
 )
-paster serve server.ini %*
+pulsar-serve server.ini %*

--- a/scripts/pulsar
+++ b/scripts/pulsar
@@ -5,14 +5,14 @@ cat <<EOF
 Usage:
 
 ${0##*/} --daemon
-    Start Pulsar server as daemon process (paster or circus):
+    Start Pulsar server as daemon process (gunicorn or circus):
 ${0##*/} --stop-daemon
-    Stop Pulsar daemon process (paster/chaussette) with circus use
+    Stop Pulsar daemon process (gunicorn) with circus use
     'circusctl quit'
 
 Extra Options:
 
-  -m|--mode   How to launch (paster,uwsgi,chaussette,circusd,webless).
+  -m|--mode   How to launch (gunicorn,uwsgi,chaussette,circusd,webless).
               In webless mode Pulsar will not attempt to bind to a port,
               this may be useful in conjuction with message queue driven
               Pulsar operation.
@@ -26,7 +26,7 @@ EOF
 while :
 do
     case "$1" in
-      -h|--help|-\?) 
+      -h|--help|-\?)
           show_help
           exit 0
           ;;
@@ -34,21 +34,21 @@ do
           if [ $# -gt 1 ]; then
               MODE=$2
               shift 2
-          else 
+          else
               echo "--mode requires explicit argument" 1>&2
               exit 1
-          fi          
+          fi
           ;;
       -c|--config)
           if [ $# -gt 1 ]; then
               PULSAR_CONFIG_DIR=$2
               shift 2
-          else 
+          else
               echo "--config requires explicit argument" 1>&2
               exit 1
           fi
           ;;
-      --) 
+      --)
           shift
           break
           ;;
@@ -76,7 +76,7 @@ then
     . $PULSAR_LOCAL_ENV
 fi
 
-if [ -d $PULSAR_VIRTUALENV ]; 
+if [ -d $PULSAR_VIRTUALENV ];
 then
     echo "Activating virtual environment $PULSAR_VIRTUALENV/bin/activate"
     . $PULSAR_VIRTUALENV/bin/activate
@@ -108,7 +108,7 @@ if [ -z "$PULSAR_CONFIG_FILE" ]; then
     export PULSAR_CONFIG_FILE
 fi
 
-if [ -z "$MODE" ]; 
+if [ -z "$MODE" ];
 then
     if hash uwsgi 2>/dev/null; then
         MODE="uwsgi"
@@ -117,7 +117,7 @@ then
     elif hash chaussette 2>/dev/null; then
         MODE="chaussette"
     else
-        MODE="paster"
+        MODE="gunicorn"
     fi
 fi
 
@@ -127,11 +127,15 @@ if [ "$MODE" == "uwsgi" ]; then
 elif [ "$MODE" == "circusd" ]; then
     circusd server.ini "$@"
 elif [ "$MODE" == "chaussette" ]; then
-    echo "Attempting to use chaussette instead of paster, you must specify port on command-line (--port 8913)."
+    echo "Attempting to use chaussette instead of gunicorn, you must specify port on command-line (--port 8913)."
     chaussette "paste:$PULSAR_CONFIG_FILE" "$@"
+elif [ "$MODE" == "gunicorn" ]; then
+    echo "Starting pulsar with command [pulsar-serve \"$PULSAR_CONFIG_FILE\" \"$@\"]"
+    pulsar-serve "$PULSAR_CONFIG_FILE" "$@"
 elif [ "$MODE" == "paster" ]; then
-    echo "Starting pulsar with command [paster server \"$PULSAR_CONFIG_FILE\" \"$@\"]"
-    paster serve "$PULSAR_CONFIG_FILE" "$@"
+    echo "WARNING: paster mode is deprecated. Using gunicorn instead." 1>&2
+    echo "Starting pulsar with command [pulsar-serve \"$PULSAR_CONFIG_FILE\" \"$@\"]"
+    pulsar-serve "$PULSAR_CONFIG_FILE" "$@"
 elif [ "$MODE" == "webless" ]; then
     if hash pulsar-main 2>/dev/null; then
         # Running from pip install since

--- a/scripts/pulsar.bat
+++ b/scripts/pulsar.bat
@@ -1,2 +1,2 @@
 
-paster serve server.ini %*
+pulsar-serve server.ini %*

--- a/server.ini.sample
+++ b/server.ini.sample
@@ -1,12 +1,8 @@
-### server:main section used by paster web server. More advanced,
-### Python3 compatible circus setup configured using sections after
+### server:main section used by pulsar-serve (gunicorn). More advanced,
+### circus setup configured using sections after
 ### app:main (circus, watcher:web, socket:web).
 
 [server:main]
-use = egg:Paste#http
-## To use chaussette w/paster deploy (no circus), use follwoing: 
-# use = egg:chaussette#main
-
 ## The port on which to listen.
 port = 8913
 ## The interface(s) on which to listen. Use '0.0.0.0' for all interfaces.
@@ -17,8 +13,6 @@ host = localhost
 # ssl_pem = host.pem
 
 [app:main]
-paste.app_factory = pulsar.web.wsgi:app_factory
-
 app_config=%(here)s/app.yml
 
 ## Configure uWSGI (if used).
@@ -34,7 +28,7 @@ enable-threads = True
 [circus]
 endpoint = tcp://127.0.0.1:5555
 pubsub_endpoint = tcp://127.0.0.1:5556
-#stats_endpoint = tcp://127.0.0.1:5557                                                                                    
+#stats_endpoint = tcp://127.0.0.1:5557
 
 [watcher:web]
 cmd = chaussette --fd $(circus.sockets.web) paste:server.ini

--- a/server.ini.sample
+++ b/server.ini.sample
@@ -8,8 +8,7 @@ port = 8913
 ## The interface(s) on which to listen. Use '0.0.0.0' for all interfaces.
 host = localhost
 
-## pem file to use to enable SSL. Set to * to generate one
-## automatically.
+## pem file to use to enable SSL.
 # ssl_pem = host.pem
 
 [app:main]

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         pulsar-submit=pulsar.scripts.submit:main
         pulsar-finish=pulsar.scripts.finish:main
         pulsar-run=pulsar.scripts.run:main
+        pulsar-serve=pulsar.scripts.serve:main
         _pulsar-conda-init=pulsar.scripts._conda_init:main
         _pulsar-configure-slurm=pulsar.scripts._configure_slurm:main
         _pulsar-configure-galaxy-cvmfs=pulsar.scripts._configure_galaxy_cvmfs:main
@@ -106,7 +107,7 @@ setup(
     install_requires=requirements,
     extras_require={
         'amqp': ['kombu'],
-        'web': ['Paste', 'PasteScript'],
+        'web': ['gunicorn'],
         'galaxy_extended_metadata': ['galaxy-job-execution', 'galaxy-util[template]'],
     },
     license="Apache License 2.0",

--- a/test/main_util_test.py
+++ b/test/main_util_test.py
@@ -95,7 +95,6 @@ def __write_mock_ini(path, **kwds):
 def __mock_ini_contents(app="main", extra=""):
     return """
 [app:{}]
-paste.app_factory = pulsar.web.wsgi:app_factory
 foo=bar1
 {}
 """.format(app, extra)


### PR DESCRIPTION
PasteScript depends on pkg_resources (from setuptools), which is no longer bundled in modern Python, causing ModuleNotFoundError when running paster serve. Replace with gunicorn, a well-maintained WSGI server that supports the same features (HTTP serving, SSL, daemon mode).

- Add pulsar/scripts/serve.py: gunicorn-based launcher with --daemon, --stop-daemon, --pid, and SSL support
- Add pulsar-serve console_scripts entry point
- Change web extra from Paste/PasteScript to gunicorn
- Remove PasteDeploy from requirements.txt and Dockerfile
- Update scripts/pulsar to default to gunicorn mode (with paster backward compat that prints deprecation warning)
- Update scripts/pulsar.bat and run.bat to use pulsar-serve
- Update pulsar-config template and defaults
- Remove Paste directives from server.ini.sample and config/server.ini
- Update documentation and install tests