### PR TITLE
Fail fast on permanent HTTP errors during staging

### DIFF
--- a/pulsar/client/transport/curl.py
+++ b/pulsar/client/transport/curl.py
@@ -72,10 +72,12 @@ def post_file(url, path):
     c = _new_curl_object_for_url(url)
     c.setopt(c.HTTPPOST, [("file", (c.FORM_FILE, path.encode('ascii')))])
     c.perform()
-    status_code = c.getinfo(HTTP_CODE)
-    if int(status_code) != 200:
-        message = POST_FAILED_MESSAGE % (url, status_code)
-        raise Exception(message)
+    status_code = int(c.getinfo(HTTP_CODE))
+    if status_code != 200:
+        raise PulsarClientTransportError(
+            transport_code=status_code,
+            transport_message=POST_FAILED_MESSAGE % (url, status_code),
+        )
 
 
 def get_size(url) -> int:
@@ -119,8 +121,10 @@ def get_file(url, path: str):
         c.perform()
         status_code = int(c.getinfo(HTTP_CODE))
         if status_code not in success_codes:
-            message = GET_FAILED_MESSAGE % (url, status_code)
-            raise Exception(message)
+            raise PulsarClientTransportError(
+                transport_code=status_code,
+                transport_message=GET_FAILED_MESSAGE % (url, status_code),
+            )
     finally:
         buf.close()
 

--- a/pulsar/client/transport/requests.py
+++ b/pulsar/client/transport/requests.py
@@ -24,12 +24,14 @@ def post_file(url, path):
     m = requests_toolbelt.MultipartEncoder(
         fields={'file': ('filename', open(path, 'rb'))}
     )
-    requests.post(url, data=m, headers={'Content-Type': m.content_type})
+    response = requests.post(url, data=m, headers={'Content-Type': m.content_type})
+    response.raise_for_status()
 
 
 def get_file(url, path):
     __ensure_requests()
     r = requests.get(url, stream=True)
+    r.raise_for_status()
     with open(path, 'wb') as f:
         for chunk in r.iter_content(chunk_size=1024):
             if chunk:  # filter out keep-alive new chunks

--- a/pulsar/client/transport/standard.py
+++ b/pulsar/client/transport/standard.py
@@ -6,7 +6,10 @@ Pulsar HTTP Client layer based on Python Standard Library (urllib)
 import mmap
 import socket
 from os.path import getsize
-from urllib.error import URLError
+from urllib.error import (
+    HTTPError,
+    URLError,
+)
 from urllib.request import (
     Request,
     urlopen,
@@ -43,6 +46,11 @@ class UrllibTransport:
                 response = self._url_open(request, data)
             except (socket.timeout, TimeoutError):
                 raise PulsarClientTransportError(code=PulsarClientTransportError.TIMEOUT)
+            except HTTPError as exc:
+                raise PulsarClientTransportError(
+                    transport_code=exc.code,
+                    transport_message=exc.reason,
+                )
             except URLError as exc:
                 raise PulsarClientTransportError(transport_message=exc.reason)
         finally:

--- a/pulsar/client/transport/transient.py
+++ b/pulsar/client/transport/transient.py
@@ -1,0 +1,69 @@
+"""Classify exceptions raised by Pulsar transports as transient or permanent.
+
+Used as the ``should_retry`` predicate for ``RetryActionExecutor`` so that
+staging actions retry on transient HTTP failures (5xx, 429, connection
+errors) but fail fast on permanent ones (4xx client errors).
+"""
+import socket
+from urllib.error import (
+    HTTPError as UrllibHTTPError,
+    URLError,
+)
+
+import requests
+
+from ..exceptions import PulsarClientTransportError
+
+
+# Per RFC 6585 / RFC 9110 plus de-facto convention used by urllib3,
+# Google Cloud SDK, AWS SDK, Azure SDK:
+#   408 Request Timeout    — server gave up waiting
+#   425 Too Early          — replay-protection backoff
+#   429 Too Many Requests  — rate limited (honor Retry-After)
+#   500 Internal Server Error
+#   502 Bad Gateway        — the nginx-upstream case from #443
+#   503 Service Unavailable
+#   504 Gateway Timeout
+TRANSIENT_HTTP_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+
+def _status_is_transient(status):
+    try:
+        return int(status) in TRANSIENT_HTTP_STATUS
+    except (TypeError, ValueError):
+        # Non-numeric transport_code (e.g. PulsarClientTransportError.TIMEOUT
+        # string constants) — these come from connection-level failures, not
+        # HTTP responses, and are always transient.
+        return True
+
+
+def is_transient_http_error(exc):
+    """Return True if ``exc`` should be retried.
+
+    The default for unrecognized exceptions is True so that non-HTTP failures
+    (filesystem hiccups, SSH disconnects, etc.) keep retrying as they did
+    before this predicate existed. We only opt *out* of retry for things we
+    positively recognize as permanent client errors.
+    """
+    # Connection-level failures: always transient.
+    if isinstance(exc, (ConnectionError, TimeoutError, socket.timeout)):
+        return True
+    if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
+        return True
+
+    # HTTP responses with a status code we can read.
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        return _status_is_transient(exc.response.status_code)
+    if isinstance(exc, UrllibHTTPError):
+        return _status_is_transient(exc.code)
+    if isinstance(exc, PulsarClientTransportError):
+        return _status_is_transient(exc.transport_code)
+
+    # urllib.error.URLError without an HTTP status is connection-level.
+    if isinstance(exc, URLError):
+        return True
+
+    # Unknown — be conservative and retry. Preserves prior behavior for
+    # filesystem, SSH, and other non-HTTP exceptions that staging actions
+    # can raise.
+    return True

--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -14,6 +14,7 @@ except ImportError:
 
 import logging
 
+from pulsar.client.transport.transient import is_transient_http_error
 from pulsar.client.util import filter_destination_params
 from pulsar.managers import (
     ManagerProxy,
@@ -53,6 +54,8 @@ class StatefulManagerProxy(ManagerProxy):
         min_polling_interval = float(manager_options.get("min_polling_interval", DEFAULT_MIN_POLLING_INTERVAL))
         preprocess_retry_action_kwds = filter_destination_params(manager_options, "preprocess_action_")
         postprocess_retry_action_kwds = filter_destination_params(manager_options, "postprocess_action_")
+        preprocess_retry_action_kwds.setdefault("should_retry", is_transient_http_error)
+        postprocess_retry_action_kwds.setdefault("should_retry", is_transient_http_error)
         self.__preprocess_action_executor = RetryActionExecutor(**preprocess_retry_action_kwds)
         self.__postprocess_action_executor = RetryActionExecutor(**postprocess_retry_action_kwds)
         self.min_polling_interval = datetime.timedelta(0, min_polling_interval)

--- a/pulsar/managers/util/retry.py
+++ b/pulsar/managers/util/retry.py
@@ -10,6 +10,13 @@ DEFAULT_INTERVAL_MAX = 30.0
 DEFAULT_INTERVAL_STEP = 2.0
 DEFAULT_CATCH = (Exception,)
 
+
+def _always_retry(_exc):
+    return True
+
+
+DEFAULT_SHOULD_RETRY = _always_retry
+
 DEFAULT_DESCRIPTION = "action"
 
 
@@ -26,6 +33,7 @@ class RetryActionExecutor:
         self.interval_max = float(kwds.get("interval_max", DEFAULT_INTERVAL_MAX))
         self.errback = kwds.get("errback", self.__default_errback)
         self.catch = kwds.get("catch", DEFAULT_CATCH)
+        self.should_retry = kwds.get("should_retry", DEFAULT_SHOULD_RETRY)
 
         self.default_description = kwds.get("description", DEFAULT_DESCRIPTION)
 
@@ -47,6 +55,7 @@ class RetryActionExecutor:
             interval_step=self.interval_step,
             interval_max=self.interval_max,
             errback=on_error,
+            should_retry=self.should_retry,
         )
 
     def __default_errback(self, exc, interval, description=None):
@@ -64,7 +73,7 @@ class RetryActionExecutor:
 # BSD License (https://github.com/celery/kombu/blob/master/LICENSE)
 def _retry_over_time(fun, catch, args=[], kwargs={}, errback=None,
                      max_retries=None, interval_start=2, interval_step=2,
-                     interval_max=30):
+                     interval_max=30, should_retry=DEFAULT_SHOULD_RETRY):
     """Retry the function over and over until max retries is exceeded.
 
     For each retry we sleep a for a while before we try again, this interval
@@ -82,6 +91,10 @@ def _retry_over_time(fun, catch, args=[], kwargs={}, errback=None,
     :keyword interval_step: By how much the interval is increased for each
         retry.
     :keyword interval_max: Maximum number of seconds to sleep between retries.
+    :keyword should_retry: Predicate ``(exc) -> bool`` evaluated on each
+        caught exception. If it returns False the exception is re-raised
+        immediately without sleeping. Defaults to retrying on every caught
+        exception.
 
     """
     retries = 0
@@ -92,6 +105,8 @@ def _retry_over_time(fun, catch, args=[], kwargs={}, errback=None,
         try:
             return fun(*args, **kwargs)
         except catch as exc:
+            if not should_retry(exc):
+                raise
             if max_retries and retries >= max_retries:
                 raise
             tts = float(errback(exc, interval_range, retries) if errback

--- a/test/client_transport_test.py
+++ b/test/client_transport_test.py
@@ -8,6 +8,7 @@ import requests as requests_module
 from simplejobfiles.app import JobFilesApp
 from webtest import TestApp
 
+from pulsar.client.exceptions import PulsarClientTransportError
 from pulsar.client.transport.standard import UrllibTransport
 from pulsar.client.transport.curl import PycurlTransport
 from pulsar.client.transport.curl import post_file
@@ -78,6 +79,23 @@ def test_curl_put_get():
             post_file(request_url, input)
             get_file(request_url, output)
             assert open(output).read() == "helloworld"
+
+
+def test_urllib_status_code():
+    """The urllib transport must surface the HTTP status code on the raised
+    PulsarClientTransportError so retry classifiers can read it."""
+    with files_server() as (server, directory):
+        server_url = server.application_url
+        absent_path = os.path.join(directory, f"test_for_GET_absent_{str(uuid4())}")
+        request_url = "{}?path={}".format(server_url, absent_path)
+        try:
+            UrllibTransport().execute(request_url, data=None)
+        except PulsarClientTransportError as exc:
+            assert isinstance(exc.transport_code, int) and exc.transport_code >= 400, (
+                f"transport_code should hold the HTTP status, got {exc.transport_code!r}"
+            )
+        else:
+            raise AssertionError("urllib transport did not raise on missing file")
 
 
 def test_curl_status_code():

--- a/test/client_transport_test.py
+++ b/test/client_transport_test.py
@@ -15,6 +15,7 @@ from pulsar.client.transport.curl import post_file
 from pulsar.client.transport.curl import get_file
 from pulsar.client.transport.requests import get_file as requests_get_file
 from pulsar.client.transport.requests import post_file as requests_post_file
+from pulsar.client.transport.transient import is_transient_http_error
 from pulsar.client.transport.tus import find_tus_endpoint
 from pulsar.client.transport import get_transport
 from pulsar.managers.util.retry import RetryActionExecutor
@@ -124,18 +125,20 @@ def test_curl_status_code():
 
 
 class _FlakyApp:
-    """WSGI middleware that returns 502 for the first ``fail_count`` requests."""
+    """WSGI middleware that returns ``status`` for the first ``fail_count``
+    requests, then delegates to the wrapped app."""
 
-    def __init__(self, app, fail_count):
+    def __init__(self, app, fail_count, status="502 Bad Gateway"):
         self.app = app
         self.fail_count = fail_count
+        self.status = status
         self.attempts = 0
 
     def __call__(self, environ, start_response):
         self.attempts += 1
         if self.attempts <= self.fail_count:
-            start_response("502 Bad Gateway", [("Content-Type", "text/html")])
-            return [b"<html><body><h1>502 Bad Gateway</h1></body></html>"]
+            start_response(self.status, [("Content-Type", "text/html")])
+            return [b"<html><body><h1>" + self.status.encode() + b"</h1></body></html>"]
         return self.app(environ, start_response)
 
 
@@ -233,6 +236,39 @@ def test_requests_persistent_failure_exhausts_retries():
 
             assert flaky.attempts == max_retries + 1
             assert not os.path.exists(output_path), "no file should have been written"
+
+
+def test_permanent_4xx_fails_fast_under_executor():
+    """A 404 must NOT be retried — retrying client errors wastes time and
+    delays job failure. The executor's should_retry predicate (default
+    is_transient_http_error) should let the HTTPError bubble on first hit."""
+    max_retries = 5
+    with temp_directory() as directory:
+        flaky = _FlakyApp(JobFilesApp(directory), fail_count=10, status="404 Not Found")
+        with server_for_test_app(TestApp(flaky)) as server:
+            request_url = "{}?path={}".format(server.application_url, str(Path(directory) / "x"))
+            output_path = os.path.join(directory, "downloaded")
+
+            executor = RetryActionExecutor(
+                max_retries=max_retries,
+                interval_start=0.01,
+                interval_step=0.01,
+                interval_max=0.05,
+                should_retry=is_transient_http_error,
+            )
+            try:
+                executor.execute(
+                    lambda: requests_get_file(request_url, output_path),
+                    "permanent-404-test",
+                )
+            except requests_module.HTTPError:
+                pass
+            else:
+                raise AssertionError("404 HTTPError should have propagated immediately")
+
+            assert flaky.attempts == 1, (
+                f"4xx must not be retried, but the server saw {flaky.attempts} attempts"
+            )
 
 
 @skip_unless_module("pycurl")

--- a/test/client_transport_test.py
+++ b/test/client_transport_test.py
@@ -4,15 +4,24 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from uuid import uuid4
 
+import requests as requests_module
+from simplejobfiles.app import JobFilesApp
+from webtest import TestApp
+
 from pulsar.client.transport.standard import UrllibTransport
 from pulsar.client.transport.curl import PycurlTransport
 from pulsar.client.transport.curl import post_file
 from pulsar.client.transport.curl import get_file
+from pulsar.client.transport.requests import get_file as requests_get_file
+from pulsar.client.transport.requests import post_file as requests_post_file
 from pulsar.client.transport.tus import find_tus_endpoint
 from pulsar.client.transport import get_transport
+from pulsar.managers.util.retry import RetryActionExecutor
 
 from .test_utils import files_server
+from .test_utils import server_for_test_app
 from .test_utils import skip_unless_module
+from .test_utils import temp_directory
 
 
 def test_urllib_transports():
@@ -91,6 +100,118 @@ def test_curl_status_code():
         except Exception:
             exception_raised = True
         assert exception_raised
+
+
+class _FlakyApp:
+    """WSGI middleware that returns 502 for the first ``fail_count`` requests."""
+
+    def __init__(self, app, fail_count):
+        self.app = app
+        self.fail_count = fail_count
+        self.attempts = 0
+
+    def __call__(self, environ, start_response):
+        self.attempts += 1
+        if self.attempts <= self.fail_count:
+            start_response("502 Bad Gateway", [("Content-Type", "text/html")])
+            return [b"<html><body><h1>502 Bad Gateway</h1></body></html>"]
+        return self.app(environ, start_response)
+
+
+def test_requests_status_code():
+    with files_server() as (server, directory):
+        server_url = server.application_url
+        absent_path = os.path.join(directory, f"test_for_GET_absent_{str(uuid4())}")
+        request_url = "{}?path={}".format(server_url, absent_path)
+        # Use a uuid in the output name: in CI, `directory` is the shared
+        # /tmp served by the simplejobfiles container, so a fixed name like
+        # "test" can collide with leftovers from prior runs and break the
+        # "no file written on error" assertion below.
+        output_path = os.path.join(directory, f"out_{uuid4()}")
+        try:
+            requests_get_file(request_url, output_path)
+        except requests_module.HTTPError:
+            pass
+        else:
+            raise AssertionError("requests get_file did not raise on missing file")
+        assert not os.path.exists(output_path), "requests get_file created file on error response"
+
+
+@skip_unless_module("requests_toolbelt")
+def test_requests_post_status_code():
+    with files_server() as (server, directory):
+        server_url = server.application_url
+        # /usr/bin/cow is read-only territory — the server will reject the upload.
+        post_request_url = "{}?path={}".format(server_url, "/usr/bin/cow")
+        source_file = os.path.join(directory, f"src_{uuid4()}")
+        Path(source_file).write_text("payload")
+        try:
+            requests_post_file(post_request_url, source_file)
+        except requests_module.HTTPError:
+            pass
+        else:
+            raise AssertionError("requests post_file did not raise on error response")
+
+
+def test_requests_transient_failure_recovers_with_retry():
+    """Issue #443: a transient nginx 502 must surface as an exception so the
+    surrounding RetryActionExecutor can retry and eventually succeed."""
+    fail_count = 2
+    with temp_directory() as directory:
+        served = Path(directory) / f"served_{uuid4()}"
+        served.write_text("recovered_content")
+
+        flaky = _FlakyApp(JobFilesApp(directory), fail_count=fail_count)
+        with server_for_test_app(TestApp(flaky)) as server:
+            request_url = "{}?path={}".format(server.application_url, str(served))
+            output_path = os.path.join(directory, "downloaded")
+
+            executor = RetryActionExecutor(
+                max_retries=fail_count + 1,
+                interval_start=0.01,
+                interval_step=0.01,
+                interval_max=0.05,
+            )
+            executor.execute(
+                lambda: requests_get_file(request_url, output_path),
+                "transient-test",
+            )
+
+            assert flaky.attempts == fail_count + 1
+            assert open(output_path).read() == "recovered_content"
+
+
+def test_requests_persistent_failure_exhausts_retries():
+    """If 502s never resolve, the retry layer must give up with HTTPError —
+    not a silent success leaving an HTML-corrupted file behind."""
+    max_retries = 2
+    with temp_directory() as directory:
+        served = Path(directory) / f"served_{uuid4()}"
+        served.write_text("never_served")
+
+        flaky = _FlakyApp(JobFilesApp(directory), fail_count=10)
+        with server_for_test_app(TestApp(flaky)) as server:
+            request_url = "{}?path={}".format(server.application_url, str(served))
+            output_path = os.path.join(directory, "downloaded")
+
+            executor = RetryActionExecutor(
+                max_retries=max_retries,
+                interval_start=0.01,
+                interval_step=0.01,
+                interval_max=0.05,
+            )
+            try:
+                executor.execute(
+                    lambda: requests_get_file(request_url, output_path),
+                    "exhaust-test",
+                )
+            except requests_module.HTTPError:
+                pass
+            else:
+                raise AssertionError("HTTPError should have propagated after retry exhaustion")
+
+            assert flaky.attempts == max_retries + 1
+            assert not os.path.exists(output_path), "no file should have been written"
 
 
 @skip_unless_module("pycurl")

--- a/test/client_transport_test.py
+++ b/test/client_transport_test.py
@@ -103,21 +103,24 @@ def test_curl_status_code():
         server_url = server.application_url
         path = os.path.join(directory, f"test_for_GET_absent_{str(uuid4())}")
         request_url = "{}?path={}".format(server_url, path)
-        # Verify curl doesn't just silently swallow errors.
-        exception_raised = False
         try:
             get_file(request_url, os.path.join(directory, "test"))
-        except Exception:
-            exception_raised = True
-        assert exception_raised
+        except PulsarClientTransportError as exc:
+            assert isinstance(exc.transport_code, int) and exc.transport_code >= 400, (
+                f"transport_code should hold the HTTP status, got {exc.transport_code!r}"
+            )
+        else:
+            raise AssertionError("curl get_file did not raise on missing file")
 
         post_request_url = "{}?path={}".format(server_url, "/usr/bin/cow")
-        exception_raised = False
         try:
             post_file(post_request_url, os.path.join(directory, "test"))
-        except Exception:
-            exception_raised = True
-        assert exception_raised
+        except PulsarClientTransportError as exc:
+            assert isinstance(exc.transport_code, int) and exc.transport_code >= 400, (
+                f"transport_code should hold the HTTP status, got {exc.transport_code!r}"
+            )
+        else:
+            raise AssertionError("curl post_file did not raise on error response")
 
 
 class _FlakyApp:

--- a/test/retry_action_test.py
+++ b/test/retry_action_test.py
@@ -29,6 +29,47 @@ def test_third_execution_fine():
     assert not exception_raised
 
 
+def test_should_retry_false_short_circuits():
+    """When should_retry returns False the exception must propagate on the
+    first failure — no sleep, no further attempts."""
+    action_tracker = ActionTracker(fail_count=5, fail_how=PermanentError)
+    executor = RetryActionExecutor(
+        max_retries=10,
+        interval_start=.01,
+        interval_step=.01,
+        should_retry=lambda exc: not isinstance(exc, PermanentError),
+    )
+    try:
+        executor.execute(action_tracker.execute)
+    except PermanentError:
+        pass
+    else:
+        raise AssertionError("PermanentError should have propagated")
+    assert action_tracker.count == 1, action_tracker.count
+
+
+def test_should_retry_true_still_retries():
+    """The predicate must not block retries for exceptions it approves."""
+    action_tracker = ActionTracker(fail_count=2, fail_how=TransientError)
+    executor = RetryActionExecutor(
+        max_retries=5,
+        interval_start=.01,
+        interval_step=.01,
+        should_retry=lambda exc: isinstance(exc, TransientError),
+    )
+    result = executor.execute(action_tracker.execute)
+    assert result == 42
+    assert action_tracker.count == 3, action_tracker.count
+
+
+class PermanentError(Exception):
+    pass
+
+
+class TransientError(Exception):
+    pass
+
+
 class ActionTracker:
 
     def __init__(self, fail_count=0, fail_how=Exception):

--- a/test/transient_test.py
+++ b/test/transient_test.py
@@ -1,0 +1,98 @@
+"""Unit tests for ``pulsar.client.transport.transient.is_transient_http_error``.
+
+Pure unit tests with synthetic exceptions — no network, no fixtures. The
+integration test that proves the predicate fires correctly through
+``RetryActionExecutor`` lives in ``client_transport_test.py``.
+"""
+import socket
+from urllib.error import (
+    HTTPError as UrllibHTTPError,
+    URLError,
+)
+
+import requests
+
+from pulsar.client.exceptions import PulsarClientTransportError
+from pulsar.client.transport.transient import (
+    is_transient_http_error,
+    TRANSIENT_HTTP_STATUS,
+)
+
+
+def _requests_http_error(status_code):
+    response = requests.Response()
+    response.status_code = status_code
+    return requests.HTTPError(response=response)
+
+
+def _urllib_http_error(code):
+    return UrllibHTTPError(url="http://example/", code=code, msg="err", hdrs=None, fp=None)
+
+
+def test_transient_status_set():
+    # Lock the policy so changing it requires a deliberate test edit.
+    assert TRANSIENT_HTTP_STATUS == frozenset({408, 425, 429, 500, 502, 503, 504})
+
+
+def test_requests_5xx_is_transient():
+    for code in (500, 502, 503, 504):
+        assert is_transient_http_error(_requests_http_error(code)), code
+
+
+def test_requests_429_is_transient():
+    assert is_transient_http_error(_requests_http_error(429))
+
+
+def test_requests_4xx_is_permanent():
+    for code in (400, 401, 403, 404, 405, 409, 410, 413, 415, 422):
+        assert not is_transient_http_error(_requests_http_error(code)), code
+
+
+def test_requests_connection_and_timeout_are_transient():
+    assert is_transient_http_error(requests.ConnectionError())
+    assert is_transient_http_error(requests.Timeout())
+
+
+def test_urllib_status_classified():
+    assert is_transient_http_error(_urllib_http_error(502))
+    assert is_transient_http_error(_urllib_http_error(429))
+    assert not is_transient_http_error(_urllib_http_error(404))
+    assert not is_transient_http_error(_urllib_http_error(403))
+
+
+def test_urllib_urlerror_no_status_is_transient():
+    """URLError without an HTTP status is a connection-level failure."""
+    assert is_transient_http_error(URLError("connection refused"))
+
+
+def test_pulsar_client_transport_error_status_classified():
+    assert is_transient_http_error(PulsarClientTransportError(transport_code=502))
+    assert is_transient_http_error(PulsarClientTransportError(transport_code=429))
+    assert not is_transient_http_error(PulsarClientTransportError(transport_code=404))
+
+
+def test_pulsar_client_transport_error_string_codes_are_transient():
+    """Non-numeric transport_code values (TIMEOUT, CONNECTION_REFUSED) come
+    from connection-level failures and should be retried."""
+    assert is_transient_http_error(
+        PulsarClientTransportError(code=PulsarClientTransportError.TIMEOUT)
+    )
+    assert is_transient_http_error(
+        PulsarClientTransportError(code=PulsarClientTransportError.CONNECTION_REFUSED)
+    )
+
+
+def test_socket_and_builtin_connection_errors_are_transient():
+    assert is_transient_http_error(socket.timeout())
+    assert is_transient_http_error(TimeoutError())
+    assert is_transient_http_error(ConnectionError())
+
+
+def test_unknown_exception_defaults_to_transient():
+    """Non-HTTP exceptions (filesystem, SSH, etc.) preserve the prior
+    retry-everything behavior so this change is additive, not regressive."""
+    class SomeOtherError(Exception):
+        pass
+
+    assert is_transient_http_error(SomeOtherError())
+    assert is_transient_http_error(OSError("disk hiccup"))


### PR DESCRIPTION
## Summary

Building on 3ad94cc (which made the `requests` transport raise on non-2xx so transient
nginx 502s during staging would surface to `RetryActionExecutor` instead of silently
writing an HTML body to `container.json`), this PR adds the missing other half:

- **5xx, 429, 408, 425, 504, connection errors → retry** (the #443 case)
- **4xx (400, 403, 404, ...) → fail fast**, instead of burning through every
  `preprocess_action_max_retries` / `postprocess_action_max_retries` attempt on a
  request that cannot succeed

Four small commits, each independently buildable and tested:

1. **Preserve HTTP status code in urllib transport** — `standard.py` was already
   raising on HTTP errors via `URLError` (since `HTTPError` subclasses it), but the
   status code was discarded. Catch `HTTPError` first and forward `exc.code` as
   `transport_code`.
2. **Raise structured error on HTTP failure in curl transport** — `curl.py` was
   raising bare `Exception("...status code N...")` with the code only in the
   message string. Switch to `PulsarClientTransportError(transport_code=N)` so the
   classifier can read it. `PulsarClientTransportError` subclasses `Exception`, so
   `except Exception` callers are unaffected.
3. **Add `should_retry` predicate to `RetryActionExecutor`** — generic mechanism only.
   `should_retry: Callable[[Exception], bool]`; default retries on every caught
   exception (no behavior change for existing call sites such as the SSH retry loop).
4. **Skip retries for permanent HTTP errors in staging actions** — new
   `pulsar/client/transport/transient.py` with `is_transient_http_error`, wired as
   the default `should_retry` for the preprocess and postprocess executors in
   `StatefulManagerProxy`. Users can still override per-destination via the
   existing `{pre,post}process_action_*` config mechanism.

The transient set follows the convention shared by urllib3, Google Cloud SDK, AWS
SDK, and Azure SDK: `{408, 425, 429, 500, 502, 503, 504}`. Connection-level
exceptions (`ConnectionError`, `socket.timeout`, `requests.ConnectionError`,
`requests.Timeout`, urllib `URLError` without a status) are always transient.
Unknown exception types default to \"retry,\" so non-HTTP staging actions
(filesystem, SSH) keep retrying as before — this PR is additive, never regressive.

## Test plan

- [x] `test/retry_action_test.py` — 2 new unit tests for the predicate hook (false
      short-circuits without sleep, true still retries)
- [x] `test/transient_test.py` — 11 unit tests covering each branch of the
      classifier (`requests.HTTPError`, `urllib.HTTPError`,
      `PulsarClientTransportError` with both numeric and string `transport_code`,
      `URLError`, builtin connection errors, unknown exception default)
- [x] `test/client_transport_test.py` — extended `_FlakyApp` to take a status code;
      added `test_permanent_4xx_fails_fast_under_executor` asserting a 404 takes
      exactly **1** attempt under an executor with `max_retries=5`
- [x] `test/client_transport_test.py` — `test_urllib_status_code` and tightened
      `test_curl_status_code` assert the structured `transport_code` is populated
- [x] Existing `test_requests_transient_failure_recovers_with_retry` and
      `test_requests_persistent_failure_exhausts_retries` (added in 3ad94cc) still
      pass — no regression in the 5xx-retry path
- [x] Pre-existing `test_ini_populate` failure on master (Python 3.12 removed
      `ConfigParser.readfp`) is unrelated

Fixes #443.