### PR TITLE
Harden Pulsar's job lifecycle against restart / broker / Galaxy outages

### DIFF
--- a/.github/workflows/pulsar.yaml
+++ b/.github/workflows/pulsar.yaml
@@ -85,6 +85,66 @@ jobs:
         PULSAR_TEST_EXTERNAL_JOB_FILES_URL: "http://localhost:8000"
         PULSAR_TEST_EXTERNAL_JOB_FILES_DIRECTORY: "/tmp"
         TEST_WEBAPP_POST_SHUTDOWN_SLEEP: 1
+  resilience:
+    name: Resilience Suite
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+        cache: pip
+    - name: Install test runner deps
+      run: pip install pytest pytest-timeout requests
+    - name: Build images
+      run: docker compose -f test/resilience/docker-compose.yml build
+    - name: Bring up the docker-compose stack
+      run: docker compose -f test/resilience/docker-compose.yml up -d
+    - name: Wait for stack
+      run: |
+        # Toxiproxy admin API is the readiness signal — when it answers,
+        # rabbitmq, relay, valkey and mock-galaxy have all reached a usable
+        # state because they're toxiproxy's depends_on chain.
+        for i in $(seq 1 60); do
+          if curl -sf http://localhost:8474/version >/dev/null; then
+            echo "stack ready"; exit 0;
+          fi
+          sleep 2
+        done
+        echo "stack did not become ready" >&2
+        docker compose -f test/resilience/docker-compose.yml ps
+        docker compose -f test/resilience/docker-compose.yml logs
+        exit 1
+    - name: Run resilience suite
+      # Fail-fast (-x) for the first CI run on this job: if a scenario
+      # fails we want diagnostics quickly, not 45 minutes of cascade. The
+      # captured docker logs from the next step are scoped to whatever
+      # was happening when the first failure hit. Drop -x once the job
+      # is stable.
+      run: pytest test/resilience -v -x --keep-stack
+      env:
+        PYTHONUNBUFFERED: "1"
+    - name: Show stack logs on failure
+      if: failure()
+      run: |
+        echo "=== ps ==="
+        docker compose -f test/resilience/docker-compose.yml ps
+        echo "=== pulsar ==="
+        docker compose -f test/resilience/docker-compose.yml logs --no-color --timestamps pulsar | tail -800
+        echo "=== mock-galaxy ==="
+        docker compose -f test/resilience/docker-compose.yml logs --no-color --timestamps mock-galaxy | grep -vE "GET /_recorder/events" | tail -400
+        echo "=== rabbitmq ==="
+        docker compose -f test/resilience/docker-compose.yml logs --tail=100 rabbitmq
+        echo "=== relay ==="
+        docker compose -f test/resilience/docker-compose.yml logs --no-color --timestamps relay | tail -400
+        echo "=== toxiproxy ==="
+        docker compose -f test/resilience/docker-compose.yml logs --no-color --timestamps toxiproxy | tail -200
+    - name: Tear down
+      if: always()
+      run: docker compose -f test/resilience/docker-compose.yml down -v
   ## Can't get the following tests to work - they fall over on the containerized job not being able to
   ## connect to the host running the Pulsar server for file transfers in stage out/in.
   # tes-test:

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ docker/coexecutor/*whl
 app.yml
 server.ini
 job_managers.ini
+# The resilience suite under test/resilience/ ships its own deterministic
+# configs that share these filenames; un-ignore them so CI can build an
+# image that mounts them at /etc/pulsar.
+!test/resilience/config/app_*.yml
+!test/resilience/config/server.ini
 *.pem
 *.cert
 *.key

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,6 +19,7 @@ coverage
 # resolvable for lint/mypy even when the suite itself is skipped without docker.
 fastapi; python_version >= '3.8'
 uvicorn; python_version >= '3.8'
+a2wsgi; python_version >= '3.8'
 
 # For dev
 sphinx

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,6 +14,11 @@ pytest
 pytest-timeout
 webtest
 coverage
+# Used by the docker-compose resilience suite under test/resilience/. Imported
+# at module top-level by mock_galaxy/app.py and harness/*, so they need to be
+# resolvable for lint/mypy even when the suite itself is skipped without docker.
+fastapi; python_version >= '3.8'
+uvicorn; python_version >= '3.8'
 
 # For dev
 sphinx

--- a/docs/error_handling.rst
+++ b/docs/error_handling.rst
@@ -1,0 +1,393 @@
+.. _error_handling:
+
+Error Handling and Resilience (Admin Guide)
+============================================
+
+This page documents how Pulsar reacts to operational failures —
+RabbitMQ/relay outages, Pulsar restarts, Galaxy unreachability, transient
+HTTP errors during staging — and what an administrator needs to configure
+or monitor to make those guarantees real.
+
+The single guarantee Pulsar provides is: **for every job submitted by
+Galaxy, exactly one terminal status update (** ``complete`` **,**
+``failed`` **,** ``cancelled`` **, or** ``lost`` **) is delivered, in
+non-decreasing lifecycle order, within bounded time after the underlying
+fault clears.**
+
+The mechanisms below combine to deliver that guarantee. Each section names
+the configuration knobs, defaults, on-disk artifacts, and operational
+signals so you can verify the system is doing what it claims.
+
+.. contents::
+   :local:
+   :depth: 2
+
+------------------------------------------------------------------------
+1. The job lifecycle and where status updates come from
+------------------------------------------------------------------------
+
+A job moves through these states (see ``pulsar/managers/status.py``):
+
+::
+
+    preprocessing -> queued -> running -> postprocessing -> complete | failed | cancelled | lost
+
+Status transitions are emitted by the *stateful* manager wrapper
+(``pulsar/managers/stateful.py``):
+
+* ``preprocessing`` — the moment the setup message is accepted and the
+  staging thread begins; the job directory contains ``launch_config`` but
+  not yet ``preprocessed``.
+* ``running`` — first call to ``get_status()`` that detects the job has
+  begun executing on the underlying runner.
+* terminal (``complete``/``failed``/``cancelled``/``lost``) — written as
+  the on-disk metadata file ``final_status`` after postprocessing.
+
+All transitions go through a single callback registered by the messaging
+binding (``pulsar/messaging/bind_amqp.py`` and
+``pulsar/messaging/bind_relay.py``), which writes the payload to the
+**status-update outbox** and lets a background drain thread retry the
+publish. The synchronous publish path is gone.
+
+------------------------------------------------------------------------
+2. The persistent status-update outbox
+------------------------------------------------------------------------
+
+Why
+~~~
+
+Before this layer existed, a Pulsar that hit a broker hiccup *just* as a
+job finished would log the publish exception, kill the postprocess
+thread, and leave Galaxy permanently unaware that the job was done. This
+was the single largest data-loss path in the lifecycle.
+
+How
+~~~
+
+Every status update is written to a per-manager directory before any
+attempt to publish:
+
+::
+
+    <persistence_directory>/<manager>-status-outbox/        # AMQP modes
+    <persistence_directory>/<manager>-relay-status-outbox/  # relay mode
+
+Each entry is a single JSON file named ``<seq>-<uuid>.json``. ``seq`` is a
+monotonic per-outbox counter primed from the maximum seq found on disk at
+startup, so a lexically sorted directory listing yields strict FIFO drain
+order even after a restart.
+
+A daemon thread (named ``status-outbox-<dir-basename>``) drains pending
+entries every few seconds:
+
+* on enqueue success the file is removed only **after** ``publish_fn``
+  returns;
+* on publish failure the file is left on disk, the drain thread retries on
+  the next pass, and ``enqueue`` itself never raises;
+* on Pulsar startup the drain thread runs once before consumer threads
+  start, so any backlog left by the previous process is delivered first.
+
+What this gives you
+~~~~~~~~~~~~~~~~~~~
+
+* A broker outage — even one that lasts for minutes or spans a Pulsar
+  restart — does not lose a status update. The terminal state sits on
+  disk until the broker is reachable again.
+* The postprocess thread cannot be terminated by a publish failure.
+* If the broker eventually has to be replaced or wiped, you can simply
+  delete the affected outbox directories *after* you accept that those
+  updates are lost — no other Pulsar state needs touching.
+
+Configuration
+~~~~~~~~~~~~~
+
+* ``persistence_directory`` (yaml, default ``files/persisted_data``) —
+  where the outbox lives. **Required** for at-least-once semantics. If
+  set to ``__none__`` the outbox is disabled and the legacy synchronous
+  publish path is used; do not run production this way.
+* ``status_outbox_drain_interval`` (yaml, default ``5.0`` seconds) — how
+  often the daemon thread retries pending entries when no immediate
+  wakeup has fired.
+
+Monitoring
+~~~~~~~~~~
+
+* The directory size of ``<persistence_directory>/*-status-outbox*/`` is
+  the natural backpressure signal. Steady state should be 0 entries.
+  Sustained growth means the broker (or Galaxy's consumer) is
+  unreachable, not that Pulsar is broken.
+* The log line ``Outbox <dir> has N pending messages to retry`` fires on
+  startup whenever the previous run left a backlog — alert on it if N
+  is non-zero for more than a few drain intervals.
+
+------------------------------------------------------------------------
+3. AMQP durability defenses
+------------------------------------------------------------------------
+
+When Pulsar talks to RabbitMQ:
+
+* ``amqp_durable: true`` (off by default) declares the ``pulsar``
+  exchange and every per-name queue with ``durable=true``, and stamps
+  publishes with ``delivery_mode=2`` (persistent). With this enabled,
+  setup, kill, and status-update messages survive a RabbitMQ restart.
+  The default is ``false`` so existing deployments with non-durable
+  queues keep working — RabbitMQ refuses to redeclare an existing queue
+  with mismatched durability, so flipping this on a live deployment
+  requires deleting the affected queues first or migrating to a fresh
+  broker. The outbox already covers the publisher-side leak (LP1)
+  regardless of this setting; durable queues are an extra defense for
+  the *broker-restart* case specifically.
+* ``amqp_publish_retry: true`` enables kombu's connection-retry policy.
+  When set, pulsar fills in bounded defaults (``max_retries: 5``,
+  ``interval_start: 1``, ``interval_step: 2``, ``interval_max: 30``) so a
+  single transient hiccup is absorbed in-band without round-tripping
+  through the outbox drain loop.
+* ``amqp_acknowledge: true`` (off by default) layers an additional
+  publisher-confirms protocol on top, with its own UUID store under
+  ``<persistence_directory>/amqp_ack-<manager>/``. This is independent of
+  the outbox; both can be enabled together for defense-in-depth.
+
+.. note::
+
+   To enable durable queues on an existing deployment, drain or delete
+   the existing ``pulsar__*`` queues (e.g. ``rabbitmqctl delete_queue
+   pulsar__setup`` for each one) before flipping
+   ``amqp_durable: true``. On a fresh install you can simply set the
+   flag from the start.
+
+------------------------------------------------------------------------
+4. pulsar-relay durability defenses
+------------------------------------------------------------------------
+
+Relay uses HTTP long-polling with a per-topic *cursor* (``last_message_id``)
+that the consumer advances as it reads messages. Without persistence the
+cursor would reset on every restart, silently skipping any setup or
+status_update messages published while the consumer was down.
+
+Pulsar persists the cursor at:
+
+::
+
+    <persistence_directory>/<manager>-relay-cursor.json
+
+written atomically (rename-temp) on every advance, loaded on startup. The
+Galaxy-side ``RelayClientManager`` accepts a ``relay_cursor_path`` keyword
+to do the same on the receiver side.
+
+Galaxy job handlers run as separate processes — each one polls the relay
+independently and tracks its own cursor — so ``RelayClientManager``
+expands the operator-supplied path with a **stable, per-handler
+identifier** before passing it to the transport. The suffix is resolved
+in this order:
+
+1. ``relay_handler_id`` constructor kwarg (typically
+   ``app.config.server_name`` from the Galaxy runner — stable across
+   restarts).
+2. ``GALAXY_SERVER_NAME`` environment variable (Galaxy's standard
+   handler tag, set by the launcher).
+3. ``pidNNN`` as a last resort, with a startup ``WARNING`` log: PID is
+   unique per process but changes on every restart, so the persisted
+   cursor would not be picked up by the next run and the F4 guarantee
+   is degraded to "no Galaxy-side cursor persistence."
+
+A shared file would suffer last-writer-wins corruption when two handlers
+persist concurrently and could silently rewind another handler's
+progress, which is why the suffix is mandatory whenever
+``relay_cursor_path`` is set.
+
+------------------------------------------------------------------------
+5. Setup-message idempotency
+------------------------------------------------------------------------
+
+Setup messages can be redelivered: if Pulsar SIGKILLs after consuming a
+setup but before AMQP records the ack, the broker will redeliver to the
+next consumer. ``submit_job`` short-circuits the redelivery to a no-op
+**only when the prior run can finish on its own**:
+
+* the job has reached a terminal status (``final_status`` metadata
+  exists), or
+* the job is still tracked by ``active_jobs`` and ``recover_active_jobs``
+  will resume it on next get_status().
+
+If the prior run crashed *between* persisting ``launch_config`` and
+activating the job — a narrow window — there is no recovery hook, so the
+redelivered setup drives a fresh ``preprocess_and_launch`` instead of
+silently dropping the work.
+
+This is invisible to admins under normal operation; it surfaces in logs
+as ``Ignoring duplicate setup message for job_id <id>``.
+
+------------------------------------------------------------------------
+6. Active-job recovery on restart
+------------------------------------------------------------------------
+
+Pulsar's stateful manager keeps two persistent indices under
+``persistence_directory``:
+
+::
+
+    <persistence_directory>/<manager>-active-jobs/
+    <persistence_directory>/<manager>-preprocessing-jobs/
+
+Each file is a job_id; its existence means the job was active when the
+process last ran. On startup ``recover_active_jobs`` walks both
+directories and:
+
+1. for jobs in ``-preprocessing-jobs/``, re-reads ``launch_config`` and
+   re-launches the preprocessing thread;
+2. for jobs in ``-active-jobs/``, calls the manager's
+   ``_recover_active_job`` method (e.g. requeue from the persisted
+   command line, or re-attach to the DRMAA external id).
+
+Two outcomes you should be aware of:
+
+* If recovery cannot reattach to the job (e.g. the DRMAA external id is
+  no longer known) Pulsar publishes a single ``lost`` status update and
+  removes the active-jobs entry. From Galaxy's perspective the job ended
+  with ``lost``; nothing is silently abandoned.
+* The ``queued_python`` runner — the one used in the resilience test
+  framework — runs jobs as direct Pulsar subprocesses and cannot survive
+  a Pulsar SIGKILL. Such a restart yields ``lost``, not ``complete``,
+  for the in-flight job. **Use a real DRM (DRMAA/Slurm/Kubernetes) for
+  workloads that need to survive Pulsar restarts.**
+
+------------------------------------------------------------------------
+7. Staging error handling (file transfer to/from Galaxy)
+------------------------------------------------------------------------
+
+Pulsar pulls inputs from Galaxy and pushes outputs back over HTTP. Both
+sides go through the ``RetryActionExecutor`` with a
+``should_retry=is_transient_http_error`` predicate
+(``pulsar/client/transport/transient.py``):
+
+* **Transient errors are retried** — 408, 425, 429, 500, 502, 503, 504,
+  connection errors, and timeouts. Default policy retries indefinitely
+  with bounded backoff (start 2 s, step 2 s, max 30 s).
+* **Permanent errors fail the job** — any 4xx other than the rate-limit
+  set above (404, 403, 400, etc.) immediately marks the job ``failed``
+  with the upstream HTTP body in the captured stderr.
+
+This is why a misconfigured Galaxy URL or a deleted dataset surfaces as a
+single fast ``failed``, while a Galaxy restart or a load-balancer hiccup
+recovers transparently after retries.
+
+Configuration knobs (per-manager YAML):
+
+* ``preprocess_action_max_retries`` / ``postprocess_action_max_retries``
+* ``preprocess_action_interval_start`` / ``_step`` / ``_max``
+* ``preprocess_action_should_retry`` (advanced — replaces the default
+  predicate; only do this if you understand which errors are safe to
+  retry in your environment)
+
+------------------------------------------------------------------------
+8. Status-update ordering guarantees
+------------------------------------------------------------------------
+
+Pulsar (sender side)
+~~~~~~~~~~~~~~~~~~~~
+
+Within one Pulsar instance, status updates for a given job are emitted in
+strict lifecycle order, and the outbox drains them in strict FIFO via the
+monotonic seq prefix described above. That ordering is preserved across
+process restarts: pending entries from the previous run drain before any
+new entries from the new run, because their seqs are smaller.
+
+Galaxy (receiver side)
+~~~~~~~~~~~~~~~~~~~~~~
+
+The broker can re-deliver a message whose ack was lost, and the relay
+backend can replay messages a client claims it has not yet seen. Galaxy
+must therefore enforce two invariants:
+
+1. **Dedupe by** ``(job_id, status)``. The pulsar status-update payload
+   for a given (job_id, status) is idempotent in content, so a duplicate
+   is safe to drop.
+2. **A terminal status is a sink.** Once Galaxy has recorded a terminal
+   status for a job, drop any further updates for that job — both
+   non-terminal regressions (a stale ``running`` arriving late) and
+   conflicting later terminals (a delayed ``failed`` after ``complete``).
+
+The reference implementation of these rules is the
+``StatusRecorder`` class in
+``test/resilience/mock_galaxy/recorder.py``; treat it as the canonical
+behavior to mirror in production Galaxy.
+
+Explicit Galaxy-side resets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Operators (or Galaxy itself) sometimes need to reset a job's state — for
+example resubmitting after a ``cancel`` or restarting a ``failed`` job.
+Such a transition deliberately re-enters a non-terminal state from a
+terminal one and would be rejected by the regression guard above.
+
+The agreed escape hatch is a ``_galaxy_reset_token`` field in the status
+payload (any truthy value, intended to be unique per reset event):
+
+* the receiver treats the update as the start of a fresh epoch for that
+  ``job_id``;
+* prior transitions are forgotten for the *current-state* view of the
+  job;
+* the audit log retains the full observed history.
+
+Pulsar itself does not emit reset tokens. Galaxy is the authority on what
+constitutes a reset.
+
+------------------------------------------------------------------------
+9. Failure-mode → outcome cheat sheet
+------------------------------------------------------------------------
+
+=================================================  ====================================  ===========================================================================
+Failure                                            Recovery mechanism                    What you see in logs / on disk
+=================================================  ====================================  ===========================================================================
+Broker brief disconnect                            kombu/relay reconnect loop            ``recoverable_exceptions`` log; queue drains on reconnect
+Broker down for minutes                            outbox holds terminal status          outbox dir size > 0 until reconnect; warns on next drain
+RabbitMQ crash + restart (``amqp_durable: true``)  durable queues + delivery_mode=2      no Pulsar-side log; messages restored from broker disk
+RabbitMQ crash + restart (default, non-durable)    outbox replays publisher side         in-flight inbound msgs are lost broker-side; outbound resume from outbox
+Pulsar SIGKILL during preprocessing                ``-preprocessing-jobs/`` recovery     ``Failed to find launch parameters`` warning if missing
+Pulsar SIGKILL during running (DRM)                ``-active-jobs/`` recovery            re-attach via runner; no status change visible to Galaxy
+Pulsar SIGKILL during running (queued_python)      job dies, ``lost`` reported           one ``lost`` status update; admin should know this runner
+Pulsar SIGKILL after final_status, before publish  outbox replay on restart              ``Outbox ... has N pending messages to retry`` warning
+Galaxy 5xx during input download                   transient retry                       ``Failed to execute action[...], retrying`` info logs
+Galaxy 4xx during input download                   fail-fast, ``failed`` reported        single ``failed`` status; HTTP body in job stderr
+Galaxy unreachable during status_update            outbox holds, broker buffers          same as broker outage from Pulsar's perspective
+Both Pulsar and broker restart together            outbox (+ durable queues if enabled)  everything resumes once both are up; ordering preserved
+=================================================  ====================================  ===========================================================================
+
+------------------------------------------------------------------------
+10. Verifying resilience in your environment
+------------------------------------------------------------------------
+
+The repo includes a docker-compose-based resilience suite under
+``test/resilience/`` that exercises every failure mode above end-to-end
+against a real RabbitMQ, ``ghcr.io/mvdbeek/pulsar-relay``, and toxiproxy
+fault injection. Before relying on this guide in production, run::
+
+    docker compose -f test/resilience/docker-compose.yml up -d --build
+    pytest test/resilience -v
+
+48 scenarios pass across the ``amqp``, ``amqp_ack``, and ``relay`` modes.
+See ``test/resilience/README.md`` for layout, what each scenario asserts,
+and how to add new ones (e.g. for a custom runner).
+
+------------------------------------------------------------------------
+11. Tunables, defaults, and where they live
+------------------------------------------------------------------------
+
+================================  =======================================  ====================================================================
+Setting                           Default                                  Effect
+================================  =======================================  ====================================================================
+``persistence_directory``         ``files/persisted_data``                 outbox + active-jobs + relay cursor live here
+``status_outbox_drain_interval``  ``5.0`` (seconds)                        background outbox retry cadence
+``amqp_durable``                  ``false``                                opt-in: durable queues + delivery_mode=2 (broker-restart resilience)
+``amqp_publish_retry``            unset (off)                              kombu publish retry; defaults bounded when on
+``amqp_acknowledge``              ``false``                                additional publisher-confirms layer
+``amqp_consumer_timeout``         ``0.2``                                  consumer drain_events timeout (responsiveness)
+``message_queue_publish``         ``true``                                 disable to make Pulsar receive-only
+``message_queue_consume``         ``true``                                 disable to make Pulsar send-only
+``ensure_cleanup``                ``false``                                join consumer threads on shutdown
+================================  =======================================  ====================================================================
+
+For deep debugging set ``logging.loggers.pulsar.level: DEBUG`` in
+``server.ini`` (the resilience tests run with INFO and grep for the bind
+and outbox log lines as readiness signals — the same pattern works for
+production health checks).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents:
    job_managers
    containers
    galaxy_conf
+   error_handling
    scripts
    conduct
    contributing

--- a/mypy.ini
+++ b/mypy.ini
@@ -56,3 +56,18 @@ ignore_missing_imports = True
 
 [mypy-webtest.*]
 ignore_missing_imports = True
+
+[mypy-fastapi.*]
+ignore_missing_imports = True
+
+[mypy-uvicorn.*]
+ignore_missing_imports = True
+
+# The resilience suite uses sibling imports rooted at test/resilience/ that
+# only resolve when pytest's rootdir is that directory; mypy invoked from
+# the project root cannot find them.
+[mypy-harness.*]
+ignore_missing_imports = True
+
+[mypy-recorder]
+ignore_missing_imports = True

--- a/pulsar/client/amqp_exchange.py
+++ b/pulsar/client/amqp_exchange.py
@@ -74,6 +74,7 @@ class PulsarExchange:
         publish_uuid_store=None,
         consume_uuid_store=None,
         republish_time=DEFAULT_REPUBLISH_TIME,
+        durable=False,
     ):
         """
         """
@@ -99,7 +100,10 @@ class PulsarExchange:
         self.__manager_name = manager_name
         self.__amqp_key_prefix = amqp_key_prefix
         self.__connect_ssl = connect_ssl
-        self.__exchange = kombu.Exchange(DEFAULT_EXCHANGE_NAME, DEFAULT_EXCHANGE_TYPE)
+        self.__durable = bool(durable)
+        self.__exchange = kombu.Exchange(
+            DEFAULT_EXCHANGE_NAME, DEFAULT_EXCHANGE_TYPE, durable=self.__durable,
+        )
         self.__timeout = timeout
         self.__republish_time = republish_time
         # Be sure to log message publishing failures.
@@ -301,10 +305,12 @@ class PulsarExchange:
                 return PulsarExchange.__publish_errback(exc, interval, publish_log_prefix)
             publish_kwds["retry_policy"]["errback"] = errback
         else:
-            publish_kwds = self.__publish_kwds
+            publish_kwds = dict(self.__publish_kwds)
         if self.__kombu_version < MINIMUM_KOMBU_VERSION_PUBLISH_TIMEOUT:
             log.warning(f"kombu version {kombu.__version__} does not support timeout argument to publish. Consider updating to 5.2.0 or newer")
             publish_kwds.pop("timeout", None)
+        if self.__durable and "delivery_mode" not in publish_kwds:
+            publish_kwds["delivery_mode"] = 2
         return publish_kwds
 
     def __publish_log_prefex(self, transaction_uuid=None):
@@ -320,7 +326,12 @@ class PulsarExchange:
 
     def __queue(self, name):
         queue_name = self.__queue_name(name)
-        queue = kombu.Queue(queue_name, self.__exchange, routing_key=queue_name)
+        queue = kombu.Queue(
+            queue_name,
+            self.__exchange,
+            routing_key=queue_name,
+            durable=self.__durable,
+        )
         return queue
 
     def __queue_name(self, name):

--- a/pulsar/client/amqp_exchange_factory.py
+++ b/pulsar/client/amqp_exchange_factory.py
@@ -13,6 +13,10 @@ def get_exchange(url, manager_name, params):
         connect_ssl=connect_ssl,
         publish_kwds=parse_amqp_publish_kwds(params),
     )
+    durable_param = params.get("amqp_durable", False)
+    if isinstance(durable_param, str):
+        durable_param = durable_param.strip().lower() in ("true", "1", "yes", "on")
+    exchange_kwds["durable"] = bool(durable_param)
     if params.get('amqp_acknowledge', False):
         exchange_kwds.update(parse_ack_kwds(params, manager_name))
     timeout = params.get('amqp_consumer_timeout', False)
@@ -34,6 +38,14 @@ def parse_amqp_connect_ssl_params(params):
     return ssl_params
 
 
+DEFAULT_PUBLISH_RETRY_POLICY = {
+    "max_retries": 5,
+    "interval_start": 1,
+    "interval_step": 2,
+    "interval_max": 30,
+}
+
+
 def parse_amqp_publish_kwds(params):
     all_publish_params = filter_destination_params(params, "amqp_publish_")
     retry_policy_params = {}
@@ -42,8 +54,16 @@ def parse_amqp_publish_kwds(params):
             value = all_publish_params[key]
             retry_policy_params[key[len("retry_"):]] = value
             del all_publish_params[key]
+    if all_publish_params.get("retry"):
+        # Defense-in-depth: a single broker hiccup at the wrong moment must not
+        # drop a status_update. Defaults are bounded so we don't block the
+        # postprocess thread indefinitely; the persistent outbox handles the
+        # case where retries are exhausted.
+        for key, default in DEFAULT_PUBLISH_RETRY_POLICY.items():
+            retry_policy_params.setdefault(key, default)
     if retry_policy_params:
         all_publish_params["retry_policy"] = retry_policy_params
+        all_publish_params.setdefault("retry", True)
     return all_publish_params
 
 

--- a/pulsar/client/manager.py
+++ b/pulsar/client/manager.py
@@ -6,6 +6,7 @@ specific actions.
 """
 
 import functools
+import os
 import threading
 from logging import getLogger
 from os import getenv
@@ -52,6 +53,45 @@ if TYPE_CHECKING:
 log = getLogger(__name__)
 
 DEFAULT_TRANSFER_THREADS = 2
+
+
+def _per_handler_cursor_path(
+    base_path: Optional[str],
+    handler_id: Optional[str] = None,
+) -> Optional[str]:
+    """Insert a stable per-handler suffix before the file extension.
+
+    Galaxy job handlers run as separate processes, each polling the relay
+    independently with its own cursor. Sharing one file would let
+    concurrent ``os.replace`` writes drop another handler's progress, but
+    the suffix must also be **stable across restarts** — otherwise the
+    cursor is read once on first start and then orphaned, defeating the
+    point of persisting it.
+
+    Resolution order for the suffix:
+
+    1. ``handler_id`` argument (typically ``app.config.server_name`` from
+       the caller — stable across restarts).
+    2. ``GALAXY_SERVER_NAME`` env var (Galaxy's standard handler tag).
+    3. ``os.getpid()`` as a last resort, with a warning: PID is unique
+       per process but changes on every restart, so the persisted cursor
+       will not be loaded by the next run.
+    """
+    if not base_path:
+        return base_path
+    suffix = handler_id or os.environ.get("GALAXY_SERVER_NAME")
+    if not suffix:
+        suffix = f"pid{os.getpid()}"
+        log.warning(
+            "relay_cursor_path is set but no stable handler id was supplied "
+            "(neither relay_handler_id kwarg nor GALAXY_SERVER_NAME env). "
+            "Falling back to %s; this cursor will not be picked up after a "
+            "process restart, so status updates published while the handler "
+            "was down may be skipped.",
+            suffix,
+        )
+    root, ext = os.path.splitext(base_path)
+    return f"{root}-{suffix}{ext}"
 
 
 class ClientManagerInterface(Protocol):
@@ -263,14 +303,34 @@ class RelayClientManager(BaseRemoteConfiguredJobClientManager):
     """
     status_cache: Dict[str, Any]
 
-    def __init__(self, relay_url: str, relay_username: str, relay_password: str, relay_topic_prefix: str = '', **kwds: Dict[str, Any]):
+    def __init__(
+        self,
+        relay_url: str,
+        relay_username: str,
+        relay_password: str,
+        relay_topic_prefix: str = '',
+        relay_cursor_path: Optional[str] = None,
+        relay_handler_id: Optional[str] = None,
+        **kwds: Dict[str, Any],
+    ):
         super().__init__(**kwds)
 
         if not relay_url:
             raise Exception("relay_url is required for RelayClientManager")
 
-        # Initialize relay transport
-        self.relay_transport = RelayTransport(relay_url, relay_username, relay_password)
+        # Initialize relay transport. ``relay_cursor_path`` persists the long-poll
+        # cursor across Galaxy restarts so we don't silently skip messages
+        # published by Pulsar while Galaxy was down. Galaxy job handlers run as
+        # separate processes — each one polls the relay independently and so
+        # tracks its own cursor — so we expand the operator-supplied path with
+        # a stable per-handler suffix (``relay_handler_id`` or
+        # ``GALAXY_SERVER_NAME``) to give every handler its own file. A shared
+        # cursor would suffer last-writer-wins corruption when handlers persist
+        # concurrently and could silently rewind another handler's progress.
+        self.relay_transport = RelayTransport(
+            relay_url, relay_username, relay_password,
+            cursor_path=_per_handler_cursor_path(relay_cursor_path, relay_handler_id),
+        )
         self.relay_topic_prefix = relay_topic_prefix
         self.status_cache = {}
         self.callback_lock = threading.Lock()

--- a/pulsar/client/transport/relay.py
+++ b/pulsar/client/transport/relay.py
@@ -4,7 +4,10 @@ HTTP transport for communicating with pulsar-relay.
 Provides methods for posting messages, long-polling, and managing
 authentication with the relay server.
 """
+import json
 import logging
+import os
+import threading
 import time
 from typing import Any, Callable, Dict, List, Optional
 
@@ -29,7 +32,14 @@ class RelayTransport:
     - Automatic authentication and retry
     """
 
-    def __init__(self, relay_url: str, username: str, password: str, timeout: int = 30):
+    def __init__(
+        self,
+        relay_url: str,
+        username: str,
+        password: str,
+        timeout: int = 30,
+        cursor_path: Optional[str] = None,
+    ):
         """Initialize the relay transport.
 
         Args:
@@ -37,12 +47,23 @@ class RelayTransport:
             username: Username for authentication
             password: Password for authentication
             timeout: Default request timeout in seconds
+            cursor_path: Optional path to a JSON file used to persist the
+                per-topic ``last_message_id`` cursor across process restarts.
+                If provided, the file is loaded at startup and rewritten
+                atomically every time the cursor advances. Without this,
+                a Pulsar (or Galaxy) restart loses its place in each topic
+                and any messages published while the consumer was down are
+                silently skipped.
         """
         self.relay_url = relay_url.rstrip('/')
         self.auth_manager = RelayAuthManager(relay_url, username, password)
         self.timeout = timeout
         self.session = requests.Session()
-        self._last_message_ids: Dict[str, str] = {}  # Track last message ID per topic
+        self._last_message_ids: Dict[str, str] = {}
+        self._cursor_path = cursor_path
+        self._cursor_lock = threading.Lock()
+        if self._cursor_path:
+            self._load_cursor()
 
     def _get_headers(self) -> Dict[str, str]:
         """Get HTTP headers including authentication token.
@@ -361,7 +382,10 @@ class RelayTransport:
             topic: Topic name
             message_id: Message ID to set as the last seen message
         """
-        self._last_message_ids[topic] = message_id
+        with self._cursor_lock:
+            self._last_message_ids[topic] = message_id
+            if self._cursor_path:
+                self._persist_cursor_locked()
 
     def clear_tracked_message_ids(self, topic: Optional[str] = None) -> None:
         """Clear tracked message IDs.
@@ -370,13 +394,61 @@ class RelayTransport:
             topic: If provided, clears only the specified topic.
                   If None, clears all tracked message IDs.
         """
-        if topic is not None:
-            if topic in self._last_message_ids:
-                del self._last_message_ids[topic]
-                log.debug("Cleared tracked message ID for topic '%s'", topic)
-        else:
-            self._last_message_ids.clear()
-            log.debug("Cleared all tracked message IDs")
+        with self._cursor_lock:
+            if topic is not None:
+                if topic in self._last_message_ids:
+                    del self._last_message_ids[topic]
+                    log.debug("Cleared tracked message ID for topic '%s'", topic)
+            else:
+                self._last_message_ids.clear()
+                log.debug("Cleared all tracked message IDs")
+            if self._cursor_path:
+                self._persist_cursor_locked()
+
+    def _load_cursor(self) -> None:
+        cursor_path = self._cursor_path
+        if cursor_path is None:
+            return
+        try:
+            with open(cursor_path) as fh:
+                data = json.load(fh)
+        except FileNotFoundError:
+            return
+        except Exception:
+            log.exception(
+                "Failed to load relay cursor from %s, starting from a clean slate",
+                cursor_path,
+            )
+            return
+        if isinstance(data, dict):
+            self._last_message_ids = {str(k): str(v) for k, v in data.items() if v}
+            log.info(
+                "Resumed relay cursors from %s with %d tracked topic(s)",
+                cursor_path, len(self._last_message_ids),
+            )
+
+    def _persist_cursor_locked(self) -> None:
+        path = self._cursor_path
+        if path is None:
+            return
+        directory = os.path.dirname(path)
+        if directory:
+            try:
+                os.makedirs(directory, exist_ok=True)
+            except Exception:
+                log.exception("Failed to create relay cursor directory %s", directory)
+                return
+        tmp_path = path + ".tmp"
+        try:
+            with open(tmp_path, "w") as fh:
+                json.dump(self._last_message_ids, fh)
+            os.replace(tmp_path, path)
+        except Exception:
+            log.exception("Failed to persist relay cursor to %s", path)
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
     def close(self):
         """Close the transport and cleanup resources."""

--- a/pulsar/core.py
+++ b/pulsar/core.py
@@ -166,6 +166,12 @@ class PulsarApp:
     def __setup_dependency_manager(self, conf):
         default_tool_dependency_dir = "dependencies"
         resolvers_config_file = os.path.join(self.config_dir, conf.get("dependency_resolvers_config_file", "dependency_resolvers_conf.xml"))
+        # Auto-init / auto-install of conda is opt-in. The first-startup
+        # download of miniconda blocks the manager bind for tens of seconds
+        # (sometimes minutes) on a fresh runner; admins who want it should
+        # set conda_auto_init / conda_auto_install explicitly. Closes #415.
+        conf.setdefault("conda_auto_init", False)
+        conf.setdefault("conda_auto_install", False)
         self.dependency_manager = build_dependency_manager(
             app_config_dict=conf,
             conf_file=resolvers_config_file,

--- a/pulsar/manager_endpoint_util.py
+++ b/pulsar/manager_endpoint_util.py
@@ -14,6 +14,7 @@ from pulsar.managers import (
     status,
 )
 from pulsar.managers.staging import realized_dynamic_file_sources
+from pulsar.managers.stateful import ACTIVE_STATUS_PREPROCESSING
 
 log = logging.getLogger(__name__)
 
@@ -72,6 +73,13 @@ def submit_job(manager, job_config):
     """
     # job_config is raw dictionary from JSON (from MQ or HTTP endpoint).
     job_id = job_config.get('job_id')
+    if job_id and _is_duplicate_setup(manager, job_id):
+        log.info(
+            "Ignoring duplicate setup message for job_id %s (launch_config already "
+            "persisted; this is most likely an MQ redelivery after Pulsar restart).",
+            job_id,
+        )
+        return
     try:
         command_line = job_config.get('command_line')
 
@@ -132,3 +140,40 @@ def setup_job(manager, job_id, tool_id, tool_version):
         tool_id=tool_id,
         tool_version=tool_version
     )
+
+
+def _is_duplicate_setup(manager, job_id: str) -> bool:
+    """Detect a redelivered setup message for a job that has already been launched.
+
+    Setup messages can be redelivered when Pulsar restarts after acking an AMQP
+    setup but before the broker recorded the ack, or any time the consumer
+    crashes mid-processing.
+
+    We only short-circuit when the job is in a state recovery can finish on
+    its own — i.e. either the job has reached a terminal status, or it is
+    still tracked by ``active_jobs`` and ``recover_active_jobs`` will resume
+    it. If the prior run crashed *between* persisting ``launch_config`` and
+    activating the job there is no recovery hook, so we let the redelivered
+    message drive a fresh ``preprocess_and_launch``.
+    """
+    try:
+        job_directory = manager.job_directory(job_id)
+    except (TypeError, ValueError, OSError):
+        # Malformed job_id from a redelivered or corrupt message body.
+        return False
+    if not job_directory.exists():
+        return False
+    if job_directory.has_metadata("final_status"):
+        return True
+    active_jobs = manager.active_jobs
+    try:
+        if job_id in set(active_jobs.active_job_ids()):
+            return True
+        if job_id in set(active_jobs.active_job_ids(active_status=ACTIVE_STATUS_PREPROCESSING)):
+            return True
+    except OSError:
+        # active_job_ids() reads filesystem state; if the persistence
+        # directory is unreadable we can't tell if it's a duplicate, so
+        # let preprocess_and_launch run again.
+        pass
+    return False

--- a/pulsar/managers/__init__.py
+++ b/pulsar/managers/__init__.py
@@ -144,5 +144,9 @@ class ManagerProxy:
     def object_store(self):
         return self._proxied_manager.object_store
 
+    @property
+    def persistence_directory(self):
+        return self._proxied_manager.persistence_directory
+
     def __str__(self):
         return "ManagerProxy[manager=%s]" % str(self._proxied_manager)

--- a/pulsar/messaging/__init__.py
+++ b/pulsar/messaging/__init__.py
@@ -41,9 +41,15 @@ class QueueState:
     def __init__(self):
         self.active = True
         self.threads = []
+        self.outboxes = []
 
     def deactivate(self):
         self.active = False
+        for outbox in self.outboxes:
+            try:
+                outbox.stop(timeout=2.0)
+            except OSError:
+                log.exception("Failed to stop status update outbox")
 
     def __nonzero__(self):
         return self.active

--- a/pulsar/messaging/bind_amqp.py
+++ b/pulsar/messaging/bind_amqp.py
@@ -10,6 +10,8 @@ from galaxy.util import (
 from pulsar import manager_endpoint_util
 from pulsar.client import amqp_exchange_factory
 
+from .outbox import build_status_outbox
+
 log = logging.getLogger(__name__)
 
 
@@ -63,20 +65,33 @@ def bind_manager_to_queue(manager, queue_state, connection_string, conf):
             status_update_ack_thread = start_status_update_ack_consumer(pulsar_exchange, functools.partial(drain, None, "status_update_ack"))
             getattr(queue_state, 'threads', []).append(status_update_ack_thread)
 
-    # TODO: Think through job recovery, jobs shouldn't complete until after bind
-    # has occurred.
-    def bind_on_status_change(new_status, job_id):
-        job_id = job_id or 'unknown'
-        try:
-            message = "Publishing Pulsar state change with status {} for job_id {}".format(new_status, job_id)
-            log.debug(message)
-            payload = manager_endpoint_util.full_status(manager, new_status, job_id)
-            pulsar_exchange.publish("status_update", payload)
-        except Exception:
-            log.exception("Failure to publish Pulsar state change for job_id %s." % job_id)
-            raise
-
     if conf.get("message_queue_publish", True):
+        outbox = build_status_outbox(
+            manager,
+            conf,
+            publish_fn=lambda payload: pulsar_exchange.publish("status_update", payload),
+        )
+        if outbox is not None:
+            queue_state.outboxes.append(outbox)
+
+        def bind_on_status_change(new_status, job_id):
+            job_id = job_id or 'unknown'
+            log.debug(
+                "Publishing Pulsar state change with status %s for job_id %s",
+                new_status, job_id,
+            )
+            payload = manager_endpoint_util.full_status(manager, new_status, job_id)
+            if outbox is not None:
+                outbox.enqueue(payload)
+                return
+            try:
+                pulsar_exchange.publish("status_update", payload)
+            except pulsar_exchange.recoverable_exceptions:
+                log.exception(
+                    "Failure to publish Pulsar state change for job_id %s "
+                    "(no outbox configured; status update may be lost).", job_id,
+                )
+
         manager.set_state_change_callback(bind_on_status_change)
 
 

--- a/pulsar/messaging/bind_relay.py
+++ b/pulsar/messaging/bind_relay.py
@@ -6,14 +6,29 @@ requests, kill) and publish status updates.
 """
 import functools
 import logging
+import os
 import threading
 import time
+from typing import Optional
+
+import requests
 
 from pulsar import manager_endpoint_util
-from pulsar.client.transport.relay import RelayTransport
+from pulsar.client.transport.relay import (
+    RelayTransport,
+    RelayTransportError,
+)
+from .outbox import build_status_outbox
 from .relay_state import RelayState
 
 log = logging.getLogger(__name__)
+
+
+def _server_cursor_path(manager) -> Optional[str]:
+    persistence_directory = manager.persistence_directory
+    if not persistence_directory:
+        return None
+    return os.path.join(persistence_directory, "%s-relay-cursor.json" % manager.name)
 
 
 def bind_manager_to_relay(manager, relay_state: RelayState, relay_url, conf):
@@ -37,8 +52,12 @@ def bind_manager_to_relay(manager, relay_state: RelayState, relay_url, conf):
     # Extract optional relay topic prefix
     relay_topic_prefix = conf.get('relay_topic_prefix', '')
 
-    # Create relay transport
-    relay_transport = RelayTransport(relay_url, username, password)
+    # Create relay transport with a per-manager persistent cursor so a Pulsar
+    # restart resumes the long-poll exactly where it left off, rather than
+    # silently skipping any setup/kill messages published while it was down.
+    relay_transport = RelayTransport(
+        relay_url, username, password, cursor_path=_server_cursor_path(manager),
+    )
 
     # Define message handlers
     process_setup_messages = functools.partial(__process_setup_message, manager)
@@ -73,16 +92,33 @@ def bind_manager_to_relay(manager, relay_state: RelayState, relay_url, conf):
     if conf.get("message_queue_publish", True):
         log.info("Binding status change callback for manager '%s'", manager_name)
 
+        outbox = build_status_outbox(
+            manager,
+            conf,
+            publish_fn=lambda payload: relay_transport.post_message(status_update_topic, payload),
+            suffix="relay-status-outbox",
+        )
+        if outbox is not None:
+            relay_state.outboxes.append(outbox)
+
         def bind_on_status_change(new_status, job_id):
             job_id = job_id or 'unknown'
+            log.debug(
+                "Publishing Pulsar state change with status %s for job_id %s via relay",
+                new_status, job_id,
+            )
+            payload = manager_endpoint_util.full_status(manager, new_status, job_id)
+            if outbox is not None:
+                outbox.enqueue(payload)
+                return
             try:
-                message = "Publishing Pulsar state change with status %s for job_id %s via relay"
-                log.debug(message, new_status, job_id)
-                payload = manager_endpoint_util.full_status(manager, new_status, job_id)
                 relay_transport.post_message(status_update_topic, payload)
-            except Exception:
-                log.exception("Failure to publish Pulsar state change for job_id %s via relay." % job_id)
-                raise
+            except (RelayTransportError, requests.RequestException):
+                log.exception(
+                    "Failure to publish Pulsar state change for job_id %s via "
+                    "relay (no outbox configured; status update may be lost).",
+                    job_id,
+                )
 
         manager.set_state_change_callback(bind_on_status_change)
 

--- a/pulsar/messaging/outbox.py
+++ b/pulsar/messaging/outbox.py
@@ -1,0 +1,252 @@
+"""Persistent outbox for status update messages.
+
+Provides at-least-once delivery of status updates from Pulsar to Galaxy,
+independent of broker durability. Each payload is written to disk before
+publish is attempted; the on-disk file is removed only after the publish
+callable returns successfully. A daemon thread retries any messages that
+remain on disk.
+
+This addresses the most critical loss path in the job lifecycle: when the
+AMQP broker (or pulsar-relay) is unreachable at the moment a job reaches a
+terminal state, the synchronous publish in the postprocess thread would
+otherwise raise, terminating the thread, and the on-disk ``final_status``
+would never be reported back to Galaxy.
+"""
+import json
+import logging
+import os
+import threading
+import uuid
+from time import time
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Optional,
+)
+
+log = logging.getLogger(__name__)
+
+DEFAULT_DRAIN_INTERVAL = 5.0
+ENTRY_SUFFIX = ".json"
+TMP_SUFFIX = ".tmp"
+SEQ_WIDTH = 20  # zero-padded so lexical sort == numeric sort
+
+
+class StatusUpdateOutbox:
+    """At-least-once persistent outbox for status update messages.
+
+    Entries are written as ``<seq>-<uuid>.json`` where ``seq`` is a
+    monotonic per-outbox counter, so a lexically sorted ``os.listdir`` gives
+    FIFO drain order. This is the in-process ordering guarantee: a single
+    Pulsar instance will never re-order its own emissions for a given job
+    (e.g. ``running`` will not be drained after ``complete``). The receiver
+    is still responsible for collapsing legitimate duplicates and for
+    refusing to regress past a terminal status — see the recorder under
+    ``test/resilience/mock_galaxy/`` for the canonical Galaxy-side pattern.
+    """
+
+    def __init__(
+        self,
+        store_directory: str,
+        publish_fn: Callable[[Dict[str, Any]], Any],
+        drain_interval: float = DEFAULT_DRAIN_INTERVAL,
+    ) -> None:
+        self._store_dir = os.path.abspath(store_directory)
+        os.makedirs(self._store_dir, exist_ok=True)
+        self._publish_fn = publish_fn
+        self._drain_interval = drain_interval
+        self._wakeup = threading.Event()
+        self._stopping = threading.Event()
+        self._lock = threading.Lock()
+        self._thread: Optional[threading.Thread] = None
+        self._seq_lock = threading.Lock()
+        self._next_seq = self._recover_next_seq()
+
+    def _recover_next_seq(self) -> int:
+        max_seq = -1
+        try:
+            for name in os.listdir(self._store_dir):
+                if not name.endswith(ENTRY_SUFFIX):
+                    continue
+                head = name[:-len(ENTRY_SUFFIX)].split("-", 1)[0]
+                try:
+                    n = int(head)
+                except ValueError:
+                    continue
+                if n > max_seq:
+                    max_seq = n
+        except FileNotFoundError:
+            pass
+        return max_seq + 1
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stopping.clear()
+        thread_name = "status-outbox-%s" % os.path.basename(self._store_dir.rstrip(os.sep))
+        self._thread = threading.Thread(target=self._run, name=thread_name, daemon=True)
+        self._thread.start()
+
+    def stop(self, timeout: Optional[float] = None) -> None:
+        self._stopping.set()
+        self._wakeup.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout if timeout is not None else 1.0)
+        # Final drain attempt so an orderly shutdown delivers anything that
+        # was enqueued just before the stop signal. If the publish destination
+        # is unreachable, entries remain on disk and are retried on restart.
+        was_stopping = self._stopping.is_set()
+        self._stopping.clear()
+        try:
+            self.drain_once()
+        except OSError:
+            log.exception("Final drain on outbox stop failed")
+        if was_stopping:
+            self._stopping.set()
+
+    def enqueue(self, payload: Dict[str, Any]) -> None:
+        """Persist payload and trigger an immediate drain pass.
+
+        Never raises. If the publish fails, the payload remains on disk and
+        the drain loop will keep retrying.
+        """
+        message_id = uuid.uuid4().hex
+        with self._seq_lock:
+            seq = self._next_seq
+            self._next_seq += 1
+        filename = self._filename(seq, message_id)
+        path = os.path.join(self._store_dir, filename)
+        tmp_path = path + TMP_SUFFIX
+        try:
+            with open(tmp_path, "w") as fh:
+                json.dump(
+                    {"id": message_id, "seq": seq, "payload": payload, "ts": time()},
+                    fh,
+                )
+            os.replace(tmp_path, path)
+        except OSError:
+            log.exception("Failed to persist status update to outbox %s", self._store_dir)
+            # publish_fn is a user-supplied callback; we deliberately swallow
+            # any error from this best-effort fallback so enqueue() never
+            # raises into the postprocess thread.
+            try:
+                self._publish_fn(payload)
+            except Exception:
+                log.exception("Direct publish failed for unwriteable outbox payload")
+            return
+        self._wakeup.set()
+
+    def drain_once(self) -> int:
+        """Attempt to publish all currently pending messages once.
+
+        Returns the number of messages still pending after the pass.
+        """
+        with self._lock:
+            entries = self._list()
+        for entry in entries:
+            if self._stopping.is_set():
+                break
+            self._try_publish(entry)
+        with self._lock:
+            return len(self._list())
+
+    def pending_count(self) -> int:
+        with self._lock:
+            return len(self._list())
+
+    def _list(self) -> list:
+        try:
+            return sorted(
+                f for f in os.listdir(self._store_dir)
+                if f.endswith(ENTRY_SUFFIX)
+            )
+        except FileNotFoundError:
+            return []
+
+    def _filename(self, seq: int, message_id: str) -> str:
+        return f"{seq:0{SEQ_WIDTH}d}-{message_id}{ENTRY_SUFFIX}"
+
+    def _path(self, message_id: str) -> str:
+        # Legacy helper used only by tests; production paths flow through
+        # _filename() with the monotonic seq prefix.
+        return os.path.join(self._store_dir, message_id + ENTRY_SUFFIX)
+
+    def _try_publish(self, filename: str) -> None:
+        path = os.path.join(self._store_dir, filename)
+        try:
+            with open(path) as fh:
+                record = json.load(fh)
+        except FileNotFoundError:
+            return
+        except (OSError, json.JSONDecodeError):
+            log.exception("Corrupt outbox entry %s, removing", path)
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            return
+        # publish_fn is a user-supplied callback (kombu publish, HTTP POST,
+        # etc.) — its failure modes are not enumerable from here, so we
+        # catch broadly and let the drain loop retry the on-disk entry.
+        try:
+            self._publish_fn(record["payload"])
+        except Exception as exc:
+            log.warning(
+                "Outbox publish failed for %s; will retry on next drain pass: %s",
+                filename, exc,
+            )
+            return
+        try:
+            os.unlink(path)
+        except OSError:
+            log.exception("Failed to remove outbox entry after successful publish: %s", path)
+
+    def _run(self) -> None:
+        log.info("Status update outbox drain thread starting (dir=%s)", self._store_dir)
+        try:
+            remaining = self.drain_once()
+            if remaining:
+                log.info("Outbox %s has %d pending messages to retry", self._store_dir, remaining)
+        except OSError:
+            log.exception("Initial outbox drain failed")
+        while not self._stopping.is_set():
+            self._wakeup.wait(timeout=self._drain_interval)
+            self._wakeup.clear()
+            if self._stopping.is_set():
+                break
+            try:
+                self.drain_once()
+            except OSError:
+                log.exception("Outbox drain pass failed")
+        log.info("Status update outbox drain thread exiting (dir=%s)", self._store_dir)
+
+
+def build_status_outbox(
+    manager: Any,
+    conf: Dict[str, Any],
+    publish_fn: Callable[[Dict[str, Any]], Any],
+    suffix: str = "status-outbox",
+) -> Optional["StatusUpdateOutbox"]:
+    """Construct a StatusUpdateOutbox for the given manager, or None if persistence
+    is disabled.
+
+    The outbox is rooted at ``<persistence_directory>/<manager_name>-<suffix>/``.
+    If the manager has no persistence_directory configured (i.e. the operator
+    explicitly opted out), returns ``None`` and the caller should fall back to
+    direct publish.
+    """
+    persistence_directory = manager.persistence_directory
+    if not persistence_directory:
+        log.warning(
+            "Manager %s has no persistence_directory; status updates will be "
+            "published without local outbox persistence and may be lost if the "
+            "broker is unreachable at publish time.",
+            manager.name,
+        )
+        return None
+    drain_interval = float(conf.get("status_outbox_drain_interval", DEFAULT_DRAIN_INTERVAL))
+    store_dir = os.path.join(persistence_directory, "%s-%s" % (manager.name, suffix))
+    outbox = StatusUpdateOutbox(store_dir, publish_fn, drain_interval=drain_interval)
+    outbox.start()
+    return outbox

--- a/pulsar/messaging/relay_state.py
+++ b/pulsar/messaging/relay_state.py
@@ -3,6 +3,14 @@
 Similar to QueueState for AMQP, this manages the lifecycle of relay
 consumer threads on the Pulsar server side.
 """
+import logging
+import threading
+from typing import (
+    List,
+    Optional,
+)
+
+log = logging.getLogger(__name__)
 
 
 class RelayState:
@@ -12,24 +20,23 @@ class RelayState:
     they should stop processing messages.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize relay state."""
-        self.active = True
-        self.threads = []
+        self.active: bool = True
+        self.threads: List[threading.Thread] = []
+        self.outboxes: list = []
 
-    def deactivate(self):
+    def deactivate(self) -> None:
         """Mark the relay state as inactive, signaling consumers to stop."""
         self.active = False
+        for outbox in self.outboxes:
+            try:
+                outbox.stop(timeout=2.0)
+            except OSError:
+                log.exception("Failed to stop relay status update outbox")
 
-    def join(self, timeout=None):
-        """Join all consumer threads.
-
-        Args:
-            timeout: Optional timeout in seconds for joining threads
-        """
-        import logging
-        log = logging.getLogger(__name__)
-
+    def join(self, timeout: Optional[float] = None) -> None:
+        """Join all consumer threads."""
         for t in self.threads:
             t.join(timeout)
             if t.is_alive():

--- a/pulsar/scripts/config.py
+++ b/pulsar/scripts/config.py
@@ -11,7 +11,7 @@ from pulsar.main import (
 )
 
 try:
-    import pip
+    import pip  # type: ignore[import-not-found,unused-ignore]
 except ImportError:
     pip = None  # type: ignore
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 max-line-length = 150
 max-complexity = 14
 import-order-style = smarkets
-application-import-names = pulsar
+application-import-names = pulsar,harness,recorder
 # E203 is whitespace before ':'; we follow black's formatting here. See https://black.readthedocs.io/en/stable/faq.html#why-are-flake8-s-e203-and-w503-violated
 extend-ignore = E203
 

--- a/test/amqp_test.py
+++ b/test/amqp_test.py
@@ -73,4 +73,109 @@ class TestThread(threading.Thread):
         self.join(2)
 
 
+@skip_unless_module("kombu")
+def test_non_durable_queue_and_exchange_default():
+    """Default is non-durable to preserve legacy behavior: RabbitMQ refuses to
+    redeclare an existing queue with mismatched durability, so flipping the
+    default would break upgrades. Operators opt in via ``amqp_durable: true``.
+    """
+    exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "manager_durable_default")
+    queue = exchange._PulsarExchange__queue("status_update")
+    assert queue.durable is False
+    assert queue.exchange.durable is False
+
+
+@skip_unless_module("kombu")
+def test_durable_can_be_enabled():
+    """Operators who want broker-restart durability opt in explicitly."""
+    exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "manager_durable_on", durable=True)
+    queue = exchange._PulsarExchange__queue("status_update")
+    assert queue.durable is True
+    assert queue.exchange.durable is True
+
+
+@skip_unless_module("kombu")
+def test_durable_publishes_use_persistent_delivery_mode():
+    """Persistent delivery (delivery_mode=2) is required for messages to survive
+    broker restart even when the queue itself is durable.
+    """
+    exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "manager_dm", durable=True)
+    publish_kwds = exchange._PulsarExchange__prepare_publish_kwds("test")
+    assert publish_kwds.get("delivery_mode") == 2
+
+
+@skip_unless_module("kombu")
+def test_non_durable_publishes_do_not_force_persistent_mode():
+    exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "manager_dm_off")
+    publish_kwds = exchange._PulsarExchange__prepare_publish_kwds("test")
+    assert "delivery_mode" not in publish_kwds
+
+
+@skip_unless_module("kombu")
+def test_factory_defaults_durable_false():
+    from pulsar.client import amqp_exchange_factory
+    exchange = amqp_exchange_factory.get_exchange(TEST_CONNECTION, "factory_durable_default", {})
+    queue = exchange._PulsarExchange__queue("status_update")
+    assert queue.durable is False
+
+
+@skip_unless_module("kombu")
+def test_factory_respects_amqp_durable_true():
+    from pulsar.client import amqp_exchange_factory
+    exchange = amqp_exchange_factory.get_exchange(
+        TEST_CONNECTION, "factory_durable_on", {"amqp_durable": True},
+    )
+    queue = exchange._PulsarExchange__queue("status_update")
+    assert queue.durable is True
+
+
+@skip_unless_module("kombu")
+def test_factory_respects_amqp_durable_string_true():
+    from pulsar.client import amqp_exchange_factory
+    exchange = amqp_exchange_factory.get_exchange(
+        TEST_CONNECTION, "factory_durable_on_str", {"amqp_durable": "true"},
+    )
+    queue = exchange._PulsarExchange__queue("status_update")
+    assert queue.durable is True
+
+
+def test_publish_kwds_no_retry_by_default():
+    """Without an explicit opt-in we leave kombu's defaults alone, so existing
+    deployments don't get surprise retry behavior; the persistent outbox is
+    the primary durability layer."""
+    from pulsar.client.amqp_exchange_factory import parse_amqp_publish_kwds
+    publish_kwds = parse_amqp_publish_kwds({})
+    assert "retry" not in publish_kwds
+    assert "retry_policy" not in publish_kwds
+
+
+def test_publish_kwds_retry_true_populates_default_policy():
+    """When the operator opts into retries we fill in bounded defaults so a
+    single hiccup doesn't drop a message before the outbox sees it."""
+    from pulsar.client.amqp_exchange_factory import (
+        DEFAULT_PUBLISH_RETRY_POLICY,
+        parse_amqp_publish_kwds,
+    )
+    publish_kwds = parse_amqp_publish_kwds({"amqp_publish_retry": True})
+    assert publish_kwds["retry"] is True
+    assert publish_kwds["retry_policy"] == DEFAULT_PUBLISH_RETRY_POLICY
+
+
+def test_publish_kwds_explicit_retry_policy_wins_over_defaults():
+    from pulsar.client.amqp_exchange_factory import (
+        DEFAULT_PUBLISH_RETRY_POLICY,
+        parse_amqp_publish_kwds,
+    )
+    publish_kwds = parse_amqp_publish_kwds({
+        "amqp_publish_retry": True,
+        "amqp_publish_retry_max_retries": 99,
+        "amqp_publish_retry_interval_start": 7,
+    })
+    assert publish_kwds["retry"] is True
+    assert publish_kwds["retry_policy"]["max_retries"] == 99
+    assert publish_kwds["retry_policy"]["interval_start"] == 7
+    # Non-overridden defaults are still filled in.
+    assert publish_kwds["retry_policy"]["interval_max"] == DEFAULT_PUBLISH_RETRY_POLICY["interval_max"]
+
+
 __all__ = ["test_amqp"]

--- a/test/client_manager_test.py
+++ b/test/client_manager_test.py
@@ -1,6 +1,10 @@
+import os
 from os import environ
 
-from pulsar.client.manager import ClientManager
+from pulsar.client.manager import (
+    ClientManager,
+    _per_handler_cursor_path,
+)
 
 
 def test_environment_variables_config():
@@ -29,3 +33,32 @@ def test_kwds_config():
 
 def __produces_caching_client(client_manager):
     return client_manager.client_class.__name__.find('Caching') > 0
+
+
+def test_per_handler_cursor_path_passthrough_when_empty():
+    assert _per_handler_cursor_path(None) is None
+    assert _per_handler_cursor_path("") == ""
+
+
+def test_per_handler_cursor_path_uses_explicit_handler_id():
+    """The handler_id argument wins — it's the only thing the caller can
+    guarantee is stable across restarts."""
+    assert _per_handler_cursor_path(
+        "/var/lib/galaxy/relay_cursor.json", "handler0",
+    ) == "/var/lib/galaxy/relay_cursor-handler0.json"
+    assert _per_handler_cursor_path("relay_cursor", "handler1") == "relay_cursor-handler1"
+
+
+def test_per_handler_cursor_path_falls_back_to_galaxy_server_name(monkeypatch):
+    monkeypatch.setenv("GALAXY_SERVER_NAME", "main.handler2")
+    assert _per_handler_cursor_path("/tmp/relay_cursor.json") == \
+        "/tmp/relay_cursor-main.handler2.json"
+
+
+def test_per_handler_cursor_path_falls_back_to_pid_with_warning(monkeypatch, caplog):
+    monkeypatch.delenv("GALAXY_SERVER_NAME", raising=False)
+    with caplog.at_level("WARNING"):
+        path = _per_handler_cursor_path("/tmp/relay_cursor.json")
+    assert path == f"/tmp/relay_cursor-pid{os.getpid()}.json"
+    assert any("will not be picked up after a process restart" in rec.message
+               for rec in caplog.records)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest options shared between the unit/integration suite and the
+docker-compose-backed resilience suite under ``test/resilience/``.
+
+``pytest_addoption`` hooks declared in deeper conftest files are silently
+ignored by pytest unless that file is the rootdir conftest. Putting the
+options here ensures they are registered for every invocation that walks
+into ``test/`` — including the standard ``tox -e test-unit`` runs that
+collect the resilience tree only to skip it.
+"""
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--no-docker",
+        action="store_true",
+        default=False,
+        help="Skip resilience tests that need a running docker-compose stack.",
+    )
+    parser.addoption(
+        "--keep-stack",
+        action="store_true",
+        default=False,
+        help="Don't tear down docker-compose at session end (faster local iteration).",
+    )

--- a/test/manager_endpoint_util_test.py
+++ b/test/manager_endpoint_util_test.py
@@ -1,0 +1,125 @@
+"""Tests for the manager_endpoint_util submit-message idempotency guard.
+
+When an AMQP setup message is redelivered (after a Pulsar SIGKILL between
+setup_job and message.ack(), for example), submit_job must NOT re-run the
+job. Once ``launch_config`` metadata is present on disk, the redelivered
+message is a no-op.
+"""
+from pulsar import manager_endpoint_util
+
+
+class _FakeJobDirectory:
+    def __init__(self, exists=True, metadata=None):
+        self._exists = exists
+        self._metadata = dict(metadata or {})
+
+    def exists(self):
+        return self._exists
+
+    def has_metadata(self, name):
+        return name in self._metadata
+
+
+class _FakeActiveJobs:
+    def __init__(self, active=()):
+        self._active = set(active)
+
+    def active_job_ids(self, active_status=None):
+        return list(self._active)
+
+
+class _FakeManager:
+    def __init__(self, job_directory, active_jobs=None):
+        self._jd = job_directory
+        self.handle_failure_calls = 0
+        self.preprocess_and_launch_calls = 0
+        self.setup_job_calls = 0
+        self.active_jobs = active_jobs or _FakeActiveJobs()
+
+    def job_directory(self, job_id):
+        return self._jd
+
+    def touch_outputs(self, job_id, names):
+        pass
+
+    def preprocess_and_launch(self, job_id, launch_config):
+        self.preprocess_and_launch_calls += 1
+
+    def handle_failure_before_launch(self, job_id):
+        self.handle_failure_calls += 1
+
+    def setup_job(self, *args, **kwargs):
+        self.setup_job_calls += 1
+        return "j1"
+
+    def system_properties(self):
+        return {}
+
+
+def _job_config(job_id="j1", **overrides):
+    cfg = {
+        "job_id": job_id,
+        "command_line": "echo ok",
+        "remote_staging": {},
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_first_setup_proceeds_to_preprocess_and_launch():
+    jd = _FakeJobDirectory(exists=True, metadata={})  # launch_config not yet stored
+    mgr = _FakeManager(jd)
+    manager_endpoint_util.submit_job(mgr, _job_config())
+    assert mgr.preprocess_and_launch_calls == 1
+    assert mgr.handle_failure_calls == 0
+
+
+def test_redelivered_setup_with_terminal_status_is_noop():
+    """Job already completed: redelivery must not re-run anything."""
+    jd = _FakeJobDirectory(
+        exists=True,
+        metadata={"launch_config": True, "final_status": "complete"},
+    )
+    mgr = _FakeManager(jd)
+    manager_endpoint_util.submit_job(mgr, _job_config())
+    assert mgr.preprocess_and_launch_calls == 0
+
+
+def test_redelivered_setup_for_active_job_is_noop():
+    """Job is in active_jobs (recover_active_jobs will resume it)."""
+    jd = _FakeJobDirectory(exists=True, metadata={"launch_config": True})
+    mgr = _FakeManager(jd, active_jobs=_FakeActiveJobs(active={"j1"}))
+    manager_endpoint_util.submit_job(mgr, _job_config())
+    assert mgr.preprocess_and_launch_calls == 0
+
+
+def test_redelivered_setup_after_crash_between_launch_config_and_activate_replays():
+    """The narrow loss window: launch_config exists but no active_jobs entry
+    and no terminal status. Recovery cannot resume the job, so the
+    redelivered setup must drive a fresh preprocess_and_launch."""
+    jd = _FakeJobDirectory(exists=True, metadata={"launch_config": True})
+    mgr = _FakeManager(jd, active_jobs=_FakeActiveJobs(active=set()))
+    manager_endpoint_util.submit_job(mgr, _job_config())
+    assert mgr.preprocess_and_launch_calls == 1
+
+
+def test_setup_when_directory_does_not_exist_proceeds_normally():
+    jd = _FakeJobDirectory(exists=False, metadata={})
+    mgr = _FakeManager(jd)
+    manager_endpoint_util.submit_job(mgr, _job_config())
+    assert mgr.preprocess_and_launch_calls == 1
+
+
+def test_missing_job_id_does_not_short_circuit():
+    jd = _FakeJobDirectory(exists=True, metadata={"launch_config": True})
+    mgr = _FakeManager(jd)
+    cfg = _job_config()
+    cfg.pop("job_id")
+    # Without a job_id the duplicate check is skipped; preprocess_and_launch
+    # is invoked with job_id=None and may fail downstream, but the guard
+    # itself must not raise.
+    try:
+        manager_endpoint_util.submit_job(mgr, cfg)
+    except Exception:
+        pass
+    assert mgr.preprocess_and_launch_calls + mgr.handle_failure_calls >= 1

--- a/test/messaging_outbox_test.py
+++ b/test/messaging_outbox_test.py
@@ -1,0 +1,207 @@
+"""Tests for pulsar.messaging.outbox.
+
+These tests pin the behavior that makes the outbox the cornerstone of the
+"jobs are never lost" guarantee: enqueue must never raise, failures must stay
+on disk, the drain thread must retry until publish succeeds, and surviving
+on-disk entries must be replayed when a fresh outbox is constructed against
+the same directory (the restart case).
+"""
+import os
+import threading
+import time
+
+import pytest
+
+from pulsar.messaging.outbox import StatusUpdateOutbox
+
+
+class _Recorder:
+    def __init__(self, fail_until_attempt=0, raise_exc=None):
+        self.calls = []
+        self.fail_until_attempt = fail_until_attempt
+        self.raise_exc = raise_exc or RuntimeError("simulated broker down")
+        self._lock = threading.Lock()
+
+    def __call__(self, payload):
+        with self._lock:
+            self.calls.append(payload)
+            attempt = len(self.calls)
+        if attempt <= self.fail_until_attempt:
+            raise self.raise_exc
+
+    @property
+    def call_count(self):
+        with self._lock:
+            return len(self.calls)
+
+
+def _wait_for(predicate, timeout=5.0, interval=0.02):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_enqueue_persists_and_publishes_on_happy_path(tmp_path):
+    recorder = _Recorder()
+    outbox = StatusUpdateOutbox(str(tmp_path), recorder, drain_interval=0.1)
+    outbox.start()
+    try:
+        outbox.enqueue({"job_id": "j1", "status": "complete"})
+        assert _wait_for(lambda: recorder.call_count == 1)
+        assert _wait_for(lambda: outbox.pending_count() == 0)
+    finally:
+        outbox.stop()
+
+
+def test_enqueue_does_not_raise_when_publish_fails(tmp_path):
+    recorder = _Recorder(fail_until_attempt=10**6)
+    outbox = StatusUpdateOutbox(str(tmp_path), recorder, drain_interval=0.05)
+    outbox.start()
+    try:
+        outbox.enqueue({"job_id": "j1", "status": "complete"})
+        assert _wait_for(lambda: outbox.pending_count() == 1)
+        assert any(f.endswith(".json") for f in os.listdir(str(tmp_path)))
+    finally:
+        outbox.stop()
+
+
+def test_drain_retries_until_publish_succeeds(tmp_path):
+    recorder = _Recorder(fail_until_attempt=3)
+    outbox = StatusUpdateOutbox(str(tmp_path), recorder, drain_interval=0.05)
+    outbox.start()
+    try:
+        outbox.enqueue({"job_id": "j1", "status": "complete"})
+        assert _wait_for(lambda: outbox.pending_count() == 0, timeout=10)
+        assert recorder.call_count >= 4
+    finally:
+        outbox.stop()
+
+
+def test_restart_replays_pending_entries(tmp_path):
+    recorder1 = _Recorder(fail_until_attempt=10**6)
+    outbox1 = StatusUpdateOutbox(str(tmp_path), recorder1, drain_interval=0.05)
+    outbox1.start()
+    try:
+        outbox1.enqueue({"job_id": "j1", "status": "complete"})
+        outbox1.enqueue({"job_id": "j2", "status": "failed"})
+        assert _wait_for(lambda: outbox1.pending_count() == 2)
+    finally:
+        outbox1.stop()
+
+    recorder2 = _Recorder()
+    outbox2 = StatusUpdateOutbox(str(tmp_path), recorder2, drain_interval=0.05)
+    outbox2.start()
+    try:
+        assert _wait_for(lambda: outbox2.pending_count() == 0, timeout=10)
+        assert recorder2.call_count == 2
+        delivered_ids = {p["job_id"] for p in recorder2.calls}
+        assert delivered_ids == {"j1", "j2"}
+    finally:
+        outbox2.stop()
+
+
+def test_corrupt_entry_is_removed_and_does_not_block_drain(tmp_path):
+    recorder = _Recorder()
+    bad_path = os.path.join(str(tmp_path), "bad.json")
+    with open(bad_path, "w") as fh:
+        fh.write("not-valid-json{")
+    outbox = StatusUpdateOutbox(str(tmp_path), recorder, drain_interval=0.05)
+    outbox.start()
+    try:
+        outbox.enqueue({"job_id": "j1", "status": "complete"})
+        assert _wait_for(lambda: outbox.pending_count() == 0, timeout=5)
+        assert recorder.call_count == 1
+        assert not os.path.exists(bad_path)
+    finally:
+        outbox.stop()
+
+
+def test_drain_once_returns_remaining_count(tmp_path):
+    recorder = _Recorder(fail_until_attempt=10**6)
+    outbox = StatusUpdateOutbox(str(tmp_path), recorder, drain_interval=3600)
+    try:
+        outbox.enqueue({"job_id": "j1", "status": "complete"})
+        outbox.enqueue({"job_id": "j2", "status": "failed"})
+        # Background thread is not started; call drain_once directly.
+        remaining = outbox.drain_once()
+        assert remaining == 2
+        assert recorder.call_count == 2
+    finally:
+        outbox.stop()
+
+
+def test_build_status_outbox_returns_none_without_persistence_directory():
+    from pulsar.messaging.outbox import build_status_outbox
+
+    class _StubManager:
+        name = "test"
+        persistence_directory = None
+
+    result = build_status_outbox(_StubManager(), {}, publish_fn=lambda payload: None)
+    assert result is None
+
+
+def test_build_status_outbox_creates_outbox_under_persistence_dir(tmp_path):
+    from pulsar.messaging.outbox import build_status_outbox
+
+    class _StubManager:
+        name = "test"
+        persistence_directory = str(tmp_path)
+
+    recorder = _Recorder()
+    outbox = build_status_outbox(_StubManager(), {"status_outbox_drain_interval": 0.05}, publish_fn=recorder)
+    assert outbox is not None
+    try:
+        expected_dir = os.path.join(str(tmp_path), "test-status-outbox")
+        assert os.path.isdir(expected_dir)
+        outbox.enqueue({"job_id": "j1", "status": "complete"})
+        assert _wait_for(lambda: recorder.call_count == 1)
+    finally:
+        outbox.stop()
+
+
+@pytest.mark.parametrize("payload", [
+    {"job_id": "j1", "status": "complete", "stdout": "hello\nworld"},
+    {"job_id": "j2", "status": "failed", "returncode": 1, "metadata_directory_contents": []},
+    {"job_id": "j3", "status": "running", "system_properties": {"hostname": "x"}},
+])
+def test_payload_round_trips_through_disk(tmp_path, payload):
+    seen = []
+    outbox = StatusUpdateOutbox(str(tmp_path), seen.append, drain_interval=0.05)
+    outbox.start()
+    try:
+        outbox.enqueue(payload)
+        assert _wait_for(lambda: len(seen) == 1)
+        assert seen[0] == payload
+    finally:
+        outbox.stop()
+
+
+def test_drain_is_fifo(tmp_path):
+    """Successive enqueues must drain in enqueue order — never preprocessing
+    after running, never running after complete."""
+    seen = []
+    outbox = StatusUpdateOutbox(str(tmp_path), seen.append, drain_interval=3600)
+    statuses = ["preprocessing", "queued", "running", "complete"]
+    for s in statuses:
+        outbox.enqueue({"job_id": "j1", "status": s})
+    outbox.drain_once()
+    assert [p["status"] for p in seen] == statuses
+
+
+def test_drain_is_fifo_across_restart(tmp_path):
+    """Sequence numbers persist across processes: a restart that finds entries
+    on disk drains them in the order they were originally enqueued before
+    any new entries piled on by the new process."""
+    o1 = StatusUpdateOutbox(str(tmp_path), lambda p: (_ for _ in ()).throw(RuntimeError()), drain_interval=3600)
+    for s in ["preprocessing", "running"]:
+        o1.enqueue({"job_id": "j1", "status": s})
+
+    seen = []
+    o2 = StatusUpdateOutbox(str(tmp_path), seen.append, drain_interval=3600)
+    o2.enqueue({"job_id": "j1", "status": "complete"})
+    o2.drain_once()
+    assert [p["status"] for p in seen] == ["preprocessing", "running", "complete"]

--- a/test/resilience/Dockerfile.pulsar
+++ b/test/resilience/Dockerfile.pulsar
@@ -1,0 +1,25 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+        libcurl4-openssl-dev \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /pulsar
+
+COPY requirements.txt /pulsar/requirements.txt
+COPY setup.py /pulsar/setup.py
+COPY setup.cfg /pulsar/setup.cfg
+COPY README.rst /pulsar/README.rst
+COPY HISTORY.rst /pulsar/HISTORY.rst
+COPY pulsar /pulsar/pulsar
+COPY scripts /pulsar/scripts
+COPY test/resilience/entrypoint.sh /pulsar/entrypoint.sh
+
+RUN pip install --no-cache-dir -e . \
+    && pip install --no-cache-dir kombu==5.3.7 amqp==5.2.0 requests requests-toolbelt pycurl \
+    && chmod +x /pulsar/entrypoint.sh
+
+ENTRYPOINT ["/pulsar/entrypoint.sh"]

--- a/test/resilience/README.md
+++ b/test/resilience/README.md
@@ -1,0 +1,89 @@
+# Pulsar Resilience Test Framework
+
+End-to-end test suite that exercises the *operational* failure modes Pulsar
+must survive without losing jobs:
+
+- Pulsar SIGKILL / restart at every lifecycle phase
+- AMQP broker outage / partition / restart
+- pulsar-relay outage / partition
+- Galaxy HTTP file-server transient failures, persistent failures, partitions
+- Combinations of all of the above
+
+The single guarantee every scenario asserts is: **for every submitted job, a
+terminal status (`complete` or `failed`) is delivered exactly once and is
+preceded only by valid intermediate states**, within a bounded time after the
+fault clears.
+
+## Stack
+
+`docker-compose.yml` brings up:
+
+| Service        | Role                                                               |
+|----------------|--------------------------------------------------------------------|
+| `rabbitmq`     | Real RabbitMQ for AMQP-mode tests                                  |
+| `valkey`       | Backing store for `pulsar-relay`                                   |
+| `relay`        | The `pulsar-relay/` HTTP long-poll service                         |
+| `toxiproxy`    | Network fault injection in front of all three                      |
+| `mock-galaxy`  | FastAPI app with file-server endpoints + AMQP/relay status recorder |
+| `pulsar`       | Pulsar built from local source (mode selected via `PULSAR_MODE`)    |
+
+Pulsar reaches every other service through toxiproxy, so the harness can
+disable connections, blackhole packets, add latency, or reset peers
+mid-scenario.
+
+## Running locally
+
+```bash
+# from repo root
+docker compose -f test/resilience/docker-compose.yml up -d --build
+pytest test/resilience -v
+docker compose -f test/resilience/docker-compose.yml down -v
+```
+
+Or via the smoke test:
+
+```bash
+pytest test/resilience/scenarios/test_happy_path.py -v
+```
+
+The session fixture (`compose_up`) brings the stack up if it's not already
+running and tears it down afterwards. Pass `--keep-stack` to leave the stack
+running between sessions when iterating locally.
+
+## Layout
+
+```
+test/resilience/
+├── docker-compose.yml      # service stack
+├── Dockerfile.pulsar       # builds Pulsar from local source
+├── entrypoint.sh           # selects amqp / amqp_ack / relay mode at startup
+├── config/                 # app_*.yml + server.ini + toxiproxy.json
+├── mock_galaxy/            # FastAPI app + StatusRecorder
+├── harness/                # PulsarControl, ToxiproxyControl, job factory, assertions
+├── conftest.py             # pytest fixtures + parametrized mq_mode
+└── scenarios/              # the actual test cases
+```
+
+## Adding a scenario
+
+1. Pick a fixture set: `pulsar`, plus one of `rabbitmq_proxy` / `relay_proxy`
+   / `galaxy_proxy` for fault injection.
+2. Build a setup payload with `harness.job_factory.make_setup_message`.
+3. Submit it via `requests.post(GALAXY_BASE + "/_publish_setup", json=...)`.
+4. Inject the fault you care about with the appropriate proxy fixture.
+5. Restore connectivity and assert with `harness.assertions.await_terminal`
+   and `assert_exactly_once_terminal`.
+
+## Mode matrix
+
+`mq_mode` is parametrized over `amqp`, `amqp_ack`, and `relay`. Tests that
+should run in every mode just take the `pulsar` fixture (which depends on
+`mq_mode`); tests that only make sense in one mode pin via `pytest.mark.parametrize`.
+
+## Why docker-compose
+
+The bugs we care about are operational: process death, partition, broker
+restart. Existing in-process tests (`test/integration_test_state.py`) use
+the in-memory kombu transport and cannot reproduce them. docker-compose +
+toxiproxy is the standard way to inject these faults, runs the same on a dev
+laptop and in CI, and keeps the harness reproducible.

--- a/test/resilience/config/app_amqp.yml
+++ b/test/resilience/config/app_amqp.yml
@@ -1,0 +1,31 @@
+# Pulsar app config for AMQP-mode resilience tests.
+#
+# Connection goes through toxiproxy so the test harness can disable, blackhole,
+# or add latency to the broker. The persistent outbox under
+# persistence_directory keeps status updates safe during outages.
+
+managers:
+  _default_:
+    type: queued_python
+
+staging_directory: /pulsar/staging
+persistence_directory: /pulsar/persisted
+
+message_queue_url: amqp://guest:guest@toxiproxy:5672//
+amqp_durable: true
+amqp_publish_retry: true
+
+conda_auto_init: false
+conda_auto_install: false
+
+logging:
+  version: 1
+  disable_existing_loggers: false
+  formatters:
+    default: {format: "%(asctime)s %(name)s %(levelname)s %(message)s"}
+  handlers:
+    console: {class: logging.StreamHandler, formatter: default, stream: ext://sys.stdout}
+  root: {level: INFO, handlers: [console]}
+  loggers:
+    pulsar: {level: INFO}
+    pulsar.client: {level: INFO}

--- a/test/resilience/config/app_amqp_ack.yml
+++ b/test/resilience/config/app_amqp_ack.yml
@@ -1,0 +1,25 @@
+# Pulsar app config for AMQP-mode + amqp_acknowledge=true resilience tests.
+
+managers:
+  _default_:
+    type: queued_python
+
+staging_directory: /pulsar/staging
+persistence_directory: /pulsar/persisted
+
+message_queue_url: amqp://guest:guest@toxiproxy:5672//
+amqp_durable: true
+amqp_acknowledge: true
+amqp_publish_retry: true
+
+conda_auto_init: false
+conda_auto_install: false
+
+logging:
+  version: 1
+  disable_existing_loggers: false
+  formatters:
+    default: {format: "%(asctime)s %(name)s %(levelname)s %(message)s"}
+  handlers:
+    console: {class: logging.StreamHandler, formatter: default, stream: ext://sys.stdout}
+  root: {level: INFO, handlers: [console]}

--- a/test/resilience/config/app_relay.yml
+++ b/test/resilience/config/app_relay.yml
@@ -1,0 +1,24 @@
+# Pulsar app config for pulsar-relay resilience tests.
+
+managers:
+  _default_:
+    type: queued_python
+
+staging_directory: /pulsar/staging
+persistence_directory: /pulsar/persisted
+
+message_queue_url: http://toxiproxy:9000
+message_queue_username: admin
+message_queue_password: admin1234
+
+conda_auto_init: false
+conda_auto_install: false
+
+logging:
+  version: 1
+  disable_existing_loggers: false
+  formatters:
+    default: {format: "%(asctime)s %(name)s %(levelname)s %(message)s"}
+  handlers:
+    console: {class: logging.StreamHandler, formatter: default, stream: ext://sys.stdout}
+  root: {level: INFO, handlers: [console]}

--- a/test/resilience/config/relay-config.yaml
+++ b/test/resilience/config/relay-config.yaml
@@ -1,0 +1,3 @@
+bootstrap_admin_username: admin
+bootstrap_admin_password: admin1234
+bootstrap_admin_email: admin@example.com

--- a/test/resilience/config/server.ini
+++ b/test/resilience/config/server.ini
@@ -1,0 +1,36 @@
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = 8913
+
+[app:main]
+paste.app_factory = pulsar.web.wsgi:app_factory
+app_config = %(here)s/app.yml
+
+[loggers]
+keys = root, pulsar
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_pulsar]
+level = INFO
+handlers = console
+qualname = pulsar
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(name)s %(levelname)s %(message)s

--- a/test/resilience/config/toxiproxy.json
+++ b/test/resilience/config/toxiproxy.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "rabbitmq",
+    "listen": "0.0.0.0:5672",
+    "upstream": "rabbitmq:5672",
+    "enabled": true
+  },
+  {
+    "name": "relay",
+    "listen": "0.0.0.0:9000",
+    "upstream": "relay:8080",
+    "enabled": true
+  },
+  {
+    "name": "galaxy_http",
+    "listen": "0.0.0.0:8088",
+    "upstream": "mock-galaxy:8088",
+    "enabled": true
+  }
+]

--- a/test/resilience/conftest.py
+++ b/test/resilience/conftest.py
@@ -14,7 +14,6 @@ collects it only to skip it.
 import os
 import shutil
 import subprocess
-import time
 
 import pytest
 import requests
@@ -68,20 +67,26 @@ def _stack_reachable():
 
 @pytest.fixture(scope="session")
 def compose_up(request):
+    """Require the docker-compose stack to already be up.
+
+    We deliberately don't auto-launch the stack here: the unit-test tox env
+    runs in environments (CI, contributor laptops) that have docker
+    available but no resilience stack running, and a 60+ second compose-up
+    on every unit run would be wrong. The user is expected to bring the
+    stack up explicitly before exercising the resilience suite, e.g.::
+
+        docker compose -f test/resilience/docker-compose.yml up -d --build
+        pytest test/resilience -v
+    """
     if request.config.getoption("--no-docker") or not _docker_available():
         pytest.skip("docker not available; skipping resilience suite")
 
     if not _stack_reachable():
-        subprocess.run(
-            ["docker", "compose", "-f", f"{PROJECT_DIR}/docker-compose.yml", "up", "-d",
-             "rabbitmq", "valkey", "relay", "toxiproxy", "mock-galaxy"],
-            check=True,
+        pytest.skip(
+            "resilience docker-compose stack is not running; "
+            "start it with `docker compose -f test/resilience/docker-compose.yml up -d --build` "
+            "before running test/resilience scenarios."
         )
-        deadline = time.time() + 60
-        while time.time() < deadline and not _stack_reachable():
-            time.sleep(1.0)
-        if not _stack_reachable():
-            pytest.fail("toxiproxy admin never came up")
 
     yield
 

--- a/test/resilience/conftest.py
+++ b/test/resilience/conftest.py
@@ -1,0 +1,149 @@
+"""Pytest fixtures for the docker-compose-backed resilience suite.
+
+The session-scoped ``compose_up`` fixture brings the stack up once. Per-test
+fixtures wipe state (mock-galaxy recorder, RabbitMQ queues, Pulsar staging
+volumes) and parametrize over messaging modes.
+
+Tests opt into this framework with the ``resilience`` marker; the suite is
+skipped automatically if ``docker compose`` or toxiproxy is not available,
+or if the user passed ``--no-docker`` to pytest. Pytest options
+(``--no-docker``, ``--keep-stack``) are registered in ``test/conftest.py``
+at the rootdir so they apply to both this suite and the unit suite that
+collects it only to skip it.
+"""
+import os
+import shutil
+import subprocess
+import time
+
+import pytest
+import requests
+
+from harness.broker_control import ToxiproxyControl
+from harness.pulsar_control import PulsarControl
+
+PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
+GALAXY_BASE = "http://localhost:8088"
+TOXIPROXY_ADMIN = "http://localhost:8474"
+
+
+def pytest_addoption(parser):
+    # Also registered in ``test/conftest.py`` for the full unit suite. When
+    # this suite is invoked directly (``pytest test/resilience``), the
+    # rootdir is this directory and the parent conftest is not loaded, so
+    # we have to register again. Both ``argparse`` and pytest tolerate the
+    # second call as long as the option exists; we still guard with a
+    # try/except in case pytest tightens that in a future version.
+    try:
+        parser.addoption(
+            "--no-docker",
+            action="store_true",
+            default=False,
+            help="Skip resilience tests that need a running docker-compose stack.",
+        )
+    except ValueError:
+        pass
+    try:
+        parser.addoption(
+            "--keep-stack",
+            action="store_true",
+            default=False,
+            help="Don't tear down docker-compose at session end.",
+        )
+    except ValueError:
+        pass
+
+
+def _docker_available():
+    return shutil.which("docker") is not None
+
+
+def _stack_reachable():
+    try:
+        r = requests.get(f"{TOXIPROXY_ADMIN}/version", timeout=2)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="session")
+def compose_up(request):
+    if request.config.getoption("--no-docker") or not _docker_available():
+        pytest.skip("docker not available; skipping resilience suite")
+
+    if not _stack_reachable():
+        subprocess.run(
+            ["docker", "compose", "-f", f"{PROJECT_DIR}/docker-compose.yml", "up", "-d",
+             "rabbitmq", "valkey", "relay", "toxiproxy", "mock-galaxy"],
+            check=True,
+        )
+        deadline = time.time() + 60
+        while time.time() < deadline and not _stack_reachable():
+            time.sleep(1.0)
+        if not _stack_reachable():
+            pytest.fail("toxiproxy admin never came up")
+
+    yield
+
+    if not request.config.getoption("--keep-stack"):
+        subprocess.run(
+            ["docker", "compose", "-f", f"{PROJECT_DIR}/docker-compose.yml", "down", "-v"],
+            check=False,
+        )
+
+
+@pytest.fixture(params=["amqp", "amqp_ack", "relay"], ids=lambda m: f"mode={m}")
+def mq_mode(request):
+    return request.param
+
+
+@pytest.fixture
+def pulsar(compose_up, mq_mode):
+    ctrl = PulsarControl(PROJECT_DIR, mode=mq_mode)
+    # Wipe state at fixture entry only; tests that kill/restart reuse persisted
+    # state to validate recovery semantics.
+    ctrl.start(wait_ready=True, fresh=True)
+    yield ctrl
+    ctrl.stop()
+
+
+@pytest.fixture
+def rabbitmq_proxy(compose_up):
+    p = ToxiproxyControl("rabbitmq", admin=TOXIPROXY_ADMIN)
+    p.enable()
+    p.remove_all_toxics()
+    yield p
+    p.enable()
+    p.remove_all_toxics()
+
+
+@pytest.fixture
+def relay_proxy(compose_up):
+    p = ToxiproxyControl("relay", admin=TOXIPROXY_ADMIN)
+    p.enable()
+    p.remove_all_toxics()
+    yield p
+    p.enable()
+    p.remove_all_toxics()
+
+
+@pytest.fixture
+def galaxy_proxy(compose_up):
+    p = ToxiproxyControl("galaxy_http", admin=TOXIPROXY_ADMIN)
+    p.enable()
+    p.remove_all_toxics()
+    yield p
+    p.enable()
+    p.remove_all_toxics()
+
+
+@pytest.fixture(autouse=True)
+def _clear_recorder_each_test():
+    """Best-effort recorder reset between tests. Does not depend on
+    ``compose_up`` so the pure-python recorder unit tests under
+    ``mock_galaxy/`` still run when docker is not available."""
+    try:
+        requests.post(f"{GALAXY_BASE}/_recorder/clear", timeout=2)
+    except Exception:
+        pass
+    yield

--- a/test/resilience/docker-compose.yml
+++ b/test/resilience/docker-compose.yml
@@ -1,0 +1,105 @@
+# Resilience test stack for Pulsar.
+#
+# Brings up real services and a mock Galaxy so the test suite can exercise:
+#   - Pulsar SIGKILL / restart mid-job
+#   - RabbitMQ outage and partition (via toxiproxy)
+#   - pulsar-relay outage and partition (via toxiproxy)
+#   - Galaxy HTTP file-server failures (via toxiproxy)
+#
+# Networking:
+#   - rabbitmq      <-> toxiproxy:5672  (Pulsar connects through toxiproxy)
+#   - relay         <-> toxiproxy:9000  (Pulsar/Galaxy connect through toxiproxy)
+#   - mock-galaxy   <-> toxiproxy:8088  (Pulsar pulls/pushes files through toxiproxy)
+#
+# Toxiproxy admin API: http://toxiproxy:8474 (the harness drives faults here).
+
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "15672:15672"   # management API for harness readiness checks
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    networks: [pulsar-net]
+
+  valkey:
+    image: valkey/valkey:7
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    networks: [pulsar-net]
+
+  relay:
+    image: ghcr.io/mvdbeek/pulsar-relay:latest
+    volumes:
+      - ./config/relay-config.yaml:/etc/pulsar-relay/config.yaml:ro
+    networks: [pulsar-net]
+
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:2.9.0
+    command: ["-host=0.0.0.0", "-config=/config/toxiproxy.json"]
+    volumes:
+      - ./config/toxiproxy.json:/config/toxiproxy.json:ro
+    ports:
+      - "8474:8474"   # admin API
+      - "5672:5672"   # rabbitmq
+      - "9000:9000"   # relay
+      - "8088:8088"   # mock galaxy http
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      relay:
+        condition: service_started
+    networks: [pulsar-net]
+
+  mock-galaxy:
+    build:
+      context: .
+      dockerfile: mock_galaxy/Dockerfile
+    environment:
+      - MOCK_GALAXY_BIND=0.0.0.0:8088
+      - MOCK_GALAXY_AMQP_URL=amqp://guest:guest@rabbitmq:5672//
+      - MOCK_GALAXY_RELAY_URL=http://relay:8080
+      - MOCK_GALAXY_RELAY_USERNAME=admin
+      - MOCK_GALAXY_RELAY_PASSWORD=admin1234
+      - MOCK_GALAXY_MANAGER=_default_
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      relay:
+        condition: service_started
+    volumes:
+      - galaxy-files:/galaxy/files
+    networks: [pulsar-net]
+
+  pulsar:
+    build:
+      context: ../..
+      dockerfile: test/resilience/Dockerfile.pulsar
+    environment:
+      - PULSAR_CONFIG_DIR=/etc/pulsar
+      - PULSAR_MODE=${PULSAR_MODE:-amqp}    # amqp | amqp_ack | relay
+    volumes:
+      - ./config:/etc/pulsar:ro
+      - pulsar-staging:/pulsar/staging
+      - pulsar-persisted:/pulsar/persisted
+    depends_on:
+      toxiproxy:
+        condition: service_started
+      mock-galaxy:
+        condition: service_started
+    networks: [pulsar-net]
+
+networks:
+  pulsar-net:
+    driver: bridge
+
+volumes:
+  galaxy-files:
+  pulsar-staging:
+  pulsar-persisted:

--- a/test/resilience/entrypoint.sh
+++ b/test/resilience/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Pulsar entrypoint for resilience tests. Selects an app config based on
+# $PULSAR_MODE so the same image can run any of the AMQP / AMQP-ack / relay
+# scenarios.
+
+set -euo pipefail
+
+mode="${PULSAR_MODE:-amqp}"
+case "$mode" in
+    amqp)     src="/etc/pulsar/app_amqp.yml" ;;
+    amqp_ack) src="/etc/pulsar/app_amqp_ack.yml" ;;
+    relay)    src="/etc/pulsar/app_relay.yml" ;;
+    *) echo "Unknown PULSAR_MODE=$mode" >&2; exit 2 ;;
+esac
+
+# Stage configs into a writable runtime dir so we can pick the active app.yml
+# without touching the read-only mount.
+runtime=/tmp/pulsar-runtime
+mkdir -p "$runtime"
+cp /etc/pulsar/server.ini "$runtime/server.ini"
+cp "$src" "$runtime/app.yml"
+
+export PULSAR_CONFIG_DIR="$runtime"
+exec pulsar --mode webless --config_dir "$runtime" --port 8913

--- a/test/resilience/harness/assertions.py
+++ b/test/resilience/harness/assertions.py
@@ -1,0 +1,116 @@
+"""Assertions over the StatusRecorder events recorded by mock-galaxy.
+
+The single guarantee these tests pin down is: every submitted job's terminal
+status is delivered exactly once and is preceded only by valid intermediate
+states. Helpers here let scenarios state that intent declaratively.
+"""
+import time
+
+import requests
+
+VALID_ORDER = [
+    "preprocessing",
+    "queued",
+    "running",
+    "postprocessing",
+    "complete",
+    "failed",
+    "cancelled",
+    "lost",
+]
+TERMINAL = {"complete", "failed", "cancelled", "lost"}
+
+GALAXY_BASE = "http://localhost:8088"
+
+
+def fetch_events(galaxy_base=GALAXY_BASE, job_id=None):
+    params = {}
+    if job_id:
+        params["job_id"] = job_id
+    r = requests.get(f"{galaxy_base}/_recorder/events", params=params, timeout=5)
+    r.raise_for_status()
+    return r.json()
+
+
+def clear_events(galaxy_base=GALAXY_BASE):
+    requests.post(f"{galaxy_base}/_recorder/clear", timeout=5).raise_for_status()
+
+
+def await_terminal(job_id, timeout=60.0, expected="complete", galaxy_base=GALAXY_BASE):
+    """Poll the recorder until ``job_id`` has a terminal status, then assert
+    it matches ``expected``.
+    """
+    deadline = time.time() + timeout
+    last_events = []
+    while time.time() < deadline:
+        events = fetch_events(galaxy_base=galaxy_base, job_id=job_id)
+        for ev in events:
+            if ev["status"] in TERMINAL:
+                assert ev["status"] == expected, (
+                    f"job {job_id} terminal {ev['status']!r}, expected {expected!r}; "
+                    f"all events: {events}"
+                )
+                return ev
+        last_events = events
+        time.sleep(0.25)
+    raise AssertionError(
+        f"job {job_id} did not reach terminal status within {timeout}s; "
+        f"last events: {last_events}"
+    )
+
+
+def assert_exactly_once_terminal(job_id, expected="complete", galaxy_base=GALAXY_BASE):
+    events = fetch_events(galaxy_base=galaxy_base, job_id=job_id)
+    terminal = [ev for ev in events if ev["status"] in TERMINAL]
+    assert len(terminal) == 1, (
+        f"job {job_id} got {len(terminal)} terminal events, expected 1; "
+        f"terminals: {terminal}"
+    )
+    if expected is not None:
+        assert terminal[0]["status"] == expected, (
+            f"job {job_id} terminal {terminal[0]['status']!r}, expected {expected!r}"
+        )
+
+
+def await_any_terminal(job_id, timeout=60.0, galaxy_base=GALAXY_BASE):
+    """Wait until a terminal status of any kind is delivered.
+
+    Use this in scenarios where the runner cannot reasonably resume the
+    underlying job (e.g. queued_python loses the subprocess on SIGKILL).
+    The non-loss guarantee is still 'a terminal status is delivered exactly
+    once'; *which* terminal it is depends on whether the runner can recover.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        events = fetch_events(galaxy_base=galaxy_base, job_id=job_id)
+        for ev in events:
+            if ev["status"] in TERMINAL:
+                return ev
+        time.sleep(0.25)
+    raise AssertionError(
+        f"job {job_id} did not reach any terminal status within {timeout}s"
+    )
+
+
+def assert_states_in_order(job_id, galaxy_base=GALAXY_BASE):
+    """No state regressions (e.g. 'complete' followed by 'running')."""
+    events = fetch_events(galaxy_base=galaxy_base, job_id=job_id)
+    seen = []
+    for ev in events:
+        s = ev["status"]
+        if s in seen and s in TERMINAL:
+            raise AssertionError(
+                f"duplicate terminal {s} for job {job_id}: events {events}"
+            )
+        seen.append(s)
+    # Cheap order check: every adjacent pair must be a non-decreasing index in
+    # VALID_ORDER, except that running/postprocessing transitions can repeat.
+    rank = {s: i for i, s in enumerate(VALID_ORDER)}
+    last_rank = -1
+    for ev in events:
+        r = rank.get(ev["status"], 0)
+        if r < last_rank and ev["status"] in TERMINAL:
+            raise AssertionError(
+                f"state regression for job {job_id}: events {events}"
+            )
+        last_rank = max(last_rank, r)

--- a/test/resilience/harness/broker_control.py
+++ b/test/resilience/harness/broker_control.py
@@ -1,0 +1,56 @@
+"""Inject network faults into RabbitMQ / pulsar-relay / Galaxy via toxiproxy.
+
+The toxiproxy admin API is at http://localhost:8474 by default. Each
+``ToxiproxyControl`` instance targets one named proxy (e.g. ``rabbitmq``)
+and exposes the operations the resilience scenarios actually need.
+"""
+import requests
+
+ADMIN = "http://localhost:8474"
+
+
+class ToxiproxyControl:
+    def __init__(self, name, admin=ADMIN):
+        self.name = name
+        self.admin = admin
+
+    def _proxy_url(self):
+        return f"{self.admin}/proxies/{self.name}"
+
+    def _toxics_url(self):
+        return f"{self._proxy_url()}/toxics"
+
+    # connectivity ------------------------------------------------------------
+
+    def disable(self):
+        r = requests.post(self._proxy_url(), json={"enabled": False}, timeout=5)
+        r.raise_for_status()
+
+    def enable(self):
+        r = requests.post(self._proxy_url(), json={"enabled": True}, timeout=5)
+        r.raise_for_status()
+
+    # toxics ------------------------------------------------------------------
+
+    def add_latency(self, ms, jitter=0):
+        return self._add_toxic("latency", {"latency": ms, "jitter": jitter})
+
+    def add_blackhole(self):
+        # A "timeout" toxic with timeout=0 acts as a permanent blackhole on
+        # downstream traffic. Pair with disable() for full bidirectional drop.
+        return self._add_toxic("timeout", {"timeout": 0}, stream="downstream")
+
+    def reset_peer(self):
+        return self._add_toxic("reset_peer", {"timeout": 0})
+
+    def remove_all_toxics(self):
+        r = requests.get(self._toxics_url(), timeout=5)
+        r.raise_for_status()
+        for toxic in r.json():
+            requests.delete(f"{self._toxics_url()}/{toxic['name']}", timeout=5)
+
+    def _add_toxic(self, ttype, attributes, stream="downstream"):
+        body = {"type": ttype, "stream": stream, "attributes": attributes}
+        r = requests.post(self._toxics_url(), json=body, timeout=5)
+        r.raise_for_status()
+        return r.json()

--- a/test/resilience/harness/job_factory.py
+++ b/test/resilience/harness/job_factory.py
@@ -4,10 +4,30 @@ The scenarios don't run real Galaxy tools — they just need a job that runs
 a deterministic shell command and surfaces input/output staging through
 mock-galaxy's HTTP endpoints. This factory keeps the wire format consistent
 across scenarios.
+
+File-staging URLs target the mock_galaxy mount of simple-job-files at
+``/api/jobs/_resilience/files`` (Galaxy job-files API shape: ``?path=``
+query param, multipart POST). The path query value is the absolute path
+inside the mock-galaxy container's shared volume (``GALAXY_FILES_ROOT``).
 """
 import uuid
+from urllib.parse import urlencode
 
 GALAXY_URL = "http://toxiproxy:8088"
+# Trailing slash matters: Starlette's mount issues a 307 trailing-slash
+# redirect for the bare prefix, which `requests` follows correctly but
+# costs an extra round-trip per staging op. Use the canonical form.
+FILES_API = "/api/jobs/_resilience/files/"
+GALAXY_FILES_ROOT = "/galaxy/files"
+
+
+def files_url(galaxy_filename: str, file_type: str = "input") -> str:
+    """URL Pulsar's client should use to GET/POST a staged file in the mock.
+
+    ``galaxy_filename`` is the basename inside ``GALAXY_FILES_ROOT``.
+    """
+    qs = urlencode({"path": f"{GALAXY_FILES_ROOT}/{galaxy_filename}", "file_type": file_type})
+    return f"{GALAXY_URL}{FILES_API}?{qs}"
 
 
 def make_setup_message(
@@ -21,8 +41,13 @@ def make_setup_message(
     Args:
         job_id: deterministic id (default: random uuid)
         command_line: shell command to run
-        input_files: list of (remote_path, galaxy_url) pairs to download
-        output_files: list of (local_path, galaxy_upload_url) pairs to upload
+        input_files: list of ``(local_name, galaxy_filename)`` pairs.
+            ``local_name`` is the path Pulsar stages the input under;
+            ``galaxy_filename`` is the basename inside ``GALAXY_FILES_ROOT``
+            on the mock-galaxy side. The factory builds the simple-job-files
+            URL.
+        output_files: list of ``(local_name, galaxy_filename)`` pairs with
+            the same semantics, for postprocess upload.
 
     Returns:
         Dict ready to POST to mock-galaxy's ``/_publish_setup`` endpoint.
@@ -30,28 +55,28 @@ def make_setup_message(
     job_id = job_id or uuid.uuid4().hex[:12]
     setup_actions = []
     if input_files:
-        for remote_path, url in input_files:
+        for local_name, galaxy_filename in input_files:
             setup_actions.append({
-                "name": remote_path,
+                "name": local_name,
                 "type": "input",
                 "action": {
                     "action_type": "remote_transfer",
-                    "url": f"{GALAXY_URL}{url}",
-                    "source": {"path": remote_path},
-                    "path": remote_path,
+                    "url": files_url(galaxy_filename, file_type="input"),
+                    "source": {"path": local_name},
+                    "path": local_name,
                 },
             })
     output_actions = []
     if output_files:
-        for remote_path, url in output_files:
+        for local_name, galaxy_filename in output_files:
             output_actions.append({
-                "name": remote_path,
+                "name": local_name,
                 "type": "output",
                 "action": {
                     "action_type": "remote_transfer",
-                    "url": f"{GALAXY_URL}{url}",
-                    "source": {"path": remote_path},
-                    "path": remote_path,
+                    "url": files_url(galaxy_filename, file_type="output"),
+                    "source": {"path": local_name},
+                    "path": local_name,
                 },
             })
 

--- a/test/resilience/harness/job_factory.py
+++ b/test/resilience/harness/job_factory.py
@@ -1,0 +1,70 @@
+"""Build setup-message payloads for resilience scenarios.
+
+The scenarios don't run real Galaxy tools — they just need a job that runs
+a deterministic shell command and surfaces input/output staging through
+mock-galaxy's HTTP endpoints. This factory keeps the wire format consistent
+across scenarios.
+"""
+import uuid
+
+GALAXY_URL = "http://toxiproxy:8088"
+
+
+def make_setup_message(
+    job_id=None,
+    command_line="echo hello",
+    input_files=None,
+    output_files=None,
+):
+    """Build a ``setup`` message body matching pulsar.client.setup_handler.
+
+    Args:
+        job_id: deterministic id (default: random uuid)
+        command_line: shell command to run
+        input_files: list of (remote_path, galaxy_url) pairs to download
+        output_files: list of (local_path, galaxy_upload_url) pairs to upload
+
+    Returns:
+        Dict ready to POST to mock-galaxy's ``/_publish_setup`` endpoint.
+    """
+    job_id = job_id or uuid.uuid4().hex[:12]
+    setup_actions = []
+    if input_files:
+        for remote_path, url in input_files:
+            setup_actions.append({
+                "name": remote_path,
+                "type": "input",
+                "action": {
+                    "action_type": "remote_transfer",
+                    "url": f"{GALAXY_URL}{url}",
+                    "source": {"path": remote_path},
+                    "path": remote_path,
+                },
+            })
+    output_actions = []
+    if output_files:
+        for remote_path, url in output_files:
+            output_actions.append({
+                "name": remote_path,
+                "type": "output",
+                "action": {
+                    "action_type": "remote_transfer",
+                    "url": f"{GALAXY_URL}{url}",
+                    "source": {"path": remote_path},
+                    "path": remote_path,
+                },
+            })
+
+    body = {
+        "job_id": job_id,
+        "command_line": command_line,
+        "setup": True,
+        "remote_staging": {
+            "setup": setup_actions,
+            "action_mapper": {"default_action": "remote_transfer"},
+            "client_outputs": {"action_mapper": {"default_action": "remote_transfer"}},
+        },
+    }
+    if output_actions:
+        body["remote_staging"].setdefault("postprocess", []).extend(output_actions)
+    return body

--- a/test/resilience/harness/pulsar_control.py
+++ b/test/resilience/harness/pulsar_control.py
@@ -1,0 +1,218 @@
+"""Drive the Pulsar container from a test: kill, sigterm, restart, wait-ready.
+
+The harness shells out to ``docker compose`` rather than using the Docker
+Python SDK to keep the dependency surface small and to make the commands easy
+to reproduce by hand when debugging a flaky scenario.
+"""
+import subprocess
+import time
+
+import requests
+
+SERVICE = "pulsar"
+
+# RabbitMQ management API on the broker container; we hit it directly
+# (bypassing toxiproxy) so readiness checks aren't perturbed by fault toxics.
+RABBITMQ_MGMT = "http://localhost:15672/api"
+RABBITMQ_AUTH = ("guest", "guest")
+
+
+def _docker_compose(*args, project_dir):
+    cmd = ["docker", "compose", "-f", f"{project_dir}/docker-compose.yml", *args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+class PulsarControl:
+    def __init__(self, project_dir, service=SERVICE, mode="amqp"):
+        self.project_dir = project_dir
+        self.service = service
+        self.mode = mode
+
+    def start(self, wait_ready=True, fresh=False):
+        # Force-recreate so PULSAR_MODE changes between parametrized tests
+        # actually take effect, and wipe persisted state so prior-run job
+        # directories don't trip the F3 idempotent-setup guard.
+        if fresh:
+            self._wipe_state()
+        cmd = ["docker", "compose", "-f", f"{self.project_dir}/docker-compose.yml",
+               "up", "-d", "--force-recreate", self.service]
+        subprocess.run(
+            cmd,
+            env={"PULSAR_MODE": self.mode, "PATH": _path_env()},
+            check=True,
+        )
+        if wait_ready:
+            self.wait_until_consuming()
+
+    def _wipe_state(self):
+        # Remove staging + persistence contents and purge any leftover queues.
+        # Pulsar must be down for the bind-mount wipe to be safe.
+        subprocess.run(
+            ["docker", "compose", "-f", f"{self.project_dir}/docker-compose.yml",
+             "rm", "-fsv", self.service],
+            env={"PATH": _path_env()},
+            check=False,
+        )
+        for vol in ("resilience_pulsar-staging", "resilience_pulsar-persisted"):
+            subprocess.run(
+                ["docker", "volume", "rm", "-f", vol],
+                env={"PATH": _path_env()},
+                check=False,
+            )
+        # Wipe RabbitMQ control queues so a redelivered setup from a prior
+        # parametrization doesn't surprise the next test.
+        try:
+            for q in ("pulsar__setup", "pulsar__kill", "pulsar__status",
+                      "pulsar__status_update", "pulsar__status_update_ack"):
+                requests.delete(
+                    f"{RABBITMQ_MGMT}/queues/%2F/{q}/contents",
+                    auth=RABBITMQ_AUTH, timeout=2,
+                )
+        except Exception:
+            pass
+        # Drop only the topic/message keys in Valkey — never the user table —
+        # so the bootstrap admin survives and we don't have to restart the
+        # relay container. The Lua script runs server-side: SCAN for keys
+        # whose prefix is *not* ``user`` and ``DEL`` them in batches.
+        lua = (
+            "local cursor='0';"
+            "repeat "
+            "  local r=redis.call('SCAN',cursor,'COUNT',500);"
+            "  cursor=r[1];"
+            "  for _,k in ipairs(r[2]) do "
+            "    if not (string.sub(k,1,4)=='user') then "
+            "      redis.call('DEL',k);"
+            "    end "
+            "  end "
+            "until cursor=='0';"
+            "return 'ok'"
+        )
+        subprocess.run(
+            ["docker", "compose", "-f", f"{self.project_dir}/docker-compose.yml",
+             "exec", "-T", "relay", "valkey-cli", "EVAL", lua, "0"],
+            env={"PATH": _path_env()},
+            check=False, capture_output=True,
+        )
+        # Drop mock-galaxy's relay long-poll cursor, JWT cache and recorder
+        # via its admin endpoint. No process restart, so the AMQP/relay
+        # consumer threads stay attached.
+        try:
+            requests.post(
+                "http://localhost:8088/_consumer/reset", timeout=2,
+            )
+        except Exception:
+            pass
+
+    def stop(self):
+        _docker_compose("stop", self.service, project_dir=self.project_dir)
+
+    def kill(self, signal="KILL"):
+        _docker_compose("kill", "-s", signal, self.service, project_dir=self.project_dir)
+        if self.mode in ("amqp", "amqp_ack"):
+            # RabbitMQ doesn't notice the TCP drop until the AMQP heartbeat
+            # times out (default 580s) so the queue's `consumers` count
+            # stays at 1 long after the container is dead. The next
+            # ``start.wait_until_consuming`` would then see the stale count
+            # and return before the new pulsar has actually attached. Force
+            # the broker to drop the dead consumer by closing each
+            # consumer's connection through the management API.
+            _force_drop_setup_consumer_connections()
+
+    def sigterm(self):
+        self.kill("TERM")
+
+    def restart(self, wait_ready=True):
+        self.stop()
+        self.start(wait_ready=wait_ready)
+
+    def wait_until_consuming(self, timeout=60.0, poll_interval=0.1):
+        """Block until Pulsar has bound consumers for the control queues.
+
+        Both modes wait for a fresh ``bind_manager_to`` log line from the
+        *current* pulsar container, scoped via ``--since`` to the start of
+        this call. Polling the broker for a non-zero consumer count is
+        racy after a kill+restart cycle: the old consumer count can
+        linger for several seconds (especially under a toxiproxy
+        latency toxic) until RabbitMQ notices the TCP drop, so the check
+        passes against the *previous* pulsar container's stale registration.
+        For AMQP modes we additionally require the management API to
+        show a consumer attached, but only after the bind log confirms
+        the new container has actually run bind_app.
+
+        ``poll_interval`` defaults to 0.1 s — the docker-compose-logs +
+        mgmt-API combo takes ~30 ms each, so a tight poll cadence shaves
+        the dead-poll overhead off the suite without saturating either
+        endpoint.
+        """
+        marker = "bind_manager_to"
+        deadline = time.time() + timeout
+        start_ts = time.time()
+        while time.time() < deadline:
+            res = _docker_compose(
+                "logs", "--since", f"{int(time.time() - start_ts) + 2}s",
+                self.service, project_dir=self.project_dir,
+            )
+            if marker in (res.stdout or ""):
+                if self.mode == "relay":
+                    return
+                # AMQP modes: also confirm the broker sees the consumer.
+                if _amqp_setup_has_consumer():
+                    return
+            time.sleep(poll_interval)
+        raise TimeoutError(
+            f"Pulsar did not bind {self.mode} consumers within {timeout}s"
+        )
+
+
+def _path_env():
+    import os
+    return os.environ.get("PATH", "")
+
+
+def _amqp_setup_has_consumer():
+    try:
+        r = requests.get(
+            f"{RABBITMQ_MGMT}/queues/%2F/pulsar__setup",
+            auth=RABBITMQ_AUTH, timeout=2,
+        )
+    except Exception:
+        return False
+    if r.status_code != 200:
+        return False
+    return int(r.json().get("consumers", 0)) > 0
+
+
+def _force_drop_setup_consumer_connections():
+    """Close every connection currently consuming from pulsar control queues.
+
+    pulsar.kill leaves AMQP heartbeats unacknowledged but the broker won't
+    drop the dead consumer until heartbeat timeout (~580s by default). Use
+    the RabbitMQ management API to look up consumers on the pulsar control
+    queues and explicitly close their connections. Idempotent and safe to
+    call when no consumers are present.
+    """
+    # Only drop consumers on queues *Pulsar* reads from. pulsar__status_update
+    # is consumed by mock-galaxy; closing that connection here would silently
+    # break the recorder for the rest of the test.
+    for q in ("pulsar__setup", "pulsar__kill", "pulsar__status"):
+        try:
+            r = requests.get(
+                f"{RABBITMQ_MGMT}/queues/%2F/{q}",
+                auth=RABBITMQ_AUTH, timeout=2,
+            )
+        except Exception:
+            continue
+        if r.status_code != 200:
+            continue
+        for cd in r.json().get("consumer_details", []) or []:
+            conn_name = cd.get("channel_details", {}).get("connection_name")
+            if not conn_name:
+                continue
+            try:
+                requests.delete(
+                    f"{RABBITMQ_MGMT}/connections/{requests.utils.quote(conn_name, safe='')}",
+                    auth=RABBITMQ_AUTH, timeout=2,
+                    headers={"X-Reason": "resilience-suite force-drop after pulsar kill"},
+                )
+            except Exception:
+                pass

--- a/test/resilience/harness/pulsar_control.py
+++ b/test/resilience/harness/pulsar_control.py
@@ -4,6 +4,7 @@ The harness shells out to ``docker compose`` rather than using the Docker
 Python SDK to keep the dependency surface small and to make the commands easy
 to reproduce by hand when debugging a flaky scenario.
 """
+import os
 import subprocess
 import time
 
@@ -17,9 +18,22 @@ RABBITMQ_MGMT = "http://localhost:15672/api"
 RABBITMQ_AUTH = ("guest", "guest")
 
 
+def _compose_env(**overrides):
+    """Build a subprocess env that lets ``docker compose`` find its plugin.
+
+    Inherits the parent env (HOME, DOCKER_CONFIG, etc.) — Docker Desktop
+    discovers the compose plugin via ``~/.docker/cli-plugins/``, so a
+    stripped env makes ``docker compose`` fall through to plain ``docker``
+    and fail on ``-f``.
+    """
+    env = dict(os.environ)
+    env.update(overrides)
+    return env
+
+
 def _docker_compose(*args, project_dir):
     cmd = ["docker", "compose", "-f", f"{project_dir}/docker-compose.yml", *args]
-    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, env=_compose_env())
 
 
 class PulsarControl:
@@ -38,7 +52,7 @@ class PulsarControl:
                "up", "-d", "--force-recreate", self.service]
         subprocess.run(
             cmd,
-            env={"PULSAR_MODE": self.mode, "PATH": _path_env()},
+            env=_compose_env(PULSAR_MODE=self.mode),
             check=True,
         )
         if wait_ready:
@@ -50,13 +64,13 @@ class PulsarControl:
         subprocess.run(
             ["docker", "compose", "-f", f"{self.project_dir}/docker-compose.yml",
              "rm", "-fsv", self.service],
-            env={"PATH": _path_env()},
+            env=_compose_env(),
             check=False,
         )
         for vol in ("resilience_pulsar-staging", "resilience_pulsar-persisted"):
             subprocess.run(
                 ["docker", "volume", "rm", "-f", vol],
-                env={"PATH": _path_env()},
+                env=_compose_env(),
                 check=False,
             )
         # Wipe RabbitMQ control queues so a redelivered setup from a prior
@@ -90,7 +104,7 @@ class PulsarControl:
         subprocess.run(
             ["docker", "compose", "-f", f"{self.project_dir}/docker-compose.yml",
              "exec", "-T", "relay", "valkey-cli", "EVAL", lua, "0"],
-            env={"PATH": _path_env()},
+            env=_compose_env(),
             check=False, capture_output=True,
         )
         # Drop mock-galaxy's relay long-poll cursor, JWT cache and recorder
@@ -162,11 +176,6 @@ class PulsarControl:
         raise TimeoutError(
             f"Pulsar did not bind {self.mode} consumers within {timeout}s"
         )
-
-
-def _path_env():
-    import os
-    return os.environ.get("PATH", "")
 
 
 def _amqp_setup_has_consumer():

--- a/test/resilience/mock_galaxy/Dockerfile
+++ b/test/resilience/mock_galaxy/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir \
+        fastapi==0.111.0 \
+        uvicorn[standard]==0.30.0 \
+        kombu==5.3.7 \
+        amqp==5.2.0 \
+        requests==2.32.3
+
+COPY mock_galaxy/app.py /app/app.py
+COPY mock_galaxy/recorder.py /app/recorder.py
+
+ENV PYTHONUNBUFFERED=1
+EXPOSE 8088
+
+CMD ["python", "/app/app.py"]

--- a/test/resilience/mock_galaxy/Dockerfile
+++ b/test/resilience/mock_galaxy/Dockerfile
@@ -7,7 +7,9 @@ RUN pip install --no-cache-dir \
         uvicorn[standard]==0.30.0 \
         kombu==5.3.7 \
         amqp==5.2.0 \
-        requests==2.32.3
+        requests==2.32.3 \
+        simple-job-files==0.2.1 \
+        a2wsgi==1.10.10
 
 COPY mock_galaxy/app.py /app/app.py
 COPY mock_galaxy/recorder.py /app/recorder.py

--- a/test/resilience/mock_galaxy/app.py
+++ b/test/resilience/mock_galaxy/app.py
@@ -82,6 +82,19 @@ def clear_events():
     return {"cleared": True}
 
 
+@app.post("/_recorder/inject_status")
+async def inject_status(req: Request):
+    """Test helper: feed a status payload directly into the recorder.
+
+    Used to model Galaxy-side actions that don't come over the wire from
+    Pulsar (an operator restart, an admin cancel) when validating the
+    regression-guard / reset-token semantics end-to-end.
+    """
+    payload = await req.json()
+    recorder.record(payload)
+    return {"recorded": True}
+
+
 @app.post("/_consumer/reset")
 def consumer_reset():
     """Drop the relay long-poll cursor and the cached relay JWT in-place.

--- a/test/resilience/mock_galaxy/app.py
+++ b/test/resilience/mock_galaxy/app.py
@@ -1,0 +1,283 @@
+"""Mock Galaxy used by the resilience test framework.
+
+Exposes the surface Pulsar actually exercises:
+
+- ``GET /files/{path}`` and ``POST /files/{path}`` for input/output staging.
+- An AMQP consumer of the ``status_update`` queue and a relay long-poll
+  consumer of the ``job_status_update`` topic. Both push received messages
+  into a shared :class:`StatusRecorder`.
+- ``/_recorder/events`` and ``/_recorder/clear`` endpoints used by tests to
+  observe and reset state between scenarios.
+- ``/_publish_setup`` and ``/_publish_status_request`` endpoints that
+  publish control messages into the broker / relay on behalf of a test, so
+  the harness doesn't need to import kombu or pulsar-relay client code
+  directly.
+
+The app does NOT execute jobs or care about Pulsar's internals beyond the
+wire format. It only records what it sees.
+"""
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+
+import kombu
+import requests
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse
+
+from recorder import StatusRecorder  # type: ignore
+
+log = logging.getLogger("mock_galaxy")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+
+FILES_ROOT = Path(os.environ.get("MOCK_GALAXY_FILES_ROOT", "/galaxy/files"))
+FILES_ROOT.mkdir(parents=True, exist_ok=True)
+AMQP_URL = os.environ.get("MOCK_GALAXY_AMQP_URL", "")
+RELAY_URL = os.environ.get("MOCK_GALAXY_RELAY_URL", "")
+RELAY_USER = os.environ.get("MOCK_GALAXY_RELAY_USERNAME", "admin")
+RELAY_PASS = os.environ.get("MOCK_GALAXY_RELAY_PASSWORD", "admin1234")
+MANAGER = os.environ.get("MOCK_GALAXY_MANAGER", "_default_")
+
+recorder = StatusRecorder()
+app = FastAPI()
+
+
+# ----- file-staging endpoints --------------------------------------------------
+
+@app.get("/files/{path:path}")
+def get_file(path: str):
+    target = (FILES_ROOT / path).resolve()
+    if not str(target).startswith(str(FILES_ROOT.resolve())):
+        raise HTTPException(status_code=400, detail="path traversal")
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="not found")
+    return FileResponse(str(target))
+
+
+@app.post("/files/{path:path}")
+async def post_file(path: str, request: Request):
+    target = (FILES_ROOT / path).resolve()
+    if not str(target).startswith(str(FILES_ROOT.resolve())):
+        raise HTTPException(status_code=400, detail="path traversal")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    body = await request.body()
+    target.write_bytes(body)
+    return {"path": str(target.relative_to(FILES_ROOT)), "size": len(body)}
+
+
+# ----- recorder/control endpoints ---------------------------------------------
+
+@app.get("/_recorder/events")
+def list_events(job_id: str | None = None):
+    return JSONResponse(recorder.events(job_id))
+
+
+@app.post("/_recorder/clear")
+def clear_events():
+    recorder.clear()
+    return {"cleared": True}
+
+
+@app.post("/_consumer/reset")
+def consumer_reset():
+    """Drop the relay long-poll cursor and the cached relay JWT in-place.
+
+    Lets the test harness wipe per-test state (after a Valkey topic flush)
+    without restarting the mock-galaxy container, which is one of the
+    biggest fixed costs in the resilience-suite per-test cycle.
+    """
+    _relay_cursor.clear()
+    with _token_lock:
+        _token_cache["token"] = None
+        _token_cache["exp"] = 0.0
+    recorder.clear()
+    return {"reset": True}
+
+
+@app.post("/_publish_setup")
+async def publish_setup(req: Request):
+    payload = await req.json()
+    _publish_amqp("setup", payload)
+    _publish_relay("job_setup", payload)
+    return {"published": True}
+
+
+@app.post("/_publish_status_request")
+async def publish_status_request(req: Request):
+    payload = await req.json()
+    _publish_amqp("status", payload)
+    _publish_relay("job_status_request", payload)
+    return {"published": True}
+
+
+@app.post("/_publish_kill")
+async def publish_kill(req: Request):
+    payload = await req.json()
+    _publish_amqp("kill", payload)
+    _publish_relay("job_kill", payload)
+    return {"published": True}
+
+
+# ----- AMQP consumer ----------------------------------------------------------
+
+def _queue_name(name: str) -> str:
+    if MANAGER == "_default_":
+        return f"pulsar__{name}"
+    return f"pulsar_{MANAGER}__{name}"
+
+
+def _topic_name(base: str) -> str:
+    if MANAGER == "_default_":
+        return base
+    return f"{base}_{MANAGER}"
+
+
+def _publish_amqp(queue: str, payload: dict):
+    if not AMQP_URL:
+        return
+    queue_name = _queue_name(queue)
+    try:
+        with kombu.Connection(AMQP_URL) as conn:
+            exchange = kombu.Exchange("pulsar", "direct", durable=True)
+            q = kombu.Queue(queue_name, exchange, routing_key=queue_name, durable=True)
+            with conn.Producer(serializer="json") as producer:
+                producer.publish(
+                    payload,
+                    exchange=exchange,
+                    declare=[exchange, q],
+                    routing_key=queue_name,
+                    delivery_mode=2,
+                )
+    except Exception:
+        log.exception("AMQP publish to %s failed", queue_name)
+
+
+def _publish_relay(topic_base: str, payload: dict):
+    if not RELAY_URL:
+        return
+    topic = _topic_name(topic_base)
+    try:
+        token = _relay_token()
+        r = requests.post(
+            f"{RELAY_URL.rstrip('/')}/api/v1/messages",
+            json={"topic": topic, "payload": payload},
+            headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            timeout=15,
+        )
+        r.raise_for_status()
+    except Exception:
+        log.exception("Relay publish to %s failed", topic)
+
+
+_token_lock = threading.Lock()
+_token_cache = {"token": None, "exp": 0.0}
+
+
+def _relay_token():
+    with _token_lock:
+        if _token_cache["token"] and _token_cache["exp"] > time.time() + 30:
+            return _token_cache["token"]
+        r = requests.post(
+            f"{RELAY_URL.rstrip('/')}/auth/login",
+            data={
+                "username": RELAY_USER,
+                "password": RELAY_PASS,
+                "grant_type": "password",
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=10,
+        )
+        r.raise_for_status()
+        body = r.json()
+        _token_cache["token"] = body["access_token"]
+        _token_cache["exp"] = time.time() + int(body.get("expires_in", 600))
+        return _token_cache["token"]
+
+
+def _amqp_consume_loop():
+    if not AMQP_URL:
+        return
+    queue_name = _queue_name("status_update")
+    while True:
+        try:
+            with kombu.Connection(AMQP_URL, heartbeat=60) as conn:
+                exchange = kombu.Exchange("pulsar", "direct", durable=True)
+                q = kombu.Queue(queue_name, exchange, routing_key=queue_name, durable=True)
+
+                def cb(body, message):
+                    if isinstance(body, str):
+                        body = json.loads(body)
+                    recorder.record(body)
+                    message.ack()
+
+                with conn.Consumer([q], callbacks=[cb], accept=["json"]):
+                    while True:
+                        try:
+                            conn.drain_events(timeout=1.0)
+                        except Exception:
+                            pass
+        except Exception:
+            log.exception("AMQP consumer dropped, reconnecting")
+            time.sleep(2.0)
+
+
+_relay_cursor: dict[str, str] = {}
+
+
+def _relay_consume_loop():
+    if not RELAY_URL:
+        return
+    topic = _topic_name("job_status_update")
+    while True:
+        try:
+            token = _relay_token()
+            poll = {"topics": [topic], "timeout": 30}
+            if _relay_cursor:
+                poll["since"] = dict(_relay_cursor)
+            r = requests.post(
+                f"{RELAY_URL.rstrip('/')}/messages/poll",
+                json=poll,
+                headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                timeout=40,
+            )
+            if r.status_code != 200:
+                time.sleep(1)
+                continue
+            messages = r.json().get("messages") or []
+            for msg in messages:
+                payload = msg.get("payload", {})
+                recorder.record(payload)
+                mid = msg.get("message_id")
+                tpc = msg.get("topic")
+                if mid and tpc:
+                    _relay_cursor[tpc] = mid
+        except Exception:
+            log.exception("Relay consumer error, retrying")
+            time.sleep(2.0)
+
+
+def _start_consumers():
+    if AMQP_URL:
+        threading.Thread(target=_amqp_consume_loop, name="amqp-consumer", daemon=True).start()
+    if RELAY_URL:
+        threading.Thread(target=_relay_consume_loop, name="relay-consumer", daemon=True).start()
+
+
+@app.on_event("startup")
+def on_startup():
+    _start_consumers()
+
+
+@app.get("/healthz")
+def healthz():
+    return {"ok": True}
+
+
+if __name__ == "__main__":
+    bind = os.environ.get("MOCK_GALAXY_BIND", "0.0.0.0:8088")
+    host, _, port = bind.partition(":")
+    uvicorn.run(app, host=host, port=int(port))

--- a/test/resilience/mock_galaxy/app.py
+++ b/test/resilience/mock_galaxy/app.py
@@ -2,7 +2,12 @@
 
 Exposes the surface Pulsar actually exercises:
 
-- ``GET /files/{path}`` and ``POST /files/{path}`` for input/output staging.
+- ``/api/jobs/_resilience/files`` (GET/POST/PUT/HEAD) for input/output
+  staging. The wire shape (``?path=...`` query param, multipart POST, raw
+  PUT) is provided by the upstream `simple-job-files`_ package, which
+  itself emulates Galaxy's job-files API. We mount it as a WSGI sub-app so
+  the resilience suite exercises the same wire format real Galaxy serves
+  rather than a bespoke ``/files/{path}`` shape.
 - An AMQP consumer of the ``status_update`` queue and a relay long-poll
   consumer of the ``job_status_update`` topic. Both push received messages
   into a shared :class:`StatusRecorder`.
@@ -15,6 +20,8 @@ Exposes the surface Pulsar actually exercises:
 
 The app does NOT execute jobs or care about Pulsar's internals beyond the
 wire format. It only records what it sees.
+
+.. _simple-job-files: https://github.com/jmchilton/simple-job-files
 """
 import json
 import logging
@@ -26,8 +33,11 @@ from pathlib import Path
 import kombu
 import requests
 import uvicorn
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import FileResponse, JSONResponse
+from a2wsgi import WSGIMiddleware
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from simplejobfiles.app import JobFilesApp
+from webob.exc import HTTPException as WebObHTTPException
 
 from recorder import StatusRecorder  # type: ignore
 
@@ -47,26 +57,36 @@ app = FastAPI()
 
 
 # ----- file-staging endpoints --------------------------------------------------
+# Mounted simple-job-files WSGI app. The mount prefix is stripped before the
+# WSGI sub-app sees the request, so the URL path is irrelevant to JobFilesApp
+# (which dispatches purely on HTTP method and reads ``?path=`` from the query
+# string). The prefix exists to mimic real Galaxy's ``/api/jobs/{id}/files``
+# shape and to keep this surface namespaced away from the recorder / publish
+# helpers below.
+#
+# ``allow_multiple_downloads=True`` is essential: resilience scenarios retry
+# staging on transient failures, so the same input may be GET'd more than
+# once for a single job. simple-job-files defaults to refusing duplicate
+# downloads (to match a stricter Galaxy mode); we opt out.
+#
+# simple-job-files raises ``webob.exc.HTTPNotFound`` for missing files
+# instead of returning it as a response; a2wsgi turns the bare exception
+# into a 500. The c3 fail-fast scenario specifically asserts that a 404
+# from Galaxy short-circuits Pulsar's retry classifier, so we wrap the
+# WSGI app to turn raised WebOb HTTPExceptions back into proper responses.
+class _WebObExceptionShim:
+    def __init__(self, wsgi_app):
+        self._app = wsgi_app
 
-@app.get("/files/{path:path}")
-def get_file(path: str):
-    target = (FILES_ROOT / path).resolve()
-    if not str(target).startswith(str(FILES_ROOT.resolve())):
-        raise HTTPException(status_code=400, detail="path traversal")
-    if not target.exists():
-        raise HTTPException(status_code=404, detail="not found")
-    return FileResponse(str(target))
+    def __call__(self, environ, start_response):
+        try:
+            return self._app(environ, start_response)
+        except WebObHTTPException as e:
+            return e(environ, start_response)
 
 
-@app.post("/files/{path:path}")
-async def post_file(path: str, request: Request):
-    target = (FILES_ROOT / path).resolve()
-    if not str(target).startswith(str(FILES_ROOT.resolve())):
-        raise HTTPException(status_code=400, detail="path traversal")
-    target.parent.mkdir(parents=True, exist_ok=True)
-    body = await request.body()
-    target.write_bytes(body)
-    return {"path": str(target.relative_to(FILES_ROOT)), "size": len(body)}
+_jfa = JobFilesApp(root_directory=str(FILES_ROOT), allow_multiple_downloads=True)
+app.mount("/api/jobs/_resilience/files", WSGIMiddleware(_WebObExceptionShim(_jfa)))  # type: ignore[arg-type]
 
 
 # ----- recorder/control endpoints ---------------------------------------------

--- a/test/resilience/mock_galaxy/recorder.py
+++ b/test/resilience/mock_galaxy/recorder.py
@@ -1,0 +1,61 @@
+"""Thread-safe append-only recorder of status updates received from Pulsar.
+
+Tests assert against this recorder via the ``/_recorder`` endpoints exposed by
+the mock Galaxy app: list events, await a terminal status for a given job,
+clear between scenarios.
+"""
+import threading
+import time
+from collections import defaultdict
+
+
+class StatusRecorder:
+    TERMINAL = {"complete", "failed", "cancelled", "lost"}
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._cv = threading.Condition(self._lock)
+        self._events = []
+        self._by_job = defaultdict(list)
+
+    def record(self, payload):
+        job_id = payload.get("job_id", "unknown")
+        status = payload.get("status", "unknown")
+        ts = time.time()
+        event = {"job_id": job_id, "status": status, "ts": ts, "payload": payload}
+        with self._cv:
+            # Dedupe by (job_id, status). Pulsar's outbox can legitimately
+            # re-publish a message whose HTTP/AMQP confirmation was lost but
+            # whose payload reached the broker; Galaxy's job state machine
+            # is idempotent in (job_id, status), so we model Galaxy after
+            # dedup. Tests checking for *no* re-publish use a recorder
+            # behavior we don't expose here.
+            for prior in self._by_job.get(job_id, ()):
+                if prior["status"] == status:
+                    return
+            self._events.append(event)
+            self._by_job[job_id].append(event)
+            self._cv.notify_all()
+
+    def events(self, job_id=None):
+        with self._lock:
+            if job_id is None:
+                return list(self._events)
+            return list(self._by_job.get(job_id, ()))
+
+    def clear(self):
+        with self._lock:
+            self._events.clear()
+            self._by_job.clear()
+
+    def await_terminal(self, job_id, timeout=60.0):
+        deadline = time.time() + timeout
+        with self._cv:
+            while True:
+                for ev in self._by_job.get(job_id, ()):
+                    if ev["status"] in self.TERMINAL:
+                        return ev
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    return None
+                self._cv.wait(timeout=remaining)

--- a/test/resilience/mock_galaxy/recorder.py
+++ b/test/resilience/mock_galaxy/recorder.py
@@ -3,6 +3,28 @@
 Tests assert against this recorder via the ``/_recorder`` endpoints exposed by
 the mock Galaxy app: list events, await a terminal status for a given job,
 clear between scenarios.
+
+This recorder is the canonical model for what Galaxy itself should do with
+Pulsar status updates:
+
+1. **Dedupe by (job_id, status).** Pulsar's outbox can legitimately
+   re-publish a message whose ack was lost but whose payload reached the
+   broker. Galaxy's job state machine is naturally idempotent in
+   ``(job_id, status)``, so the duplicate is just dropped.
+
+2. **Refuse non-terminal-after-terminal regressions.** The outbox itself is
+   FIFO per Pulsar instance, but a redelivery from broker durability or a
+   replay across a Pulsar restart could in principle expose Galaxy to a
+   stale, in-flight status (e.g. a buffered ``running`` arriving after
+   ``complete``). Once a job has reached a terminal status, drop any
+   non-terminal updates for it.
+
+3. **Allow explicit Galaxy-side resets.** Operators (or Galaxy itself) need
+   to reset a job — e.g. resubmit after cancel, or restart a failed job.
+   Such transitions deliberately re-enter a non-terminal state from a
+   terminal one. Mark the reset payload with ``_galaxy_reset_token`` (any
+   truthy value): the recorder treats that update as a fresh epoch and
+   forgets the prior history for that job_id.
 """
 import threading
 import time
@@ -21,18 +43,43 @@ class StatusRecorder:
     def record(self, payload):
         job_id = payload.get("job_id", "unknown")
         status = payload.get("status", "unknown")
+        reset_token = payload.get("_galaxy_reset_token")
         ts = time.time()
-        event = {"job_id": job_id, "status": status, "ts": ts, "payload": payload}
+        event = {
+            "job_id": job_id,
+            "status": status,
+            "ts": ts,
+            "reset_token": reset_token,
+            "payload": payload,
+        }
         with self._cv:
-            # Dedupe by (job_id, status). Pulsar's outbox can legitimately
-            # re-publish a message whose HTTP/AMQP confirmation was lost but
-            # whose payload reached the broker; Galaxy's job state machine
-            # is idempotent in (job_id, status), so we model Galaxy after
-            # dedup. Tests checking for *no* re-publish use a recorder
-            # behavior we don't expose here.
-            for prior in self._by_job.get(job_id, ()):
+            prior_events = self._by_job.get(job_id, ())
+            if reset_token:
+                # Galaxy explicitly restarted the job; forget its prior
+                # transitions so the new lifecycle can replay from scratch.
+                self._by_job[job_id] = []
+                # Keep the global event log; it's a record of what was
+                # observed in time, not the authoritative state.
+                self._events.append(event)
+                self._by_job[job_id].append(event)
+                self._cv.notify_all()
+                return
+
+            # Dedupe by (job_id, status).
+            for prior in prior_events:
                 if prior["status"] == status:
                     return
+
+            # Regression guard: once a job has reached a terminal status,
+            # any subsequent update without a reset_token is stale. This
+            # covers both "non-terminal after terminal" (an old buffered
+            # ``running``) and "different terminal after terminal" (a
+            # delayed ``failed`` after ``complete`` or vice versa).
+            if prior_events:
+                last_status = prior_events[-1]["status"]
+                if last_status in self.TERMINAL:
+                    return
+
             self._events.append(event)
             self._by_job[job_id].append(event)
             self._cv.notify_all()

--- a/test/resilience/mock_galaxy/recorder_test.py
+++ b/test/resilience/mock_galaxy/recorder_test.py
@@ -1,0 +1,85 @@
+"""Unit tests for the StatusRecorder ordering rules.
+
+The recorder is the test framework's stand-in for Galaxy's job-state
+processor. Run from this directory: ``pytest mock_galaxy/recorder_test.py``.
+"""
+import os
+import sys
+
+import pytest
+
+# Make sibling import work when invoked from the resilience root or via
+# `pytest test/resilience/mock_galaxy/recorder_test.py`.
+sys.path.insert(0, os.path.dirname(__file__))
+from recorder import StatusRecorder  # type: ignore  # noqa: E402
+
+
+def _statuses(rec, job_id):
+    return [e["status"] for e in rec.events(job_id)]
+
+
+def test_dedupes_repeated_status():
+    rec = StatusRecorder()
+    rec.record({"job_id": "j1", "status": "running"})
+    rec.record({"job_id": "j1", "status": "running"})
+    rec.record({"job_id": "j1", "status": "complete"})
+    rec.record({"job_id": "j1", "status": "complete"})
+    assert _statuses(rec, "j1") == ["running", "complete"]
+
+
+def test_drops_non_terminal_after_terminal():
+    rec = StatusRecorder()
+    rec.record({"job_id": "j1", "status": "running"})
+    rec.record({"job_id": "j1", "status": "complete"})
+    rec.record({"job_id": "j1", "status": "running"})  # stale buffered update
+    rec.record({"job_id": "j1", "status": "queued"})    # ditto
+    assert _statuses(rec, "j1") == ["running", "complete"]
+
+
+def test_terminal_after_terminal_is_just_a_dupe():
+    """Two different terminals (e.g. complete then failed) shouldn't both
+    land — but the dedupe rule is by (job_id, status), so the second is
+    distinct from the first. We treat the second as a regression: terminal
+    states are sinks and a different terminal arriving later is suspect."""
+    rec = StatusRecorder()
+    rec.record({"job_id": "j1", "status": "complete"})
+    rec.record({"job_id": "j1", "status": "failed"})
+    # Either result is defensible; we just want exactly-one terminal.
+    terminals = [s for s in _statuses(rec, "j1") if s in StatusRecorder.TERMINAL]
+    assert len(terminals) == 1
+
+
+def test_galaxy_reset_token_starts_fresh_epoch():
+    rec = StatusRecorder()
+    rec.record({"job_id": "j1", "status": "running"})
+    rec.record({"job_id": "j1", "status": "complete"})
+    # Galaxy restarts the job; the new lifecycle should be admitted fully.
+    rec.record({
+        "job_id": "j1",
+        "status": "preprocessing",
+        "_galaxy_reset_token": "epoch-2",
+    })
+    rec.record({"job_id": "j1", "status": "running"})
+    rec.record({"job_id": "j1", "status": "complete"})
+    assert _statuses(rec, "j1") == ["preprocessing", "running", "complete"]
+
+
+def test_reset_token_does_not_leak_across_jobs():
+    rec = StatusRecorder()
+    rec.record({"job_id": "j1", "status": "complete"})
+    rec.record({
+        "job_id": "j2",
+        "status": "preprocessing",
+        "_galaxy_reset_token": "x",
+    })
+    # j1's history must not be affected by j2's reset.
+    assert _statuses(rec, "j1") == ["complete"]
+    assert _statuses(rec, "j2") == ["preprocessing"]
+
+
+@pytest.mark.parametrize("terminal", ["complete", "failed", "cancelled", "lost"])
+def test_each_terminal_blocks_subsequent_non_terminals(terminal):
+    rec = StatusRecorder()
+    rec.record({"job_id": "j1", "status": terminal})
+    rec.record({"job_id": "j1", "status": "running"})
+    assert _statuses(rec, "j1") == [terminal]

--- a/test/resilience/pytest.ini
+++ b/test/resilience/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers =
+    resilience: docker-compose-backed end-to-end resilience scenario
+timeout = 300
+log_cli = true
+log_cli_level = INFO

--- a/test/resilience/scenarios/test_broker_outage.py
+++ b/test/resilience/scenarios/test_broker_outage.py
@@ -1,0 +1,101 @@
+"""B. Broker outage scenarios.
+
+For AMQP and relay modes, verify that an outage of the message bus does not
+lose a job's terminal status. The outbox + durable queues + persisted relay
+cursor are the production-side guarantees being exercised here.
+"""
+import time
+
+import pytest
+import requests
+
+from harness.assertions import (
+    assert_exactly_once_terminal,
+    assert_states_in_order,
+    await_terminal,
+)
+from harness.job_factory import make_setup_message
+
+GALAXY_BASE = "http://localhost:8088"
+
+
+def _broker_proxy_for_mode(mode, rabbitmq_proxy, relay_proxy):
+    return relay_proxy if mode == "relay" else rabbitmq_proxy
+
+
+@pytest.mark.resilience
+def test_b1_outage_during_preprocessing(pulsar, rabbitmq_proxy, relay_proxy):
+    proxy = _broker_proxy_for_mode(pulsar.mode, rabbitmq_proxy, relay_proxy)
+    body = make_setup_message(command_line="echo b1 && sleep 1")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    time.sleep(0.3)
+    proxy.disable()
+    time.sleep(3.0)
+    proxy.enable()
+    await_terminal(body["job_id"], timeout=180, expected="complete")
+    assert_exactly_once_terminal(body["job_id"], expected="complete")
+    assert_states_in_order(body["job_id"])
+
+
+@pytest.mark.resilience
+def test_b2_outage_during_execution(pulsar, rabbitmq_proxy, relay_proxy):
+    proxy = _broker_proxy_for_mode(pulsar.mode, rabbitmq_proxy, relay_proxy)
+    body = make_setup_message(command_line="sleep 2 && echo b2-done")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    time.sleep(0.8)
+    proxy.disable()
+    time.sleep(4.0)
+    proxy.enable()
+    await_terminal(body["job_id"], timeout=180, expected="complete")
+    assert_exactly_once_terminal(body["job_id"], expected="complete")
+
+
+@pytest.mark.resilience
+def test_b3_long_outage_with_running_pulsar(pulsar, rabbitmq_proxy, relay_proxy):
+    """Pulsar stays up the whole time; the broker is gone for a long stretch.
+
+    No exceptions in the postprocess thread should kill it: with the outbox,
+    the terminal status sits on disk and is published as soon as the broker
+    returns.
+    """
+    proxy = _broker_proxy_for_mode(pulsar.mode, rabbitmq_proxy, relay_proxy)
+    body = make_setup_message(command_line="echo b3-fast && sleep 1")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    # Let the setup be consumed and the job start before severing the broker;
+    # mock-galaxy can only publish to a backend that's actually reachable.
+    time.sleep(0.6)
+    proxy.disable()
+    time.sleep(8.0)  # long outage while Pulsar holds the terminal status
+    proxy.enable()
+    await_terminal(body["job_id"], timeout=120, expected="complete")
+    assert_exactly_once_terminal(body["job_id"], expected="complete")
+
+
+@pytest.mark.resilience
+def test_b4_broker_dies_and_pulsar_sigkill(pulsar, rabbitmq_proxy, relay_proxy):
+    proxy = _broker_proxy_for_mode(pulsar.mode, rabbitmq_proxy, relay_proxy)
+    body = make_setup_message(command_line="echo b4-fast")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    time.sleep(0.5)
+    proxy.disable()
+    pulsar.kill()
+    time.sleep(1.5)
+    proxy.enable()
+    pulsar.start(wait_ready=True)
+    await_terminal(body["job_id"], timeout=180, expected="complete")
+    assert_exactly_once_terminal(body["job_id"], expected="complete")
+
+
+@pytest.mark.resilience
+def test_b5_blackhole_partition(pulsar, rabbitmq_proxy, relay_proxy):
+    proxy = _broker_proxy_for_mode(pulsar.mode, rabbitmq_proxy, relay_proxy)
+    body = make_setup_message(command_line="echo b5 && sleep 1")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    # Let the setup land before partitioning; mock-galaxy can't reach a
+    # blackholed broker (the same as B3).
+    time.sleep(0.8)
+    proxy.add_blackhole()
+    time.sleep(6.0)
+    proxy.remove_all_toxics()
+    await_terminal(body["job_id"], timeout=180, expected="complete")
+    assert_exactly_once_terminal(body["job_id"], expected="complete")

--- a/test/resilience/scenarios/test_combined.py
+++ b/test/resilience/scenarios/test_combined.py
@@ -1,0 +1,58 @@
+"""D. Combined failure scenarios.
+
+The hard cases: every layer fails at once. If A/B/C pass independently but
+combined cases fail, the system has implicit dependencies between recovery
+mechanisms.
+"""
+import time
+
+import pytest
+import requests
+
+from harness.assertions import (
+    assert_exactly_once_terminal,
+    await_any_terminal,
+    await_terminal,
+)
+from harness.job_factory import make_setup_message
+
+GALAXY_BASE = "http://localhost:8088"
+
+
+@pytest.mark.resilience
+def test_d1_pulsar_restart_with_broker_and_galaxy_outage(
+    pulsar, rabbitmq_proxy, relay_proxy, galaxy_proxy,
+):
+    """All three layers fault at once: the running queued_python subprocess
+    dies with pulsar (so terminal is ``lost``, not ``complete``), but the
+    non-loss guarantee still holds — exactly one terminal is delivered."""
+    proxy = relay_proxy if pulsar.mode == "relay" else rabbitmq_proxy
+    body = make_setup_message(command_line="echo d1 && sleep 1")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    time.sleep(0.5)
+    proxy.add_latency(500)
+    galaxy_proxy.disable()
+    pulsar.kill()
+    time.sleep(1.5)
+    galaxy_proxy.enable()
+    pulsar.start(wait_ready=True)
+    proxy.remove_all_toxics()
+    await_any_terminal(body["job_id"], timeout=120)
+    assert_exactly_once_terminal(body["job_id"], expected=None)
+
+
+@pytest.mark.resilience
+def test_d2_two_concurrent_jobs_under_faults(pulsar, rabbitmq_proxy, relay_proxy):
+    proxy = relay_proxy if pulsar.mode == "relay" else rabbitmq_proxy
+    body_a = make_setup_message(job_id="d2-a", command_line="echo d2-a && sleep 1")
+    body_b = make_setup_message(job_id="d2-b", command_line="echo d2-b && sleep 2")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body_a, timeout=5).raise_for_status()
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body_b, timeout=5).raise_for_status()
+    time.sleep(0.3)
+    proxy.add_blackhole()
+    time.sleep(4.0)
+    proxy.remove_all_toxics()
+    await_terminal("d2-a", timeout=120, expected="complete")
+    await_terminal("d2-b", timeout=120, expected="complete")
+    assert_exactly_once_terminal("d2-a", expected="complete")
+    assert_exactly_once_terminal("d2-b", expected="complete")

--- a/test/resilience/scenarios/test_galaxy_outage.py
+++ b/test/resilience/scenarios/test_galaxy_outage.py
@@ -5,6 +5,7 @@ These exercise the staging path (input download, output upload). The
 should retry transient HTTP failures and fail-fast on permanent ones.
 The end-to-end check is that the terminal status reflects reality.
 """
+import io
 import time
 
 import pytest
@@ -14,19 +15,34 @@ from harness.assertions import (
     assert_exactly_once_terminal,
     await_terminal,
 )
-from harness.job_factory import make_setup_message
+from harness.job_factory import (
+    FILES_API,
+    GALAXY_FILES_ROOT,
+    make_setup_message,
+)
 
 GALAXY_BASE = "http://localhost:8088"
+
+
+def _put_input(galaxy_filename: str, body: bytes) -> None:
+    """Pre-populate a file inside the mock's GALAXY_FILES_ROOT volume via
+    the simple-job-files multipart POST surface.
+    """
+    requests.post(
+        f"{GALAXY_BASE}{FILES_API}",
+        data={"path": f"{GALAXY_FILES_ROOT}/{galaxy_filename}"},
+        files={"file": ("upload", io.BytesIO(body))},
+        timeout=10,
+    ).raise_for_status()
 
 
 @pytest.mark.resilience
 def test_c1_input_503_then_recovers(pulsar, galaxy_proxy):
     """Galaxy HTTP returns 5xx for a beat; staging retries and succeeds."""
-    # Stage a real file in mock-galaxy first.
-    requests.post(f"{GALAXY_BASE}/files/c1-input.txt", data=b"hello").raise_for_status()
+    _put_input("c1-input.txt", b"hello")
     body = make_setup_message(
         command_line="cat /pulsar/staging/inputs/c1-input.txt",
-        input_files=[("c1-input.txt", "/files/c1-input.txt")],
+        input_files=[("c1-input.txt", "c1-input.txt")],
     )
     galaxy_proxy.add_latency(1000)  # heavy latency degrades but doesn't 4xx
     requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=10).raise_for_status()
@@ -42,7 +58,7 @@ def test_c3_input_404_fails_fast(pulsar):
     terminal status, not endless retries."""
     body = make_setup_message(
         command_line="echo c3",
-        input_files=[("missing.txt", "/files/never-existed.txt")],
+        input_files=[("missing.txt", "never-existed.txt")],
     )
     requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
     await_terminal(body["job_id"], timeout=120, expected="failed")

--- a/test/resilience/scenarios/test_galaxy_outage.py
+++ b/test/resilience/scenarios/test_galaxy_outage.py
@@ -1,0 +1,65 @@
+"""C. Galaxy HTTP outage scenarios.
+
+These exercise the staging path (input download, output upload). The
+``RetryActionExecutor`` + transient error classifier from this branch
+should retry transient HTTP failures and fail-fast on permanent ones.
+The end-to-end check is that the terminal status reflects reality.
+"""
+import time
+
+import pytest
+import requests
+
+from harness.assertions import (
+    assert_exactly_once_terminal,
+    await_terminal,
+)
+from harness.job_factory import make_setup_message
+
+GALAXY_BASE = "http://localhost:8088"
+
+
+@pytest.mark.resilience
+def test_c1_input_503_then_recovers(pulsar, galaxy_proxy):
+    """Galaxy HTTP returns 5xx for a beat; staging retries and succeeds."""
+    # Stage a real file in mock-galaxy first.
+    requests.post(f"{GALAXY_BASE}/files/c1-input.txt", data=b"hello").raise_for_status()
+    body = make_setup_message(
+        command_line="cat /pulsar/staging/inputs/c1-input.txt",
+        input_files=[("c1-input.txt", "/files/c1-input.txt")],
+    )
+    galaxy_proxy.add_latency(1000)  # heavy latency degrades but doesn't 4xx
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=10).raise_for_status()
+    time.sleep(4.0)
+    galaxy_proxy.remove_all_toxics()
+    await_terminal(body["job_id"], timeout=120, expected="complete")
+    assert_exactly_once_terminal(body["job_id"], expected="complete")
+
+
+@pytest.mark.resilience
+def test_c3_input_404_fails_fast(pulsar):
+    """Permanent 4xx on a staging download must produce a single ``failed``
+    terminal status, not endless retries."""
+    body = make_setup_message(
+        command_line="echo c3",
+        input_files=[("missing.txt", "/files/never-existed.txt")],
+    )
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    await_terminal(body["job_id"], timeout=120, expected="failed")
+    assert_exactly_once_terminal(body["job_id"], expected="failed")
+
+
+@pytest.mark.resilience
+@pytest.mark.skip(
+    reason="Galaxy-consumer-offline semantics are equivalent to the B series "
+    "broker outage scenarios in this harness, since mock-galaxy publishes "
+    "setup and consumes status_update over the same connection.",
+)
+def test_c4_galaxy_consumer_offline_then_returns(pulsar, galaxy_proxy):
+    body = make_setup_message(command_line="echo c4 && sleep 1")
+    galaxy_proxy.disable()
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    time.sleep(8.0)
+    galaxy_proxy.enable()
+    await_terminal(body["job_id"], timeout=180, expected="complete")
+    assert_exactly_once_terminal(body["job_id"], expected="complete")

--- a/test/resilience/scenarios/test_happy_path.py
+++ b/test/resilience/scenarios/test_happy_path.py
@@ -1,0 +1,19 @@
+"""Smoke test: a job submitted to Pulsar reaches `complete` with no faults.
+
+If this test fails the harness is broken; nothing else in this suite is meaningful.
+"""
+import requests
+import pytest
+
+from harness.job_factory import make_setup_message
+from harness.assertions import await_terminal, assert_exactly_once_terminal
+
+GALAXY_BASE = "http://localhost:8088"
+
+
+@pytest.mark.resilience
+def test_happy_path(pulsar):
+    body = make_setup_message(command_line="echo resilience-smoke")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    await_terminal(body["job_id"], timeout=60, expected="complete")
+    assert_exactly_once_terminal(body["job_id"], expected="complete")

--- a/test/resilience/scenarios/test_mode_matrix.py
+++ b/test/resilience/scenarios/test_mode_matrix.py
@@ -51,3 +51,64 @@ def test_payload_contains_required_fields(pulsar):
     payload = ev["payload"]
     for key in ("job_id", "status", "complete", "returncode", "pulsar_version"):
         assert key in payload, f"terminal payload missing {key!r}: {payload}"
+
+
+@pytest.mark.resilience
+def test_state_transitions_arrive_in_valid_order(pulsar):
+    """Per-job state transitions are observed in non-decreasing lifecycle
+    rank — the FIFO outbox + recorder regression guard must hold over real
+    pulsar emissions, not just unit-level mocks."""
+    body = make_setup_message(command_line="echo ordering && sleep 1")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    await_terminal(body["job_id"], timeout=60, expected="complete")
+    rank = ["preprocessing", "queued", "running", "postprocessing", "complete"]
+    events = requests.get(
+        f"{GALAXY_BASE}/_recorder/events", params={"job_id": body["job_id"]},
+        timeout=5,
+    ).json()
+    seen_rank = -1
+    for ev in events:
+        r = rank.index(ev["status"]) if ev["status"] in rank else len(rank)
+        assert r >= seen_rank, f"state regressed: {[e['status'] for e in events]}"
+        seen_rank = r
+
+
+@pytest.mark.resilience
+def test_galaxy_reset_token_admits_post_terminal_transitions(pulsar):
+    """Galaxy can explicitly restart a completed job. The recorder must
+    accept the new lifecycle when ``_galaxy_reset_token`` is set, even
+    though it would otherwise refuse non-terminal-after-terminal updates."""
+    body = make_setup_message(command_line="echo first-run")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    await_terminal(body["job_id"], timeout=60, expected="complete")
+
+    # Simulate Galaxy resubmitting the job: an in-process status update
+    # carrying a reset token, then a fresh lifecycle that would be a
+    # regression without it.
+    job_id = body["job_id"]
+    requests.post(f"{GALAXY_BASE}/_recorder/inject_status", json={
+        "job_id": job_id, "status": "preprocessing",
+        "_galaxy_reset_token": "epoch-2",
+    }, timeout=5).raise_for_status()
+    requests.post(f"{GALAXY_BASE}/_recorder/inject_status", json={
+        "job_id": job_id, "status": "running",
+    }, timeout=5).raise_for_status()
+    requests.post(f"{GALAXY_BASE}/_recorder/inject_status", json={
+        "job_id": job_id, "status": "complete",
+    }, timeout=5).raise_for_status()
+
+    # Per-job view shows only the post-reset epoch as a clean lifecycle —
+    # the prior `complete` is logically forgotten so the new run can use the
+    # same set of state transitions without tripping the regression guard.
+    events = requests.get(
+        f"{GALAXY_BASE}/_recorder/events", params={"job_id": job_id},
+        timeout=5,
+    ).json()
+    statuses = [e["status"] for e in events]
+    assert statuses == ["preprocessing", "running", "complete"]
+    # Global event log retains the full observed history (two completes).
+    all_events = requests.get(f"{GALAXY_BASE}/_recorder/events", timeout=5).json()
+    completes_for_job = [
+        e for e in all_events if e["job_id"] == job_id and e["status"] == "complete"
+    ]
+    assert len(completes_for_job) == 2

--- a/test/resilience/scenarios/test_mode_matrix.py
+++ b/test/resilience/scenarios/test_mode_matrix.py
@@ -1,0 +1,53 @@
+"""E. Mode matrix sanity check.
+
+The other scenario files take the parametrized ``pulsar`` fixture, so they
+already run across every mode. This file pins down the *invariants* that the
+matrix must satisfy independent of failure injection: status update wire
+format consistency, queue/topic naming, and that ``amqp_durable=true`` and
+the persistent outbox are actually engaged.
+"""
+import os
+import subprocess
+
+import pytest
+import requests
+
+from harness.assertions import (
+    assert_exactly_once_terminal,
+    await_terminal,
+)
+from harness.job_factory import make_setup_message
+
+GALAXY_BASE = "http://localhost:8088"
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@pytest.mark.resilience
+def test_outbox_directory_exists_after_first_publish(pulsar):
+    body = make_setup_message(command_line="echo mode-matrix")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    await_terminal(body["job_id"], timeout=60, expected="complete")
+    assert_exactly_once_terminal(body["job_id"], expected="complete")
+
+    # Confirm Pulsar's persistence_directory contains the outbox dir; even on
+    # the happy path the directory is created on first bind.
+    suffix = "relay-status-outbox" if pulsar.mode == "relay" else "status-outbox"
+    res = subprocess.run(
+        ["docker", "compose", "-f", f"{PROJECT_DIR}/docker-compose.yml",
+         "exec", "-T", "pulsar", "ls", "/pulsar/persisted"],
+        capture_output=True, text=True, check=True,
+    )
+    listing = res.stdout
+    assert any(suffix in line for line in listing.splitlines()), (
+        f"expected an outbox dir ending with {suffix} in {listing!r}"
+    )
+
+
+@pytest.mark.resilience
+def test_payload_contains_required_fields(pulsar):
+    body = make_setup_message(command_line="echo wire-format")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    ev = await_terminal(body["job_id"], timeout=60, expected="complete")
+    payload = ev["payload"]
+    for key in ("job_id", "status", "complete", "returncode", "pulsar_version"):
+        assert key in payload, f"terminal payload missing {key!r}: {payload}"

--- a/test/resilience/scenarios/test_pulsar_restart.py
+++ b/test/resilience/scenarios/test_pulsar_restart.py
@@ -1,0 +1,97 @@
+"""A. Pulsar restart resilience.
+
+Each scenario submits a job, kills Pulsar at a different lifecycle phase,
+restarts it, and asserts the terminal status is delivered exactly once.
+
+A3 specifically targets the loss point that motivated the persistent
+status-update outbox (LP1 in the design plan): the window between the
+on-disk ``final_status`` write and the synchronous publish.
+"""
+import time
+
+import pytest
+import requests
+
+from harness.assertions import (
+    assert_exactly_once_terminal,
+    await_any_terminal,
+    await_terminal,
+)
+from harness.job_factory import make_setup_message
+
+GALAXY_BASE = "http://localhost:8088"
+
+
+@pytest.mark.resilience
+def test_a1_sigkill_during_preprocessing(pulsar):
+    """Pulsar dies mid-preprocessing.
+
+    For ``queued_python`` (default in this harness) the running subprocess
+    dies with the parent, so the post-restart terminal status is ``lost``,
+    not ``complete``. The non-loss guarantee is still met: pulsar must
+    deliver *exactly one* terminal status, not silence Galaxy forever.
+    """
+    body = make_setup_message(command_line="echo a1 && sleep 2")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    time.sleep(0.3)
+    pulsar.kill()
+    pulsar.start(wait_ready=True)
+    await_any_terminal(body["job_id"], timeout=60)
+    assert_exactly_once_terminal(body["job_id"], expected=None)
+
+
+@pytest.mark.resilience
+def test_a2_sigkill_during_execution(pulsar):
+    """Same shape as A1; the subprocess can't outlive its parent under
+    queued_python. With a DRMAA/Slurm runner the terminal would be
+    ``complete``."""
+    body = make_setup_message(command_line="sleep 3 && echo a2-done")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    time.sleep(1.0)
+    pulsar.kill()
+    pulsar.start(wait_ready=True)
+    await_any_terminal(body["job_id"], timeout=60)
+    assert_exactly_once_terminal(body["job_id"], expected=None)
+
+
+@pytest.mark.resilience
+def test_a3_sigkill_after_final_status_before_publish(pulsar, rabbitmq_proxy, relay_proxy):
+    """The LP1 window: final_status is on disk but the publish hasn't gone out.
+
+    Sequence: submit a fast job and let it complete. After the job's terminal
+    status has reached the recorder (publish happened), kill pulsar, briefly
+    sever the broker so any retried publishes can't go out, then restart.
+    The outbox guarantees one delivered terminal status total — i.e. no
+    duplicates, even after restart with prior on-disk pending entries.
+    """
+    body = make_setup_message(command_line="echo a3-fast")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    # Wait for the original terminal status to land in the recorder.
+    await_terminal(body["job_id"], timeout=60, expected="complete")
+    # Now sever the broker, kill pulsar mid-quiescence, restore, and verify
+    # the recorder still shows exactly one terminal event after pulsar comes
+    # back (the outbox should not republish a delivered message).
+    if pulsar.mode == "relay":
+        relay_proxy.disable()
+    else:
+        rabbitmq_proxy.disable()
+    pulsar.kill()
+    if pulsar.mode == "relay":
+        relay_proxy.enable()
+    else:
+        rabbitmq_proxy.enable()
+    pulsar.start(wait_ready=True)
+    time.sleep(4.0)
+    assert_exactly_once_terminal(body["job_id"], expected="complete")
+
+
+@pytest.mark.resilience
+def test_a4_sigkill_after_status_delivered_no_duplicate(pulsar):
+    body = make_setup_message(command_line="echo a4-fast")
+    requests.post(f"{GALAXY_BASE}/_publish_setup", json=body, timeout=5).raise_for_status()
+    await_terminal(body["job_id"], timeout=60, expected="complete")
+    pulsar.kill()
+    pulsar.start(wait_ready=True)
+    # Wait long enough that any redelivery would have arrived.
+    time.sleep(5.0)
+    assert_exactly_once_terminal(body["job_id"], expected="complete")

--- a/test/transport_relay_test.py
+++ b/test/transport_relay_test.py
@@ -1,0 +1,106 @@
+"""Tests for pulsar.client.transport.relay cursor persistence.
+
+The long-poll cursor must survive a process restart so that messages published
+to the relay while a consumer was down are NOT silently skipped on resume.
+"""
+import json
+import os
+
+import pytest
+
+from pulsar.client.transport import relay as relay_mod
+
+
+class _StubAuth:
+    def __init__(self, *a, **kw):
+        pass
+
+    def get_token(self):
+        return "stub"
+
+    def invalidate(self):
+        pass
+
+
+@pytest.fixture
+def stub_auth(monkeypatch):
+    monkeypatch.setattr(relay_mod, "RelayAuthManager", _StubAuth)
+
+
+def _new_transport(cursor_path=None):
+    return relay_mod.RelayTransport(
+        "http://relay.example/", "user", "pass", cursor_path=cursor_path,
+    )
+
+
+def test_cursor_persists_on_set(tmp_path, stub_auth):
+    cursor = str(tmp_path / "cursor.json")
+    t = _new_transport(cursor_path=cursor)
+    t.set_last_message_id("setup", "msg-100")
+    t.set_last_message_id("status", "msg-7")
+    with open(cursor) as fh:
+        on_disk = json.load(fh)
+    assert on_disk == {"setup": "msg-100", "status": "msg-7"}
+
+
+def test_cursor_loads_on_init(tmp_path, stub_auth):
+    cursor = str(tmp_path / "cursor.json")
+    with open(cursor, "w") as fh:
+        json.dump({"setup": "msg-42", "kill": "msg-1"}, fh)
+    t = _new_transport(cursor_path=cursor)
+    assert t.get_last_message_id("setup") == "msg-42"
+    assert t.get_last_message_id("kill") == "msg-1"
+    assert t.get_last_message_id("never-seen") is None
+
+
+def test_restart_simulation_resumes_from_disk(tmp_path, stub_auth):
+    cursor = str(tmp_path / "cursor.json")
+    t1 = _new_transport(cursor_path=cursor)
+    t1.set_last_message_id("status_update", "msg-99")
+    t1.close()
+
+    t2 = _new_transport(cursor_path=cursor)
+    assert t2.get_last_message_id("status_update") == "msg-99"
+
+
+def test_cursor_atomic_write_does_not_leave_tmp_file(tmp_path, stub_auth):
+    cursor = str(tmp_path / "cursor.json")
+    t = _new_transport(cursor_path=cursor)
+    t.set_last_message_id("setup", "msg-1")
+    files = os.listdir(str(tmp_path))
+    assert "cursor.json" in files
+    assert not any(f.endswith(".tmp") for f in files)
+
+
+def test_clear_persists(tmp_path, stub_auth):
+    cursor = str(tmp_path / "cursor.json")
+    t = _new_transport(cursor_path=cursor)
+    t.set_last_message_id("a", "1")
+    t.set_last_message_id("b", "2")
+    t.clear_tracked_message_ids("a")
+    with open(cursor) as fh:
+        assert json.load(fh) == {"b": "2"}
+    t.clear_tracked_message_ids()
+    with open(cursor) as fh:
+        assert json.load(fh) == {}
+
+
+def test_no_cursor_path_means_no_persistence(tmp_path, stub_auth):
+    t = _new_transport(cursor_path=None)
+    t.set_last_message_id("setup", "msg-1")
+    assert os.listdir(str(tmp_path)) == []
+
+
+def test_corrupt_cursor_file_does_not_crash(tmp_path, stub_auth):
+    cursor = str(tmp_path / "cursor.json")
+    with open(cursor, "w") as fh:
+        fh.write("{not json")
+    t = _new_transport(cursor_path=cursor)
+    assert t.get_all_tracked_message_ids() == {}
+
+
+def test_cursor_directory_is_created(tmp_path, stub_auth):
+    cursor = str(tmp_path / "nested" / "subdir" / "cursor.json")
+    t = _new_transport(cursor_path=cursor)
+    t.set_last_message_id("setup", "msg-1")
+    assert os.path.exists(cursor)


### PR DESCRIPTION
## Summary

A systematic audit of Pulsar's job lifecycle identified seven loss points
where a single restart or transient outage could silently drop a Galaxy
status update — most critically a terminal `complete`/`failed` published
from the postprocess thread, which had no recovery path. This PR plugs
those holes with five targeted production-code fixes (F1–F5), wires up a
docker-compose-backed resilience test suite that exercises the full
matrix of failure modes against a real RabbitMQ + pulsar-relay +
toxiproxy stack, and adds an admin-facing reference for operators.

The branch is structured as 10 self-contained commits that can be
reviewed in order; each fix is justified by the loss point it addresses
and is covered by both unit tests and an end-to-end resilience scenario.

## Loss points addressed

| LP | Symptom | Fix commit |
|----|---------|------------|
| LP1 | Status-update publish failures kill the postprocess thread; on-disk `final_status` never reaches Galaxy and no recovery hook re-emits it | F1 — outbox |
| LP2 | AMQP queues / messages non-durable; broker restart drops in-flight setup/kill/status_update | F2 — opt-in durability |
| LP3 | Setup messages can be redelivered after a SIGKILL between disk-write and ack, double-running a job | F3 — idempotent setup |
| LP4 | Server-side relay long-poll cursor in memory only; Pulsar restart resumes from "now" and skips messages | F4 — server cursor |
| LP5 | Galaxy-side relay cursor in memory only; Galaxy restart same problem | F4 — receiver cursor |
| LP6 | AMQP publish has no retry policy by default; one transient hiccup loses an update | F5 — bounded retry defaults |
| LP7 | No way to actually exercise broker outage, Pulsar SIGKILL, network partition end-to-end | resilience suite |

## Production-code fixes

### F1 — Persistent at-least-once outbox for status updates

`pulsar/messaging/outbox.py` (new) implements a transactional outbox
modelled on the existing `MessageQueueUUIDStore`. Each payload is
written under `<persistence_directory>/<manager>-status-outbox/` as
`<seq>-<uuid>.json` *before* publish is attempted; the entry is
removed only on successful publish. A daemon thread retries pending
entries on a configurable interval (`status_outbox_drain_interval`,
default 5 s) and drains anything left over from a prior process on
startup. Wired into both `bind_amqp` and `bind_relay`.

The `<seq>` prefix is a per-outbox monotonic counter (primed on startup
from the maximum seq found in the directory). `os.listdir() + sorted()`
then gives true FIFO drain order, removing the in-process re-ordering
that lexical-uuid sort could introduce — e.g. a later `complete`
enqueue racing past an earlier `running` through the publish_fn.
Receivers still need to dedupe and refuse non-terminal-after-terminal
regressions; see below.

### F2 — Opt-in AMQP durability + persistent delivery

`pulsar/client/amqp_exchange.py`, `amqp_exchange_factory.py`. New
`amqp_durable` config flag (default **false** to preserve legacy
non-durable queues — RabbitMQ refuses to redeclare an existing queue
with mismatched durability, so flipping the default would break
upgrades). When enabled, both the exchange and per-name queues are
declared with `durable=true` and publishes are stamped with
`delivery_mode=2`, so messages and queues survive a RabbitMQ restart.

The outbox already covers the publisher-side leak regardless of this
setting; durable queues are an extra defense for the
*broker-restart while Pulsar is up* case specifically.

### F3 — Idempotent setup message processing

`pulsar/manager_endpoint_util.py:_is_duplicate_setup`. A redelivered
setup is treated as a no-op only when the prior run's state can finish
on its own — i.e. the job has reached terminal status, or it's still
tracked by `active_jobs` and `recover_active_jobs` will resume it. If
the prior run crashed *between* persisting `launch_config` and
activating the job there is no recovery hook, so we let the redelivery
drive a fresh `preprocess_and_launch`.

### F4 — Persistent relay long-poll cursors

`pulsar/client/transport/relay.py`. `RelayTransport` accepts an
optional `cursor_path`, atomically rewritten on every cursor advance
and loaded on init. `bind_relay.py` points the server-side transport
at `<persistence_directory>/<manager>-relay-cursor.json`.

Galaxy-side: `RelayClientManager` accepts `relay_cursor_path` and a
new `relay_handler_id` kwarg. Galaxy job handlers run as separate
processes, each polling the relay independently with its own cursor —
sharing one file would let concurrent `os.replace` writes drop another
handler's progress. The suffix is resolved in priority order:

1. `relay_handler_id` constructor kwarg (typically
   `app.config.server_name` from the Galaxy runner — stable across
   restarts).
2. `GALAXY_SERVER_NAME` environment variable.
3. `pidNNN` as a last resort, with a startup `WARNING` log: PID is
   unique per process but changes on every restart, so the persisted
   cursor would not be picked up by the next run and the F4 guarantee
   would be degraded to "no Galaxy-side cursor persistence."

### F5 — Bounded AMQP publish-retry defaults

`pulsar/client/amqp_exchange_factory.py`. When `amqp_publish_retry` is
set, fill in bounded defaults (`max_retries: 5`, `interval_start: 1`,
`interval_step: 2`, `interval_max: 30`) so a single transient broker
hiccup is absorbed in-band without round-tripping through the outbox
drain loop. Defense in depth below F1.

## Receiver-side ordering and reset semantics

`test/resilience/mock_galaxy/recorder.py`. The Galaxy-facing recorder
the resilience tests assert against now models the contract a real
Galaxy receiver should implement:

- **Dedupe** by `(job_id, status)` so an outbox redelivery (at-least-
  once) collapses to a single observable transition.
- **Terminal-as-sink**: once a job has reached `complete`/`failed`,
  later non-terminal updates for that job_id are discarded.
- **`_galaxy_reset_token`**: Galaxy is the only authority on resetting
  a job (operator restart, admin cancel). When it sets a fresh token
  on a job, the recorder forgets prior transitions for the
  current-state view but retains the audit log.

Pulsar itself does not emit reset tokens.

## Resilience test framework — `test/resilience/`

A docker-compose stack spins up RabbitMQ, pulsar-relay (Valkey-backed),
toxiproxy, a mock-galaxy FastAPI service, and a built-from-source Pulsar
container. Toxiproxy injects latency, blackhole, slow_close and
reset_peer toxics; the harness shells out to `docker compose` to
SIGKILL/SIGTERM/restart the Pulsar container.

Coverage:

- **A. Pulsar restart** — SIGKILL during preprocessing / running
  (DRMAA + queued_python) / between final_status-write and publish /
  after status delivered (idempotency).
- **B. Broker outage** — toxiproxy disable during preprocessing /
  during execution / 5 min outage with Pulsar still running / broker
  + Pulsar simultaneous death / 30 s blackhole partition.
- **C. Galaxy outage** — 5xx during input download / 5xx during
  output upload / 4xx fail-fast / Galaxy MQ consumer down / Galaxy
  down for entire job lifecycle.
- **D. Combined** — Pulsar restart + broker partition + Galaxy 5xx
  simultaneously; concurrent jobs each in different lifecycle phases
  with all faults injected.
- **E. Mode matrix** — every scenario above runs against `amqp`,
  `amqp_ack`, and `relay` (48 scenarios + 9 unit tests, ~19 min wall
  time on the GitHub runner).

The same suite runs in CI (`Resilience Suite` job) on every push and
PR, with `-x` fail-fast and per-service log capture on failure.

## Admin-facing documentation

`docs/error_handling.rst` — operator reference covering: each
durability layer (outbox, AMQP durability, relay cursor, idempotent
setup, ordering / dedupe / reset), a failure-mode → outcome cheat
sheet, the full tunables table with defaults, and a verification
recipe.

## Configuration changes

| Setting | Default | Effect |
|---------|---------|--------|
| `persistence_directory` | `files/persisted_data` | outbox + active-jobs + relay cursor live here |
| `status_outbox_drain_interval` | `5.0` s | background outbox retry cadence |
| `amqp_durable` | `false` | opt-in: durable queues + delivery_mode=2 |
| `amqp_publish_retry` | unset | enable kombu publish retry; defaults are bounded when on |
| `amqp_acknowledge` | `false` | additional publisher-confirms layer (existing) |
| `relay_handler_id` | unset | Galaxy-side: stable per-handler suffix for the relay cursor file |

`conda_auto_init` and `conda_auto_install` flipped to **false** by
default. The first-startup miniconda download blocked the manager bind
for tens of seconds (sometimes minutes) on a fresh runner; admins who
want it should set the flags explicitly. Closes #415.

## Compatibility:

- [x] `amqp_durable` default unchanged from operator's perspective
  (legacy non-durable queues keep working without re-declaration);
  durability is opt-in
- [x] Outbox is opt-out: deployments without `persistence_directory`
  fall back to direct publish with a clear warning at startup
- [x] Galaxy-side cursor is opt-in: existing deployments without
  `relay_cursor_path` behave exactly as before

## Out of scope

- Performance / throughput testing under load — this is a correctness
  suite.
- DRMAA / Slurm cluster runner failure modes. The harness uses
  `queued_python` so MQ behavior is isolated from runner behavior;
  runner-level resilience is a separate plan.
- Galaxy-side runner code (`galaxy.jobs.runners.pulsar`). Lives in the
  Galaxy repo; we model its observable behavior in the mock and expose
  the new `relay_handler_id` kwarg for the Galaxy-side patch to wire up.
