### PR TITLE
Force-copy input metadata files when default_file_action is none

### DIFF
--- a/pulsar/client/action_mapper.py
+++ b/pulsar/client/action_mapper.py
@@ -141,6 +141,12 @@ class FileActionMapper:
     True
     >>> action.staging_needed
     True
+    >>> # Always at least copy input metadata files.
+    >>> action = mapper.action({'path': '/opt/galaxy/database/working_directory/metadata'}, 'metadata')
+    >>> action.action_type == u'copy'
+    True
+    >>> action.staging_needed
+    True
     >>> # Test glob mapper (matching test)
     >>> mapper.action({'path': '/cool/bamfiles/projectABC/study1/patient3.bam'}, 'input').action_type == u'copy'
     True
@@ -250,7 +256,7 @@ class FileActionMapper:
         action_type = self.default_action if type in ACTION_DEFAULT_PATH_TYPES else "none"
         if mapper:
             action_type = mapper.action_type
-        if type in ["workdir", "jobdir", "output_workdir", "output_metadata", "output_jobdir"] and action_type == "none":
+        if type in ["workdir", "jobdir", "metadata", "output_workdir", "output_metadata", "output_jobdir"] and action_type == "none":
             # We are changing the working_directory/job_directory relative to what
             # Galaxy would use, these need to be copied over.
             action_type = "copy"


### PR DESCRIPTION
When default_file_action: none is set on a Pulsar destination + metadata_strategy=extended:

1. Galaxy writes set.py, params.json, registry.xml, outputs_* and other extended-metadata helper files to <galaxy_working>/metadata/.
2. Galaxy passes metadata_directory=<galaxy_working>/metadata to Pulsar in ClientJobDescription.
3. Pulsar's ClientStagingTransfer.__upload_metadata_directory_files() (pulsar/client/staging/up.py:312-315) walks that directory and asks the action mapper how to stage each file, using path_type.METADATA. 4.Pulsar's FileActionMapper.__action_class
(pulsar/client/action_mapper.py:249-256) returns the default action — none — for path_type.METADATA. Note that output_metadata, workdir, jobdir, output_workdir, output_jobdir are forced to copy here even when the default is none, but plain metadata is not in that forced-copy list.
5. Result: set.py/params.json stay in Galaxy's working directory, but Pulsar still creates its own pulsar_staging/N/ and cds into it before running python metadata/set.py. The relative path resolves against Pulsar's staging dir → FileNotFoundError.

Treat "metadata" the same as workdir/jobdir/output_* path types: always escalate to "copy" when the resolved action would otherwise be "none".

This removes a footgun for deployments that combine default_file_action: none with extended metadata without a matching file_actions override.

One of the test errors found while looking at https://github.com/galaxyproject/galaxy/actions/workflows/integration.yaml?query=event%3Aschedule