### PR TITLE
Make sudo calls return stdout as str

### DIFF
--- a/pulsar/managers/queued_external_drmaa.py
+++ b/pulsar/managers/queued_external_drmaa.py
@@ -29,7 +29,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
         self.drmaa_launch_script = _handle_default(kwds.get('drmaa_launch_script', None), "drmaa_launch")
         self.production = str(kwds.get('production', "true")).lower() != "false"
         self.reclaimed = {}
-        self.user_map = {}
+        self.user_map: dict[str, str] = {}
 
     def launch(self, job_id, command_line, submit_params={}, dependencies_description=None, env=[], setup_params=None):
         self._check_execution_with_tool_file(job_id, command_line)
@@ -66,7 +66,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
             self.__change_ownership(job_id, getuser())
         return external_status
 
-    def __launch(self, job_attributes, user):
+    def __launch(self, job_attributes, user) -> str:
         return self.__sudo(self.drmaa_launch_script, "--job_attributes", str(job_attributes), user=user)
 
     def __change_ownership(self, job_id, username):
@@ -81,7 +81,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
         # TODO: Verify ownership change.
         self.__sudo(*cmds)
 
-    def __sudo(self, *cmds, **kwargs):
+    def __sudo(self, *cmds, **kwargs) -> str:
         p = sudo_popen(*cmds, **kwargs)
         stdout, stderr = p.communicate()
         assert p.returncode == 0, "{}, {}".format(stdout, stderr)

--- a/pulsar/managers/util/sudo.py
+++ b/pulsar/managers/util/sudo.py
@@ -22,5 +22,5 @@ def sudo_popen(*args, **kwargs):
         full_command.extend([SUDO_USER_ARG, user])
     full_command.extend(args)
     log.info(f"About to execute the following sudo command - [{' '.join(full_command)}]")
-    p = Popen(full_command, shell=False, stdout=PIPE, stderr=PIPE)
+    p = Popen(full_command, shell=False, stdout=PIPE, stderr=PIPE, text=True)
     return p


### PR DESCRIPTION
Otherwise I get

```
Traceback (most recent call last):
  File "/data/galaxy_server/pulsar_venv/lib/python3.12/site-packages/pulsar/managers/stateful.py", line 217, in __deactivate
    deactivate_method(job_id)
  File "/data/galaxy_server/pulsar_venv/lib/python3.12/site-packages/pulsar/managers/queued_external_drmaa.py", line 98, in _deactivate_job
    del self.user_map[external_id]
        ~~~~~~~~~~~~~^^^^^^^^^^^^^
  KeyError: '49104886'
```

the launch method stored mapping with key `b'49104886'`.