### PR TITLE
Allow a user mapping script for ExternalDrmaaQueueManager

### DIFF
--- a/docs/job_managers.rst
+++ b/docs/job_managers.rst
@@ -150,10 +150,17 @@ run DRMAA jobs via the user requested by the client (e.g. the Galaxy user).
         #chown_working_directory_script: scripts/chown_working_directory.bash
         #drmaa_kill_script: scripts/drmaa_kill.bash
         #drmaa_launch_script: scripts/drmaa_launch.bash
+        #user_mapping_script: 
 
 For more information on running jobs as the real user, check out `this discussion
 <http://dev.list.galaxyproject.org/Managing-Data-Locality-tp4662438.html>`__ from
 the Galaxy mailing list.
+
+A script that maps the user name that pulsr gets from the Galaxy server to a user name
+on the target system can be configured with the optional parameter ``user_mapping_script``.
+The script is supposed to get a single positional parameter and should output the
+desired user name to stdout. In can a mapping is not possible a non-zero exit code 
+be returned and an error message should be printed on stderr.
 
 More Options
 -------------------------------

--- a/pulsar/managers/queued_external_drmaa.py
+++ b/pulsar/managers/queued_external_drmaa.py
@@ -1,5 +1,6 @@
 from getpass import getuser
 from json import dumps
+import subprocess
 
 from .base.base_drmaa import BaseDrmaaManager
 from .util.sudo import sudo_popen
@@ -27,6 +28,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
         self.chown_working_directory_script = _handle_default(kwds.get('chown_working_directory_script', None), "chown_working_directory")
         self.drmaa_kill_script = _handle_default(kwds.get('drmaa_kill_script', None), "drmaa_kill")
         self.drmaa_launch_script = _handle_default(kwds.get('drmaa_launch_script', None), "drmaa_launch")
+        self.user_mapping_script = kwds.get('user_mapping_script', None)
         self.production = str(kwds.get('production', "true")).lower() != "false"
         self.reclaimed = {}
         self.user_map = {}
@@ -47,6 +49,14 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
         log.info("Submit as user %s" % user)
         if not user:
             raise Exception("Must specify user submit parameter with this manager.")
+        if self.user_mapping_script:
+            try:
+                mapped_user = subprocess.check_output([self.user_mapping_script, user], text=True).strip()
+                log.info("Mapped user %s to %s" % (user, mapped_user))
+                user = mapped_user
+            except subprocess.CalledProcessError as e:
+                log.error(f"Could not map user {user}: {e.stderr}")
+                raise Exception("User mapping script failed")
         self.__change_ownership(job_id, user)
         external_id = self.__launch(job_attributes_file, user).strip()
         self.user_map[external_id] = user


### PR DESCRIPTION
Use case: I'm currently trying to connect our HPC to usegalaxy.eu. The HPC requires submission as real user. Of course usernames on HPC and usegalaxy do not match. My idea is that I configure the destination on the Galaxy side to transfer  the email instead of the username to the pulsar server. On the pulsar server I can then use an LDAP lookup to get the username from the email. 

