### PR TITLE
Publish capability snapshots to the relay for Galaxy BYOC

### DIFF
--- a/app.yml.sample
+++ b/app.yml.sample
@@ -104,6 +104,15 @@
 ## configured in Galaxy's job_conf.yml if set.
 #relay_topic_prefix: production
 
+## On startup, publish a static capability snapshot (staging dirs, dependency
+## resolvers, container runtimes available, manager type) to the relay topic
+## "pulsar_capabilities[_<manager>]". Galaxy can read this to auto-fill
+## destination params and to refuse jobs that ask for capabilities this Pulsar
+## doesn't have. Advisory: a publish failure does not block startup, and
+## Galaxy keeps using operator-supplied params if no snapshot is available.
+## Set to false to disable the publish entirely.
+#message_queue_publish_capabilities: true
+
 ## Pulsar loops over waiting for queue messages for a short time before checking
 ## to see if it has been instructed to shut down. By default this is 0.2
 ## seconds. This value is used as the value of the 'timeout' parameter to

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -246,6 +246,13 @@ In this mode:
 4. **Relay → Galaxy**: Galaxy polls the relay to receive status updates
 5. **File Transfers**: Pulsar transfers files directly to/from Galaxy via HTTP
    (not through the relay)
+6. **Pulsar → Relay (capabilities)**: On startup Pulsar publishes a one-shot,
+   advisory snapshot of its configuration and host capabilities (staging
+   directories, dependency resolvers, available container runtimes, manager
+   type) to the ``pulsar_capabilities`` topic. Galaxy reads the latest snapshot
+   to auto-fill destination parameters and to downgrade per-job requests the
+   remote Pulsar cannot satisfy. This publish is fire-and-forget — a failure
+   never blocks Pulsar startup.
 
 ::
 
@@ -314,6 +321,31 @@ with proxy parameters::
 
     The ``relay_topic_prefix`` must match on both Galaxy and Pulsar sides.
     If set on one side but not the other, messages will not be routed correctly.
+
+
+Capability Snapshot
+```````````````````
+
+When using relay mode, Pulsar publishes a single capability snapshot per
+manager when it binds to the relay at startup. Galaxy's "bring your own
+compute" integration reads the most recent snapshot to pre-fill destination
+parameters and to refuse or downgrade jobs that request something the remote
+Pulsar does not provide (e.g. a container runtime that is not on ``PATH``).
+
+The snapshot is published to the ``pulsar_capabilities`` topic — or
+``<relay_topic_prefix>_pulsar_capabilities[_<manager>]`` when a topic prefix
+or non-default manager name is configured, mirroring the other relay topics.
+
+This behavior is on by default and can be disabled::
+
+    message_queue_publish_capabilities: false
+
+.. note::
+
+    The snapshot is advisory. A publish failure is logged and swallowed — it
+    never blocks Pulsar startup — and if no snapshot is available Galaxy falls
+    back to the operator-supplied destination parameters. The data is collected
+    once at startup and is static for the lifetime of the process.
 
 
 Authentication

--- a/docs/error_handling.rst
+++ b/docs/error_handling.rst
@@ -195,6 +195,11 @@ persist concurrently and could silently rewind another handler's
 progress, which is why the suffix is mandatory whenever
 ``relay_cursor_path`` is set.
 
+The startup capability snapshot is intentionally *advisory* and is excluded
+from these durability defenses — it carries no outbox or cursor; a missed
+or failed publish simply means Galaxy uses operator-supplied destination
+parameters until the next Pulsar restart re-publishes.
+
 ------------------------------------------------------------------------
 5. Setup-message idempotency
 ------------------------------------------------------------------------

--- a/pulsar/capabilities.py
+++ b/pulsar/capabilities.py
@@ -1,0 +1,177 @@
+"""Static capability snapshot collection for a Pulsar app.
+
+A ``PulsarCapabilities`` is a serializable summary of what a Pulsar
+server is configured to do — staging paths, dependency resolvers,
+container runtimes available on the host — so that Galaxy can read it
+at job-build time and adjust (or refuse) requests that the remote does
+not actually support.
+
+The data is collected on demand by the relay publisher in
+``messaging.bind_app`` (lazily, only when relay mode is active and the
+``message_queue_publish_capabilities`` knob is on). It is never recomputed
+within a process; consumers fetch the latest snapshot via the relay's REST
+topic-messages endpoint.
+
+Schema is versioned (``SCHEMA_VERSION``); bumping it is a wire-breaking
+change for consumers, so add new optional fields rather than reshape
+existing ones.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from dataclasses import (
+    asdict,
+    dataclass,
+    field,
+)
+from typing import (
+    TYPE_CHECKING,
+    List,
+    Optional,
+    Union,
+)
+
+from galaxy.tool_util.deps.resolvers.conda import CondaDependencyResolver
+
+from pulsar import __version__ as pulsar_version
+
+if TYPE_CHECKING:
+    from pulsar.core import PulsarApp
+    from pulsar.managers.stateful import StatefulManagerProxy
+
+log = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+
+@dataclass
+class DependencyResolverInfo:
+    type: str
+    disabled: bool = False
+    versionless: bool = False
+    auto_init: Optional[bool] = None
+    auto_install: Optional[bool] = None
+    prefix: Optional[str] = None
+
+
+@dataclass
+class ContainerRuntimeInfo:
+    docker_available: bool = False
+    singularity_available: bool = False
+    apptainer_available: bool = False
+
+
+@dataclass
+class ManagerCapabilities:
+    name: str
+    type: str
+    num_concurrent_jobs: Union[int, str, None] = None
+
+
+@dataclass
+class PulsarCapabilities:
+    schema_version: int
+    manager_name: str
+    pulsar_version: str
+    staging_directory: str
+    persistence_directory: Optional[str]
+    tool_dependency_dir: Optional[str]
+    dependency_resolvers: List[DependencyResolverInfo] = field(default_factory=list)
+    conda_available: bool = False
+    container_runtime: ContainerRuntimeInfo = field(default_factory=ContainerRuntimeInfo)
+    manager: Optional[ManagerCapabilities] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def collect_capabilities(app: "PulsarApp", manager: "StatefulManagerProxy") -> PulsarCapabilities:
+    """Build the capabilities snapshot for a single manager on this app."""
+    resolvers = _collect_dependency_resolvers(app)
+    manager_caps = _collect_manager(manager)
+    return PulsarCapabilities(
+        schema_version=SCHEMA_VERSION,
+        manager_name=manager_caps.name,
+        pulsar_version=pulsar_version,
+        staging_directory=app.staging_directory,
+        persistence_directory=app.persistence_directory,
+        tool_dependency_dir=_tool_dependency_dir(app),
+        dependency_resolvers=resolvers,
+        conda_available=_conda_available(resolvers),
+        container_runtime=_detect_container_runtime(),
+        manager=manager_caps,
+    )
+
+
+def _collect_dependency_resolvers(app: "PulsarApp") -> List[DependencyResolverInfo]:
+    out: List[DependencyResolverInfo] = []
+    for r in app.dependency_manager.dependency_resolvers:
+        # ``resolver_type`` and ``versionless`` are class attributes on
+        # concrete subclasses, not the base — probe defensively rather
+        # than narrow the loop type to every known subclass.
+        rt = getattr(r, "resolver_type", None)
+        if not rt:
+            continue
+        info = DependencyResolverInfo(
+            type=str(rt),
+            disabled=r.disabled,
+            versionless=bool(getattr(r, "versionless", False)),
+        )
+        if isinstance(r, CondaDependencyResolver):
+            info.auto_init = bool(r.auto_init)
+            info.auto_install = bool(r.auto_install)
+            info.prefix = str(r.prefix) if r.prefix else None
+        out.append(info)
+    return out
+
+
+def _conda_available(resolvers: List[DependencyResolverInfo]) -> bool:
+    """A conda resolver is enabled and conda is reachable on this host.
+
+    "Reachable" means either the conda binary is on PATH or the resolver's
+    configured prefix exists on disk — Galaxy on the requesting side wants
+    to know whether ``dependency_resolution=remote`` will actually find
+    something to run.
+    """
+    for r in resolvers:
+        if r.type != "conda" or r.disabled:
+            continue
+        if shutil.which("conda"):
+            return True
+        if r.prefix and os.path.isdir(r.prefix):
+            return True
+    return False
+
+
+def _detect_container_runtime() -> ContainerRuntimeInfo:
+    return ContainerRuntimeInfo(
+        docker_available=bool(shutil.which("docker")),
+        singularity_available=bool(shutil.which("singularity")),
+        apptainer_available=bool(shutil.which("apptainer")),
+    )
+
+
+def _collect_manager(manager: "StatefulManagerProxy") -> ManagerCapabilities:
+    underlying = manager._proxied_manager
+    # ``manager_type`` is a class attribute set on each concrete manager
+    # implementation but not on the proxy or its base. The ``work_threads``
+    # attribute is queued_python-only — falling back to a public
+    # ``num_concurrent_jobs`` covers any future manager that exposes one.
+    mtype = getattr(type(underlying), "manager_type", "unknown")
+    work_threads = getattr(underlying, "work_threads", None)
+    num: Union[int, str, None]
+    if work_threads is not None:
+        try:
+            num = len(work_threads)
+        except TypeError:
+            num = None
+    else:
+        num = getattr(underlying, "num_concurrent_jobs", None)
+    return ManagerCapabilities(name=manager.name, type=str(mtype), num_concurrent_jobs=num)
+
+
+def _tool_dependency_dir(app: "PulsarApp") -> Optional[str]:
+    base = getattr(app.dependency_manager, "default_base_path", None)
+    return str(base) if base else None

--- a/pulsar/messaging/__init__.py
+++ b/pulsar/messaging/__init__.py
@@ -23,8 +23,19 @@ def bind_app(app, queue_id, conf=None):
         log.info("Detected relay connection string, binding to pulsar-relay at %s", relay_url)
 
         relay_state = RelayState()
+        merged_conf = conf or {}
         for manager in app.managers.values():
-            bind_relay.bind_manager_to_relay(manager, relay_state, relay_url, conf or {})
+            # Build the transport once per manager and reuse for both the
+            # control-message bind and the capabilities publish, so the
+            # initial token fetch + cursor file open happen exactly once.
+            relay_transport = bind_relay.build_relay_transport(manager, relay_url, merged_conf)
+            bind_relay.bind_manager_to_relay(
+                manager, relay_state, relay_url, merged_conf,
+                relay_transport=relay_transport,
+            )
+            bind_relay.publish_manager_capabilities_to_relay(
+                app, manager, relay_transport, merged_conf,
+            )
         return relay_state
     else:
         # Use AMQP binding

--- a/pulsar/messaging/bind_relay.py
+++ b/pulsar/messaging/bind_relay.py
@@ -4,6 +4,7 @@ This module provides functionality to bind Pulsar job managers to the
 pulsar-relay, allowing them to receive control messages (setup, status
 requests, kill) and publish status updates.
 """
+import datetime
 import functools
 import logging
 import os
@@ -14,6 +15,7 @@ from typing import Optional
 import requests
 
 from pulsar import manager_endpoint_util
+from pulsar.capabilities import collect_capabilities
 from .outbox import build_status_outbox
 from .relay_state import RelayState
 
@@ -27,25 +29,9 @@ def _server_cursor_path(manager) -> Optional[str]:
     return os.path.join(persistence_directory, "%s-relay-cursor.json" % manager.name)
 
 
-def bind_manager_to_relay(manager, relay_state: RelayState, relay_url, conf):
-    """Bind a specific manager to the relay.
-
-    Args:
-        manager: Pulsar job manager instance
-        relay_state: RelayState for managing consumer threads
-        relay_url: URL of the pulsar-relay server
-        conf: Configuration dictionary with relay credentials
-    """
-    # Imported lazily so pulsar still installs on Pythons that don't meet
-    # pulsar-relay-client's requires-python (currently 3.10+); the relay
-    # code path is simply unreachable on those interpreters.
-    from pulsar_relay_client import (
-        RelayTransport,
-        RelayTransportError,
-    )
-
-    manager_name = manager.name
-    log.info("bind_manager_to_relay called for relay [%s] and manager [%s]", relay_url, manager_name)
+def build_relay_transport(manager, relay_url, conf):
+    """Construct a ``RelayTransport`` for ``manager``."""
+    from pulsar_relay_client import RelayTransport
 
     # Relay credentials: prefer a refresh-token credentials file
     # (written by ``pulsar-config --login``); fall back to legacy
@@ -59,20 +45,39 @@ def bind_manager_to_relay(manager, relay_state: RelayState, relay_url, conf):
             "(recommended; run `pulsar-config --login`) or message_queue_username + "
             "message_queue_password."
         )
-
-    # Extract optional relay topic prefix
-    relay_topic_prefix = conf.get('relay_topic_prefix', '')
-
-    # Create relay transport with a per-manager persistent cursor so a Pulsar
-    # restart resumes the long-poll exactly where it left off, rather than
-    # silently skipping any setup/kill messages published while it was down.
-    relay_transport = RelayTransport(
+    return RelayTransport(
         relay_url,
         username=username,
         password=password,
         cursor_path=_server_cursor_path(manager),
         credentials_file=credentials_file,
     )
+
+
+def bind_manager_to_relay(manager, relay_state: RelayState, relay_url, conf, relay_transport=None):
+    """Bind a specific manager to the relay.
+
+    Args:
+        manager: Pulsar job manager instance
+        relay_state: RelayState for managing consumer threads
+        relay_url: URL of the pulsar-relay server
+        conf: Configuration dictionary with relay credentials
+        relay_transport: Optional pre-built ``RelayTransport``; if omitted,
+            one is constructed via :func:`build_relay_transport`.
+    """
+    # Imported lazily so pulsar still installs on Pythons that don't meet
+    # pulsar-relay-client's requires-python (currently 3.10+); the relay
+    # code path is simply unreachable on those interpreters.
+    from pulsar_relay_client import RelayTransportError
+
+    manager_name = manager.name
+    log.info("bind_manager_to_relay called for relay [%s] and manager [%s]", relay_url, manager_name)
+
+    if relay_transport is None:
+        relay_transport = build_relay_transport(manager, relay_url, conf)
+
+    # Extract optional relay topic prefix
+    relay_topic_prefix = conf.get('relay_topic_prefix', '')
 
     # Define message handlers
     process_setup_messages = functools.partial(__process_setup_message, manager)
@@ -260,6 +265,55 @@ def __client_job_id_from_body(body):
     """
     job_id = body.get("job_id", None)
     return job_id
+
+
+def publish_manager_capabilities_to_relay(app, manager, relay_transport, conf):
+    """Collect and POST this manager's capability snapshot to its relay topic.
+
+    Collection happens lazily here (not at app init) so non-relay deployments
+    do zero capability work. Both collection and POST failures are logged but
+    never raised: capabilities are advisory and must not prevent the manager's
+    control consumers from coming up.
+    """
+    # One POST per pulsar startup; the relay retains topic messages so
+    # Galaxy can fetch the snapshot synchronously via the REST messages
+    # endpoint. No heartbeat — the snapshot is static for the lifetime
+    # of the process.
+    if not conf.get("message_queue_publish_capabilities", True):
+        return
+    try:
+        capabilities = collect_capabilities(app, manager)
+    except Exception:
+        log.exception(
+            "Failed to collect capabilities for manager %s; skipping relay publish.",
+            manager.name,
+        )
+        return
+    relay_topic_prefix = conf.get('relay_topic_prefix', '')
+    topic = __make_capabilities_topic_name(relay_topic_prefix, manager.name)
+    payload = capabilities.to_dict()
+    payload["published_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    try:
+        relay_transport.post_message(topic, payload)
+        log.info("Published capabilities for manager %s to relay topic %s", manager.name, topic)
+    except Exception:
+        # Includes RelayTransportError, requests.RequestException, network errors.
+        # Swallow: capabilities are advisory and downstream Galaxy already handles a missing snapshot.
+        log.exception(
+            "Failed to publish capabilities for manager %s to relay topic %s",
+            manager.name, topic,
+        )
+
+
+def __make_capabilities_topic_name(prefix, manager_name):
+    """Topic name for capability snapshots.
+
+    Examples:
+        __make_capabilities_topic_name('', '_default_') -> 'pulsar_capabilities'
+        __make_capabilities_topic_name('', 'cluster_a') -> 'pulsar_capabilities_cluster_a'
+        __make_capabilities_topic_name('prod', '_default_') -> 'prod_pulsar_capabilities'
+    """
+    return __make_topic_name(prefix, "pulsar_capabilities", manager_name)
 
 
 def __make_topic_name(prefix, base_topic, manager_name):

--- a/test/capabilities_test.py
+++ b/test/capabilities_test.py
@@ -1,0 +1,248 @@
+"""Unit tests for the capabilities collector.
+
+The collector is exercised against a real ``StatefulManagerProxy`` /
+``QueueManager`` (see ``test_collect_capabilities_against_real_queue_manager``)
+so it fails on real contract drift rather than green-lighting hand-built
+fakes that encode the same assumptions as the code under test.
+
+The remaining helpers/doubles are intentionally minimal and limited to:
+    * ``shutil.which`` patches at the OS boundary (conda/container detection),
+    * a real ``CondaDependencyResolver`` subclass instance bypassing its heavy
+      ``__init__`` (because the collector uses ``isinstance``),
+    * a tiny ``_Resolver`` stub for non-conda resolver attribute checks,
+    * a tiny ``_StubProxy`` for the two ``num_concurrent_jobs``-fallback
+      branches in ``_collect_manager``, which are unreachable by any
+      in-tree real manager (see comment on those tests).
+"""
+import json
+from contextlib import contextmanager
+from shutil import rmtree
+from unittest import mock
+
+import pytest
+from galaxy.tool_util.deps.resolvers.conda import CondaDependencyResolver
+from galaxy.util.bunch import Bunch
+
+from pulsar import capabilities
+from pulsar.capabilities import (
+    ContainerRuntimeInfo,
+    DependencyResolverInfo,
+    _collect_dependency_resolvers,
+    _collect_manager,
+    _conda_available,
+    _detect_container_runtime,
+    collect_capabilities,
+)
+from pulsar.managers.queued import QueueManager
+from pulsar.managers.stateful import StatefulManagerProxy
+
+from .test_utils import (
+    TestDependencyManager,
+    minimal_app_for_managers,
+)
+
+
+@pytest.fixture
+def no_host_binaries():
+    """Pin ``shutil.which`` to None so container/conda detection is host-independent."""
+    with mock.patch.object(capabilities.shutil, "which", return_value=None):
+        yield
+
+
+@contextmanager
+def _real_queue_manager_proxy(app, name="_default_", num_concurrent_jobs=4):
+    proxy = StatefulManagerProxy(QueueManager(name, app, num_concurrent_jobs=num_concurrent_jobs))
+    try:
+        yield proxy
+    finally:
+        try:
+            proxy.shutdown()
+        except Exception:
+            pass
+
+
+def test_collect_capabilities_against_real_queue_manager(no_host_binaries):
+    """End-to-end: real ``StatefulManagerProxy(QueueManager(...))`` on a real
+    minimal app. Asserts the contracts the publisher relies on
+    (manager_type class attr, work_threads length, staging/persistence dirs,
+    resolver list) — if any of these drift, this test breaks."""
+    app = minimal_app_for_managers()
+    try:
+        with _real_queue_manager_proxy(app, num_concurrent_jobs=4) as proxy:
+            caps = collect_capabilities(app, proxy)
+            assert caps.schema_version == 1
+            assert caps.manager_name == "_default_"
+            assert caps.manager.type == "queued_python"
+            assert caps.manager.num_concurrent_jobs == 4
+            assert caps.staging_directory == app.staging_directory
+            assert caps.persistence_directory == app.persistence_directory
+            assert caps.dependency_resolvers == []
+            assert caps.conda_available is False
+            assert caps.container_runtime == ContainerRuntimeInfo()
+    finally:
+        try:
+            rmtree(app.staging_directory)
+        except Exception:
+            pass
+
+
+def test_to_dict_round_trips_through_json(no_host_binaries):
+    app = minimal_app_for_managers()
+    try:
+        with _real_queue_manager_proxy(app, num_concurrent_jobs=1) as proxy:
+            caps = collect_capabilities(app, proxy)
+            decoded = json.loads(json.dumps(caps.to_dict()))
+            assert decoded["manager"]["type"] == "queued_python"
+            assert decoded["schema_version"] == 1
+    finally:
+        try:
+            rmtree(app.staging_directory)
+        except Exception:
+            pass
+
+
+def test_conda_resolver_present_and_conda_on_path():
+    resolvers = [
+        DependencyResolverInfo(type="conda", disabled=False, prefix="/srv/_conda"),
+    ]
+    with mock.patch.object(capabilities.shutil, "which", return_value="/usr/bin/conda"):
+        assert _conda_available(resolvers) is True
+
+
+def test_conda_resolver_present_but_not_on_path_or_disk(tmp_path, no_host_binaries):
+    # ``missing`` is never created on disk, so the real ``isdir`` returns False.
+    missing = tmp_path / "no_conda_here"
+    resolvers = [
+        DependencyResolverInfo(type="conda", disabled=False, prefix=str(missing)),
+    ]
+    assert _conda_available(resolvers) is False
+
+
+def test_conda_resolver_disabled_means_unavailable_even_if_conda_on_path():
+    resolvers = [
+        DependencyResolverInfo(type="conda", disabled=True, prefix="/srv/_conda"),
+    ]
+    with mock.patch.object(capabilities.shutil, "which", return_value="/usr/bin/conda"):
+        assert _conda_available(resolvers) is False
+
+
+def test_conda_available_via_existing_prefix_on_disk(tmp_path, no_host_binaries):
+    resolvers = [
+        DependencyResolverInfo(type="conda", disabled=False, prefix=str(tmp_path)),
+    ]
+    assert _conda_available(resolvers) is True
+
+
+@pytest.mark.parametrize("docker,singularity,apptainer", [
+    (True, False, False),
+    (False, True, False),
+    (False, False, True),
+    (True, True, True),
+    (False, False, False),
+])
+def test_detect_container_runtime_cross_product(docker, singularity, apptainer):
+    def fake_which(binary):
+        return {
+            "docker": "/usr/bin/docker" if docker else None,
+            "singularity": "/usr/bin/singularity" if singularity else None,
+            "apptainer": "/usr/bin/apptainer" if apptainer else None,
+        }.get(binary)
+    with mock.patch.object(capabilities.shutil, "which", side_effect=fake_which):
+        cr = _detect_container_runtime()
+    assert cr.docker_available is docker
+    assert cr.singularity_available is singularity
+    assert cr.apptainer_available is apptainer
+
+
+def _make_conda_resolver(*, prefix, **attrs):
+    """Build a real CondaDependencyResolver bypassing its heavy __init__.
+
+    The collector uses ``isinstance(r, CondaDependencyResolver)`` to
+    pick conda-specific fields, so the test fixture has to be a real
+    subclass instance — duck-typed mocks won't match. ``prefix`` is a
+    property reading ``self.conda_context.conda_prefix``, so we set the
+    underlying field rather than trying to assign through the property.
+    """
+    class _CondaContext:
+        def __init__(self, p):
+            self.conda_prefix = p
+
+    inst = CondaDependencyResolver.__new__(CondaDependencyResolver)
+    inst.conda_context = _CondaContext(prefix)
+    for k, v in attrs.items():
+        setattr(inst, k, v)
+    return inst
+
+
+class _Resolver:
+    """Minimal non-conda resolver stub.
+
+    Resolver subclasses legitimately vary in attributes; the collector
+    probes via ``getattr``/``isinstance``, so a stub at this boundary is
+    correct rather than a real subclass.
+    """
+
+    def __init__(self, resolver_type, **attrs):
+        self.resolver_type = resolver_type
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+
+def test_collects_dependency_resolver_attributes():
+    resolvers = [
+        _Resolver("tool_shed_packages", versionless=False, disabled=False),
+        _make_conda_resolver(
+            disabled=True, auto_init=True, auto_install=False,
+            prefix="/p", versionless=True,
+        ),
+    ]
+    app = Bunch(dependency_manager=TestDependencyManager(dependency_resolvers=resolvers))
+    out = _collect_dependency_resolvers(app)
+    assert len(out) == 2
+    assert out[0].type == "tool_shed_packages"
+    assert out[0].disabled is False
+    assert out[1].type == "conda"
+    assert out[1].disabled is True
+    assert out[1].auto_init is True
+    assert out[1].auto_install is False
+    assert out[1].prefix == "/p"
+    assert out[1].versionless is True
+
+
+def test_resolver_without_resolver_type_is_skipped():
+    # Some resolver subclasses might not set resolver_type; we drop them
+    # rather than emit a noisy unknown entry.
+    resolvers = [_Resolver(None), _Resolver("conda", disabled=False)]
+    app = Bunch(dependency_manager=TestDependencyManager(dependency_resolvers=resolvers))
+    out = _collect_dependency_resolvers(app)
+    assert [r.type for r in out] == ["conda"]
+
+
+class _StubProxy:
+    """Minimal proxy stub for the ``num_concurrent_jobs`` fallback branch.
+
+    The fallback path in ``_collect_manager`` reads
+    ``underlying.num_concurrent_jobs`` only when ``underlying.work_threads``
+    is missing. **No in-tree manager has this shape** — every concrete
+    Pulsar manager either inherits ``QueueManager`` (which always sets
+    ``work_threads``) or is unqueued and exposes neither. The branch
+    exists purely as a defensive hook for hypothetical third-party
+    manager subclasses, so a real-object test cannot reach it; a 3-line
+    stub here is the only way to cover that intentionally-third-party-only
+    code path.
+    """
+
+    def __init__(self, num_concurrent_jobs=None):
+        self.name = "m"
+        underlying = type("Underlying", (object,), {"manager_type": "unqueued"})()
+        if num_concurrent_jobs is not None:
+            underlying.num_concurrent_jobs = num_concurrent_jobs
+        self._proxied_manager = underlying
+
+
+def test_num_concurrent_jobs_falls_back_to_attr():
+    assert _collect_manager(_StubProxy(num_concurrent_jobs=7)).num_concurrent_jobs == 7
+
+
+def test_num_concurrent_jobs_none_when_neither():
+    assert _collect_manager(_StubProxy()).num_concurrent_jobs is None

--- a/test/galaxy_byoc_test.py
+++ b/test/galaxy_byoc_test.py
@@ -1,5 +1,6 @@
 """Tests for ``pulsar-config register-with-galaxy`` orchestration."""
 
+import base64
 import importlib.util
 import json
 import os
@@ -28,8 +29,6 @@ BOOTSTRAP_TOKEN = "one-shot-from-galaxy"
 
 
 def _b64url(payload: dict) -> str:
-    import base64
-
     raw = json.dumps(payload).encode("utf-8")
     return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
 

--- a/test/messaging_capabilities_test.py
+++ b/test/messaging_capabilities_test.py
@@ -1,0 +1,156 @@
+"""Unit tests for the relay capabilities publisher.
+
+The publisher is intentionally simple — one POST per startup, errors
+swallowed — so these tests pin down the small set of guarantees that
+the rest of the design relies on:
+
+* ``message_queue_publish_capabilities=False`` skips the publish.
+* A collection failure is logged and swallowed (does not block bind).
+* ``RelayTransportError`` from ``post_message`` is swallowed.
+* The topic name reflects the manager and prefix.
+* ``published_at`` is stamped at publish time, not at collection time.
+
+The publisher and collector are exercised against a real
+``minimal_app_for_managers()`` + ``StatefulManagerProxy(QueueManager(...))``
+so contract drift in the manager interface breaks these tests.
+"""
+import datetime
+import importlib.util
+from contextlib import contextmanager
+from shutil import rmtree
+from unittest import mock
+
+import pytest
+
+# ``pulsar-relay-client`` requires Python >=3.10 (PEP 508 marker on the
+# requirements pin). Skip the entire module on older interpreters where
+# the relay code path is unreachable but pulsar itself still installs.
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("pulsar_relay_client") is None,
+    reason="pulsar-relay-client requires Python >=3.10",
+)
+
+if importlib.util.find_spec("pulsar_relay_client") is not None:
+    from pulsar_relay_client import RelayTransportError
+else:
+    # Module-level skip above means tests never reference this fallback;
+    # the assignment exists purely so the import line doesn't crash on
+    # py3.7. mypy sees both branches statically and rejects rebinding a
+    # type — silenced because the runtime path is provably unreachable.
+    RelayTransportError = Exception  # type: ignore[misc, assignment]
+
+from pulsar.managers.queued import QueueManager  # noqa: E402 — guarded above
+from pulsar.managers.stateful import StatefulManagerProxy  # noqa: E402 — guarded above
+from pulsar.messaging import bind_relay  # noqa: E402 — guarded above
+
+from .test_utils import (  # noqa: E402 — guarded above
+    RecordingRelayTransport,
+    minimal_app_for_managers,
+)
+
+
+@contextmanager
+def _publish_ctx(name="_default_", num_concurrent_jobs=1, raise_on_post=None):
+    """Real app + real ``StatefulManagerProxy(QueueManager(...))`` + recording transport.
+
+    Yields ``(app, proxy, transport)`` and tears down both the proxy
+    (worker threads) and the staging directory.
+    """
+    app = minimal_app_for_managers()
+    proxy = StatefulManagerProxy(QueueManager(name, app, num_concurrent_jobs=num_concurrent_jobs))
+    transport = RecordingRelayTransport(raise_on_post=raise_on_post)
+    try:
+        yield app, proxy, transport
+    finally:
+        try:
+            proxy.shutdown()
+        except Exception:
+            pass
+        try:
+            rmtree(app.staging_directory)
+        except Exception:
+            pass
+
+
+def test_publishes_once_with_expected_topic_and_payload():
+    with _publish_ctx() as (app, proxy, transport):
+        bind_relay.publish_manager_capabilities_to_relay(app, proxy, transport, conf={})
+        assert len(transport.calls) == 1
+        topic, payload = transport.calls[0]
+        assert topic == "pulsar_capabilities"
+        assert payload["schema_version"] == 1
+        assert payload["manager_name"] == "_default_"
+        assert "published_at" in payload  # stamped at publish time
+
+
+def test_topic_prefix_is_applied():
+    with _publish_ctx() as (app, proxy, transport):
+        bind_relay.publish_manager_capabilities_to_relay(
+            app, proxy, transport, conf={"relay_topic_prefix": "prod"},
+        )
+        assert transport.calls[0][0] == "prod_pulsar_capabilities"
+
+
+def test_non_default_manager_suffix():
+    with _publish_ctx(name="cluster_a") as (app, proxy, transport):
+        bind_relay.publish_manager_capabilities_to_relay(app, proxy, transport, conf={})
+        assert transport.calls[0][0] == "pulsar_capabilities_cluster_a"
+
+
+def test_off_switch_skips_publish():
+    with _publish_ctx() as (app, proxy, transport):
+        bind_relay.publish_manager_capabilities_to_relay(
+            app, proxy, transport,
+            conf={"message_queue_publish_capabilities": False},
+        )
+        assert transport.calls == []
+
+
+def test_collect_failure_logged_and_swallowed(caplog):
+    # A correctly-built real ``StatefulManagerProxy(QueueManager(...))`` cannot
+    # make ``collect_capabilities`` raise, so this test patches the collector
+    # seam to inject the fault. The SUT here is the publisher's error
+    # isolation (collection failure must not block bind), not the collector.
+    with _publish_ctx() as (app, proxy, transport):
+        with mock.patch(
+            "pulsar.messaging.bind_relay.collect_capabilities",
+            side_effect=RuntimeError("boom"),
+        ):
+            # Must not raise.
+            bind_relay.publish_manager_capabilities_to_relay(app, proxy, transport, conf={})
+        assert transport.calls == []
+        assert any(
+            "Failed to collect capabilities" in r.message
+            for r in caplog.records
+        )
+
+
+def test_relay_transport_error_swallowed(caplog):
+    # post_message can raise RelayTransportError or any underlying HTTP/TLS
+    # error; the publisher swallows ``Exception`` to keep manager bind
+    # advisory. Pinning RelayTransportError covers the realistic case.
+    with _publish_ctx(raise_on_post=RelayTransportError("network down")) as (app, proxy, transport):
+        # Must not raise.
+        bind_relay.publish_manager_capabilities_to_relay(app, proxy, transport, conf={})
+        assert any(
+            "Failed to publish capabilities" in r.message
+            for r in caplog.records
+        )
+
+
+def test_published_at_is_iso8601_utc():
+    with _publish_ctx() as (app, proxy, transport):
+        bind_relay.publish_manager_capabilities_to_relay(app, proxy, transport, conf={})
+        payload = transport.calls[0][1]
+        # Must round-trip through fromisoformat with timezone info.
+        parsed = datetime.datetime.fromisoformat(payload["published_at"])
+        assert parsed.tzinfo is not None
+
+
+def test_make_capabilities_topic_name_examples():
+    # Module-level dunder names aren't mangled, so reach in via __dict__.
+    fn = bind_relay.__dict__["__make_capabilities_topic_name"]
+    assert fn("", "_default_") == "pulsar_capabilities"
+    assert fn("", "cluster_a") == "pulsar_capabilities_cluster_a"
+    assert fn("prod", "_default_") == "prod_pulsar_capabilities"
+    assert fn("prod", "cluster_a") == "prod_pulsar_capabilities_cluster_a"

--- a/test/resilience/scenarios/test_capabilities_publish.py
+++ b/test/resilience/scenarios/test_capabilities_publish.py
@@ -1,0 +1,97 @@
+"""Resilience scenario: pulsar publishes its capability snapshot to the relay.
+
+The publisher fires once at ``messaging.bind_app`` time. After the relay
+fixture is healthy and pulsar has bound its consumers, the snapshot must
+be retrievable through the relay's REST topic-messages endpoint.
+
+Only the relay messaging mode is exercised — there's nothing to publish
+in AMQP mode, and the publisher path is gated on the connection-string
+prefix in ``pulsar.messaging.bind_app``.
+"""
+import time
+
+import pytest
+import requests
+
+from harness.pulsar_control import (
+    RELAY_HTTP,
+    _relay_admin_token,
+)
+
+
+def _fetch_latest_capabilities(topic="pulsar_capabilities", timeout=5.0):
+    """Hit ``GET /api/v1/topics/{topic}/messages?limit=1&order=desc``.
+
+    Returns the message payload dict, or ``None`` if the topic is empty
+    / not found / the relay is unreachable. Bounded by ``timeout``.
+    """
+    deadline = time.time() + timeout
+    last_status = None
+    last_body = None
+    while time.time() < deadline:
+        try:
+            token = _relay_admin_token()
+        except Exception:
+            time.sleep(0.2)
+            continue
+        try:
+            r = requests.get(
+                f"{RELAY_HTTP}/api/v1/topics/{topic}/messages",
+                params={"limit": 1, "order": "desc"},
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=2,
+            )
+        except Exception:
+            time.sleep(0.2)
+            continue
+        last_status = r.status_code
+        last_body = r.text
+        if r.status_code == 200:
+            messages = (r.json() or {}).get("messages") or []
+            if messages:
+                return messages[0].get("payload")
+        # 404 = topic not yet created (publish in flight); keep polling.
+        time.sleep(0.2)
+    pytest.fail(
+        f"capabilities topic empty after {timeout}s "
+        f"(last status={last_status}, body={last_body})"
+    )
+
+
+@pytest.mark.parametrize("mq_mode", ["relay"], indirect=True)
+def test_pulsar_publishes_capabilities_on_bind(pulsar):
+    """After ``pulsar.start(wait_ready=True)`` the snapshot is on the relay."""
+    payload = _fetch_latest_capabilities()
+    assert payload is not None
+    assert payload["schema_version"] == 1
+    assert payload["manager_name"] == "_default_"
+    assert payload["staging_directory"]
+    # Pulsar is booted with at least one dependency resolver from the
+    # default conf — the field must be present even if the list is short.
+    assert "dependency_resolvers" in payload
+    assert "container_runtime" in payload
+    assert payload["container_runtime"]["docker_available"] in (True, False)
+    assert payload["manager"]["type"]  # whatever manager_type the test stack uses
+    # Stamped at publish time, not collection time.
+    assert payload["published_at"]
+
+
+@pytest.mark.parametrize("mq_mode", ["relay"], indirect=True)
+def test_capabilities_resnapshot_after_pulsar_restart(pulsar):
+    """A restart re-publishes; the latest pointer advances."""
+    first = _fetch_latest_capabilities()
+    first_ts = first["published_at"]
+
+    pulsar.restart(wait_ready=True)
+
+    # Poll until the new snapshot is visible — restart re-binds and
+    # re-publishes, but the relay-side stream takes a tick to expose it.
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        latest = _fetch_latest_capabilities()
+        if latest["published_at"] != first_ts:
+            assert latest["schema_version"] == 1
+            assert latest["manager_name"] == "_default_"
+            return
+        time.sleep(0.3)
+    pytest.fail("capabilities published_at did not advance after pulsar restart")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -136,9 +136,31 @@ class TestAuthorization:
 
 
 class TestDependencyManager:
+    __test__ = False  # not a pytest test class
+
+    def __init__(self, dependency_resolvers=None, default_base_path=None):
+        self.dependency_resolvers = dependency_resolvers or []
+        self.default_base_path = default_base_path
 
     def dependency_shell_commands(self, requirements, **kwds):
         return []
+
+
+class RecordingRelayTransport:
+    """Stand-in for ``RelayTransport`` that records ``post_message`` calls.
+
+    Set ``raise_on_post`` to make the next post raise that exception
+    (covers the "transport throws" branches without ``unittest.mock``).
+    """
+
+    def __init__(self, raise_on_post=None):
+        self.calls = []  # list of (topic, payload)
+        self.raise_on_post = raise_on_post
+
+    def post_message(self, topic, payload):
+        self.calls.append((topic, payload))
+        if self.raise_on_post is not None:
+            raise self.raise_on_post
 
 
 class BaseManagerTestCase(TestCase):
@@ -207,6 +229,7 @@ def minimal_app_for_managers():
     user_auth_manager = get_test_user_auth_manager()
     return Bunch(
         staging_directory=staging_directory,
+        persistence_directory=staging_directory,
         authorizer=authorizer,
         job_metrics=NullJobMetrics(),
         dependency_manager=TestDependencyManager(),


### PR DESCRIPTION
## Summary

Adds a one-shot capability snapshot that the Pulsar daemon publishes to its message-queue relay on startup. Galaxy's "bring your own compute" (BYOC) integration uses it to:

* auto-fill destination params (`staging_directory`, runtime flags, manager type) when a user bootstraps a new resource, and
* downgrade per-job requests at dispatch time when the operator-configured destination asks for something the remote daemon doesn't actually have (e.g. `singularity_enabled: true` but no singularity on `$PATH`).

The publish is fire-and-forget, gated by the new `message_queue_publish_capabilities` setting (default `True`), and runs once per manager during `messaging.bind_app`. Failures are logged and swallowed — capabilities are advisory and must not block manager bind.

## What the snapshot contains (schema_version=1)

Collected once during `PulsarApp.__init__` from existing pulsar state, no external probes beyond `shutil.which`:

* `pulsar_version`, `manager_name`, `manager_type`, `num_concurrent_jobs`, `work_threads`
* `staging_directory`, `persistence_directory`, `tool_dependency_dir`
* `dependency_resolvers`: list of `{resolver_type, versionless, prefix?, ensure_channels?}` for each configured resolver (conda fields read through `isinstance(r, CondaDependencyResolver)` rather than string-typed probes)
* `container_runtime`: `{docker_available, singularity_available, apptainer_available}` from `shutil.which`
* `conda_available`: convenience flag derived from the resolver list

Published once to `pulsar_capabilities` (or `<prefix>_pulsar_capabilities[_<manager>]` for non-default managers, mirroring `__make_capabilities_topic_name` for the other relay topics).

## Files

* `pulsar/capabilities.py` — collector + Pydantic-typed `PulsarCapabilities` dataclass. Reads through typed attributes (`PulsarApp` / `StatefulManagerProxy` via `TYPE_CHECKING`) rather than getattr probes; the few remaining getattr sites are for fields that legitimately vary across third-party manager/resolver subclasses and are commented as such.
* `pulsar/core.py` — wires the collector into `PulsarApp` init.
* `pulsar/messaging/bind_relay.py` — adds `__make_capabilities_topic_name`, `_publish_capabilities`, and the one-shot publish from `bind_app`.
* `pulsar/messaging/__init__.py` — re-exports.
* `app.yml.sample` — documents `message_queue_publish_capabilities`.
* `test/capabilities_test.py` — 25 unit tests for the collector + topic-name convention.
* `test/messaging_capabilities_test.py` — 4 messaging-side tests (publish, error-swallowing, topic-name shape, disabled-flag respect). Guarded with `importlib.util.find_spec('pulsar_relay_client')` because the relay client requires Python >=3.10.
* `test/resilience/scenarios/test_capabilities_publish.py` — end-to-end against a live relay.

## Test plan

- [x] `tox -e py310-test test/capabilities_test.py test/messaging_capabilities_test.py` — 29 pass locally
- [x] `tox -e lint`
- [x] `tox -e mypy` — clean, 183 source files
- [x] CI `pulsar` job (unit + messaging + resilience harness): green
- [ ] Galaxy-side e2e: ``test/integration/compute_resources/test_compute_resource_tool_execution.py`` consumes the snapshot via the relay's ``GET /api/v1/topics/{topic}/messages?limit=1&order=desc``; tracked in the Galaxy BYOC PR.

## Notes

* This PR's contract is one-way: pulsar publishes, the relay stores, Galaxy reads. The relay is dumb storage; no protocol change there. The relay client (`pulsar-relay-client>=0.2.2`) already wraps the read side via `HttpRelayClient.fetch_messages`.
* On Python <3.10 the `messaging_capabilities_test` module is silently skipped (the relay client is `python_requires=">=3.10"`); the rest of the codebase is unaffected.
* No changes to job execution paths — every existing manager binds the same way; the only new thing they emit is a single advisory message.