### PR TITLE
Sync Galaxy BYOC bootstrap URLs with compute_resources rename

### DIFF
--- a/pulsar/client/amqp_exchange.py
+++ b/pulsar/client/amqp_exchange.py
@@ -74,7 +74,7 @@ class PulsarExchange:
         publish_uuid_store=None,
         consume_uuid_store=None,
         republish_time=DEFAULT_REPUBLISH_TIME,
-        durable=False,
+        durable=True,
     ):
         """
         """

--- a/pulsar/client/amqp_exchange_factory.py
+++ b/pulsar/client/amqp_exchange_factory.py
@@ -13,7 +13,11 @@ def get_exchange(url, manager_name, params):
         connect_ssl=connect_ssl,
         publish_kwds=parse_amqp_publish_kwds(params),
     )
-    durable_param = params.get("amqp_durable", False)
+    # Default True: kombu declares durable queues/exchanges by default, which is
+    # what Pulsar did before opt-in durability was added, and RabbitMQ 4.x
+    # rejects transient non-exclusive queues outright (transient_nonexcl_queues
+    # is deprecated). Keep the knob for explicit opt-out on legacy brokers.
+    durable_param = params.get("amqp_durable", True)
     if isinstance(durable_param, str):
         durable_param = durable_param.strip().lower() in ("true", "1", "yes", "on")
     exchange_kwds["durable"] = bool(durable_param)

--- a/pulsar/client/galaxy_byoc.py
+++ b/pulsar/client/galaxy_byoc.py
@@ -9,8 +9,8 @@ A user runs ``pulsar-config register-with-galaxy --galaxy <url> --token <one-sho
    id, which we adopt as the BYOC manager name (and as the Pulsar manager
    name in the local ``app.yml``).
 3. Posts the secondary refresh token to Galaxy at
-   ``/api/pulsar_byoc/bootstrap`` (authenticated by the one-shot token from
-   ``POST /api/pulsar_byoc/registration``).
+   ``/api/compute_resources/registrations/complete`` (authenticated by the
+   one-shot token from ``POST /api/compute_resources/registrations``).
 4. Writes the local ``relay_credentials.json`` with the *primary* refresh
    token only; the secondary is in-flight to Galaxy and never persisted on
    the host.
@@ -69,7 +69,8 @@ def register_with_galaxy(
 
     Side effects:
       * Writes the primary refresh token to ``credentials_path``.
-      * Calls Galaxy's ``POST /api/pulsar_byoc/bootstrap`` with the secondary.
+      * Calls Galaxy's ``POST /api/compute_resources/registrations/complete``
+        with the secondary.
     """
     # Imported lazily so pulsar still installs on Pythons that don't meet
     # pulsar-relay-client's requires-python.
@@ -108,7 +109,7 @@ def register_with_galaxy(
         "relay_url": relay_url,
         "manager_name": manager_name,
     }
-    bootstrap_url = galaxy_url.rstrip("/") + "/api/pulsar_byoc/bootstrap"
+    bootstrap_url = galaxy_url.rstrip("/") + "/api/compute_resources/registrations/complete"
     try:
         resp = requests.post(bootstrap_url, json=payload, timeout=timeout)
     except requests.RequestException as exc:

--- a/pulsar/client/manager.py
+++ b/pulsar/client/manager.py
@@ -365,6 +365,11 @@ class RelayClientManager(BaseRemoteConfiguredJobClientManager):
             )
             auth_manager = RelayAuthManager(relay_url, credentials_store=store)
 
+        # Keep a handle on the explicit refresh-token auth manager so read-only
+        # relay probes (e.g. Galaxy's capability-snapshot fetch) can reuse this
+        # manager's centrally-cached access token instead of exchanging the
+        # refresh token themselves — see ``get_relay_access_token``.
+        self._relay_auth_manager = auth_manager
         self.relay_transport = RelayTransport(
             relay_url,
             username=relay_username,
@@ -381,6 +386,25 @@ class RelayClientManager(BaseRemoteConfiguredJobClientManager):
         self.callback_thread = None
         self.active = True
         self.shutdown_event = threading.Event()
+
+    def get_relay_access_token(self) -> Optional[str]:
+        """Return a relay access token from this manager's central auth cache.
+
+        Read-only relay probes (e.g. Galaxy's capability-snapshot fetch) must
+        reuse this token rather than exchanging the refresh token on their own:
+        the relay rotates refresh tokens single-use and revokes the entire
+        chain on replay, so a second, independent exchange of the same token
+        would tear down this manager's credentials mid-flight. Routing every
+        consumer through the one :class:`RelayAuthManager` keeps the exchange
+        count at one (it caches the access token until expiry).
+
+        Returns ``None`` when this manager was not built with refresh-token
+        auth (e.g. credentials-file / password auth), in which case callers
+        fall back to their own credential handling.
+        """
+        if self._relay_auth_manager is None:
+            return None
+        return self._relay_auth_manager.get_token()
 
     def callback_wrapper(self, callback, message_data):
         """Process status update messages from the relay."""

--- a/pulsar/client/staging/down.py
+++ b/pulsar/client/staging/down.py
@@ -10,6 +10,7 @@ from os.path import (
 
 from ..action_mapper import FileActionMapper
 from ..staging import COMMAND_VERSION_FILENAME
+from ..transport.transient import http_status_code
 
 log = getLogger(__name__)
 
@@ -223,6 +224,21 @@ class ResultsCollector:
         try:
             return self.output_collector.collect_output(self, output_type, action, name)
         except Exception as e:
+            if http_status_code(e) == 403:
+                # The Galaxy server authoritatively refused this upload (HTTP
+                # 403). The usual cause is the output's dataset being purged or
+                # deleted while the job ran — Galaxy is the source of truth for
+                # the dataset's state, retrying cannot help, and the tool itself
+                # ran, so this must not fail the job. Surface the path/output so
+                # the reason is visible rather than a generic failure.
+                log.warning(
+                    "Galaxy refused output '%s' (HTTP 403) at %s; not failing the job. "
+                    "This is expected when the output dataset was purged or deleted "
+                    "while the job was running.",
+                    name,
+                    getattr(action, "url", None) or getattr(action, "path", action),
+                )
+                return False
             if _allow_collect_failure(output_type):
                 log.warning(
                     "Allowed failure in postprocessing, will not force job failure but generally indicates a tool"

--- a/pulsar/client/transport/transient.py
+++ b/pulsar/client/transport/transient.py
@@ -27,6 +27,26 @@ from ..exceptions import PulsarClientTransportError
 TRANSIENT_HTTP_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
 
 
+def http_status_code(exc):
+    """Best-effort HTTP status code from a transport exception, else ``None``.
+
+    Normalizes the several exception shapes Pulsar transports raise (requests
+    ``HTTPError``, urllib ``HTTPError``, ``PulsarClientTransportError``) into a
+    single integer status, so callers can react to specific codes (e.g. a 403
+    that means the Galaxy server authoritatively refused an upload).
+    """
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        return exc.response.status_code
+    if isinstance(exc, UrllibHTTPError):
+        return exc.code
+    if isinstance(exc, PulsarClientTransportError):
+        try:
+            return int(exc.transport_code)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
 def _status_is_transient(status):
     try:
         return int(status) in TRANSIENT_HTTP_STATUS

--- a/pulsar/scripts/config.py
+++ b/pulsar/scripts/config.py
@@ -223,14 +223,14 @@ def main(argv=None):
                                 "Bootstrap a BYOC Pulsar registration against a Galaxy "
                                 "server. Drives the relay device flow with pair-issuance "
                                 "and hands the secondary refresh token to Galaxy at "
-                                "/api/pulsar_byoc/bootstrap. Requires --relay-url and "
-                                "--galaxy-token (the one-shot token returned by "
-                                "POST /api/pulsar_byoc/registration)."
+                                "/api/compute_resources/registrations/complete. Requires "
+                                "--relay-url and --galaxy-token (the one-shot token returned "
+                                "by POST /api/compute_resources/registrations)."
                             ))
     arg_parser.add_argument("--galaxy-token",
                             dest="galaxy_token",
                             default=None,
-                            help="One-shot bootstrap token from /api/pulsar_byoc/registration.")
+                            help="One-shot bootstrap token from /api/compute_resources/registrations.")
     # arg_parser.add_argument("--pip_install_args",
     #                         default="pulsar-app",
     #                         help=HELP_PIP_INSTALL_ARGS_HELP)

--- a/test/amqp_test.py
+++ b/test/amqp_test.py
@@ -74,24 +74,25 @@ class TestThread(threading.Thread):
 
 
 @skip_unless_module("kombu")
-def test_non_durable_queue_and_exchange_default():
-    """Default is non-durable to preserve legacy behavior: RabbitMQ refuses to
-    redeclare an existing queue with mismatched durability, so flipping the
-    default would break upgrades. Operators opt in via ``amqp_durable: true``.
+def test_durable_queue_and_exchange_default():
+    """Default is durable. That matches kombu's own default (which Pulsar relied
+    on before opt-in durability was added) and is required by RabbitMQ 4.x,
+    which refuses transient non-exclusive queues outright. Operators can opt out
+    on a legacy broker via ``amqp_durable: false``.
     """
     exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "manager_durable_default")
     queue = exchange._PulsarExchange__queue("status_update")
-    assert queue.durable is False
-    assert queue.exchange.durable is False
+    assert queue.durable is True
+    assert queue.exchange.durable is True
 
 
 @skip_unless_module("kombu")
-def test_durable_can_be_enabled():
-    """Operators who want broker-restart durability opt in explicitly."""
-    exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "manager_durable_on", durable=True)
+def test_durable_can_be_disabled():
+    """Explicit opt-out for legacy brokers that still allow transient queues."""
+    exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "manager_durable_off", durable=False)
     queue = exchange._PulsarExchange__queue("status_update")
-    assert queue.durable is True
-    assert queue.exchange.durable is True
+    assert queue.durable is False
+    assert queue.exchange.durable is False
 
 
 @skip_unless_module("kombu")
@@ -106,15 +107,25 @@ def test_durable_publishes_use_persistent_delivery_mode():
 
 @skip_unless_module("kombu")
 def test_non_durable_publishes_do_not_force_persistent_mode():
-    exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "manager_dm_off")
+    exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "manager_dm_off", durable=False)
     publish_kwds = exchange._PulsarExchange__prepare_publish_kwds("test")
     assert "delivery_mode" not in publish_kwds
 
 
 @skip_unless_module("kombu")
-def test_factory_defaults_durable_false():
+def test_factory_defaults_durable_true():
     from pulsar.client import amqp_exchange_factory
     exchange = amqp_exchange_factory.get_exchange(TEST_CONNECTION, "factory_durable_default", {})
+    queue = exchange._PulsarExchange__queue("status_update")
+    assert queue.durable is True
+
+
+@skip_unless_module("kombu")
+def test_factory_respects_amqp_durable_false():
+    from pulsar.client import amqp_exchange_factory
+    exchange = amqp_exchange_factory.get_exchange(
+        TEST_CONNECTION, "factory_durable_off", {"amqp_durable": False},
+    )
     queue = exchange._PulsarExchange__queue("status_update")
     assert queue.durable is False
 

--- a/test/client_staging_test.py
+++ b/test/client_staging_test.py
@@ -1,10 +1,15 @@
 from collections import deque
 import os
+from types import SimpleNamespace
+
+import pytest
+import requests
 
 from .test_utils import TempDirectoryTestCase
 from pulsar.client.test.test_common import write_config
 from pulsar.client import submit_job, ClientJobDescription
 from pulsar.client import ClientOutputs
+from pulsar.client.staging.down import ResultsCollector
 from galaxy.tool_util.deps.dependencies import DependenciesDescription
 from galaxy.tool_util.deps.requirements import ToolRequirement
 
@@ -193,3 +198,36 @@ class MockClient:
     def put_file(self, path, type, name, contents, action_type='transfer'):
         self.put_files.append((path, type, name, contents))
         return {"path": self.put_paths.popleft()}
+
+
+def _results_collector_with_failing_collect(exc):
+    """Build a minimal ResultsCollector whose output collection raises ``exc``."""
+    output_collector = SimpleNamespace(collect_output=lambda *a, **k: (_ for _ in ()).throw(exc))
+    client_outputs = SimpleNamespace(output_files=[])
+    pulsar_outputs = SimpleNamespace(
+        working_directory_contents=[], metadata_directory_contents=[], job_directory_contents=[]
+    )
+    return ResultsCollector(output_collector, action_mapper=None, client_outputs=client_outputs, pulsar_outputs=pulsar_outputs)
+
+
+def _http_error(status_code):
+    response = requests.Response()
+    response.status_code = status_code
+    return requests.HTTPError(response=response)
+
+
+def test_collect_output_tolerates_403_without_failing_job():
+    """A 403 means Galaxy authoritatively refused the upload (e.g. the output
+    dataset was purged mid-job). Even for a normally-fatal output type this
+    must not fail the job — _collect_output returns without raising, so the
+    exception tracker records no failure."""
+    rc = _results_collector_with_failing_collect(_http_error(403))
+    action = SimpleNamespace(url="http://galaxy.test/api/jobs/1/files?path=/x&file_type=output")
+    assert rc._collect_output("output", action, "out1") is False
+
+
+def test_collect_output_reraises_non_403_for_fatal_output_type():
+    rc = _results_collector_with_failing_collect(_http_error(500))
+    action = SimpleNamespace(url="http://galaxy.test/api/jobs/1/files?path=/x&file_type=output")
+    with pytest.raises(requests.HTTPError):
+        rc._collect_output("output", action, "out1")

--- a/test/galaxy_byoc_test.py
+++ b/test/galaxy_byoc_test.py
@@ -85,7 +85,7 @@ def test_register_with_galaxy_happy_path(tmp_path):
     # 3. Galaxy accepts the bootstrap callback.
     responses.add(
         responses.POST,
-        f"{GALAXY_URL}/api/pulsar_byoc/bootstrap",
+        f"{GALAXY_URL}/api/compute_resources/registrations/complete",
         json={"id": 42, "manager_name": "byoc_7_lab", "status": "active"},
         status=200,
     )
@@ -108,7 +108,7 @@ def test_register_with_galaxy_happy_path(tmp_path):
     assert os.stat(cred_path).st_mode & 0o777 == 0o600
 
     # Galaxy got the right payload.
-    galaxy_call = next(c for c in responses.calls if c.request.url.endswith("/bootstrap"))
+    galaxy_call = next(c for c in responses.calls if c.request.url.endswith("/registrations/complete"))
     body = json.loads(galaxy_call.request.body)
     assert body == {
         "bootstrap_token": BOOTSTRAP_TOKEN,
@@ -193,7 +193,7 @@ def test_register_with_galaxy_surfaces_galaxy_error(tmp_path):
     )
     responses.add(
         responses.POST,
-        f"{GALAXY_URL}/api/pulsar_byoc/bootstrap",
+        f"{GALAXY_URL}/api/compute_resources/registrations/complete",
         json={"detail": "bootstrap_token has expired"},
         status=410,
     )

--- a/test/transient_test.py
+++ b/test/transient_test.py
@@ -14,6 +14,7 @@ import requests
 
 from pulsar.client.exceptions import PulsarClientTransportError
 from pulsar.client.transport.transient import (
+    http_status_code,
     is_transient_http_error,
     TRANSIENT_HTTP_STATUS,
 )
@@ -86,6 +87,19 @@ def test_socket_and_builtin_connection_errors_are_transient():
     assert is_transient_http_error(socket.timeout())
     assert is_transient_http_error(TimeoutError())
     assert is_transient_http_error(ConnectionError())
+
+
+def test_http_status_code_extracts_across_exception_shapes():
+    assert http_status_code(_requests_http_error(403)) == 403
+    assert http_status_code(_urllib_http_error(403)) == 403
+    assert http_status_code(PulsarClientTransportError(transport_code=403)) == 403
+
+
+def test_http_status_code_none_when_unavailable():
+    # Connection-level / non-numeric transport codes have no HTTP status.
+    assert http_status_code(ConnectionError()) is None
+    assert http_status_code(PulsarClientTransportError(code=PulsarClientTransportError.TIMEOUT)) is None
+    assert http_status_code(requests.HTTPError()) is None
 
 
 def test_unknown_exception_defaults_to_transient():


### PR DESCRIPTION
Galaxy renamed ``/api/pulsar_byoc`` → ``/api/compute_resources`` and
restructured the bootstrap endpoints, so the existing
``pulsar-config register-with-galaxy`` calls would 404 against current
Galaxy. Update the URLs to match:

  /api/pulsar_byoc/registration  →  /api/compute_resources/registrations
  /api/pulsar_byoc/bootstrap     →  /api/compute_resources/registrations/complete

Touches three sites: the orchestration function in galaxy_byoc.py, the
``pulsar-config`` argparse help text, and the mocked URLs in
galaxy_byoc_test.py. The pulsar-side module/function names
(``galaxy_byoc.py``, ``register_with_galaxy``) describe the local intent
("register this Pulsar host with a Galaxy server's BYOC API") rather
than the Galaxy-side resource name, so they stay as-is.

Builds on #458 