### PR TITLE
Block on kombu producer pool acquire instead of raising LimitExceeded

### DIFF
--- a/pulsar/client/amqp_exchange.py
+++ b/pulsar/client/amqp_exchange.py
@@ -234,7 +234,7 @@ class PulsarExchange:
             self.publish_uuid_store[ack_uuid] = payload
             log.debug('Requesting acknowledgement of UUID %s on queue %s', ack_uuid, ack_queue)
         with self.connection(self.__url) as connection:
-            with pools.producers[connection].acquire() as producer:
+            with pools.producers[connection].acquire(block=True) as producer:
                 log.debug("%sHave producer for publishing to key %s", publish_log_prefix, key)
                 publish_kwds = self.__prepare_publish_kwds(publish_log_prefix)
                 producer.publish(


### PR DESCRIPTION
When many jobs complete simultaneously, all postprocess threads compete for the 10-slot kombu producer pool. The non-blocking acquire() raises LimitExceeded which is not in recoverable_exceptions, crashing the thread and losing the status update. Blocking waits for a free slot instead.

Reported by @martindemko