### PR TITLE
Fix GCP Batch co-execution deadlocks

### DIFF
--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -1128,17 +1128,24 @@ class LaunchesGcpContainersMixin(CoexecutionLaunchMixin):
         if raw:
             extra_volumes = [v.strip() for v in raw.split(",") if v.strip()]
 
-        runnable = container_command_to_gcp_runnable("pulsar-container", pulsar_submit_container)
-        if extra_volumes:
-            runnable.container.volumes = extra_volumes
-        job.task_groups[0].task_spec.runnables.append(runnable)
-
+        # Order matters: GCP Batch runs runnables sequentially. A background
+        # runnable starts and immediately yields to the next runnable. We need:
+        #   1. Tool (background) — starts polling for command_line file
+        #   2. Sidecar (foreground) — stages inputs, writes command_line, polls
+        #      for return_code, collects outputs, sends AMQP callback
+        # The sidecar must be foreground so it survives after the tool finishes
+        # (GCP Batch kills background runnables when all foreground ones exit).
         if tool_container:
             tool_runnable = container_command_to_gcp_runnable("tool-container", tool_container)
             tool_runnable.background = True
             if extra_volumes:
                 tool_runnable.container.volumes = extra_volumes
             job.task_groups[0].task_spec.runnables.append(tool_runnable)
+
+        runnable = container_command_to_gcp_runnable("pulsar-container", pulsar_submit_container)
+        if extra_volumes:
+            runnable.container.volumes = extra_volumes
+        job.task_groups[0].task_spec.runnables.append(runnable)
 
         job_name = self._job_name
         create_request = gcp_job_request(gcp_job_params, job, job_name)

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -1121,6 +1121,7 @@ class LaunchesGcpContainersMixin(CoexecutionLaunchMixin):
         gcp_job_params = self._gcp_job_params
         job = gcp_job_template(gcp_job_params)
         runnable = container_command_to_gcp_runnable("pulsar-container", pulsar_submit_container)
+        runnable.background = True
         job.task_groups[0].task_spec.runnables.append(runnable)
 
         if tool_container:

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -1120,12 +1120,24 @@ class LaunchesGcpContainersMixin(CoexecutionLaunchMixin):
         assert pulsar_finish_container is None
         gcp_job_params = self._gcp_job_params
         job = gcp_job_template(gcp_job_params)
+
+        # Parse docker_extra_volumes (comma-separated Docker -v style strings)
+        # into a list for GCP Batch Runnable.Container.volumes
+        extra_volumes = []
+        raw = self.destination_params.get("docker_extra_volumes", "")
+        if raw:
+            extra_volumes = [v.strip() for v in raw.split(",") if v.strip()]
+
         runnable = container_command_to_gcp_runnable("pulsar-container", pulsar_submit_container)
         runnable.background = True
+        if extra_volumes:
+            runnable.container.volumes = extra_volumes
         job.task_groups[0].task_spec.runnables.append(runnable)
 
         if tool_container:
             tool_runnable = container_command_to_gcp_runnable("tool-container", tool_container)
+            if extra_volumes:
+                tool_runnable.container.volumes = extra_volumes
             job.task_groups[0].task_spec.runnables.append(tool_runnable)
 
         job_name = self._job_name

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -1129,13 +1129,13 @@ class LaunchesGcpContainersMixin(CoexecutionLaunchMixin):
             extra_volumes = [v.strip() for v in raw.split(",") if v.strip()]
 
         runnable = container_command_to_gcp_runnable("pulsar-container", pulsar_submit_container)
-        runnable.background = True
         if extra_volumes:
             runnable.container.volumes = extra_volumes
         job.task_groups[0].task_spec.runnables.append(runnable)
 
         if tool_container:
             tool_runnable = container_command_to_gcp_runnable("tool-container", tool_container)
+            tool_runnable.background = True
             if extra_volumes:
                 tool_runnable.container.volumes = extra_volumes
             job.task_groups[0].task_spec.runnables.append(tool_runnable)


### PR DESCRIPTION
Part of #465.

This PR ensures the tool and sidecar runnables are executed in the correct order and don't deadlock. 

This PR also:
1. Ensures outputs from intermediate jobs are collected.
Galaxy's path rewriting causes tools to write outputs into `working/` rather than `outputs/`, but `__collect_outputs()` only checked the outputs directory, so those files were skipped. Also relaxes the dynamic collection pattern from `dataset_\d+\.dat` to  `dataset_[\w-]+\.dat` so UUID-named datasets (e.g. `dataset_b0e57817-…​.dat`) match.
2. Re-raises infrastructure errors so they fail the job rather than producing a "successful" job with empty outputs. `FileNotFoundError` is deliberately excluded.
3. Pass `docker_extra_volumes` to the Batch containers
Comma-separated Docker `-v`-style volumes (used to bind-mount CVMFS paths such as
`/cvmfs/data.galaxyproject.org`) are now applied to both the sidecar and tool runnable
containers, so tools that depend on CVMFS reference data work.
