### PR TITLE
Re-raise infrastructure errors during output collection

### DIFF
--- a/pulsar/client/staging/down.py
+++ b/pulsar/client/staging/down.py
@@ -223,6 +223,9 @@ class ResultsCollector:
         log.info("collecting output {} with action {}".format(name, action))
         try:
             return self.output_collector.collect_output(self, output_type, action, name)
+        except (ImportError, MemoryError, SystemError):
+            # Genuine infrastructure failures must never be downgraded.
+            raise
         except Exception as e:
             if http_status_code(e) == 403:
                 # The Galaxy server authoritatively refused this upload (HTTP
@@ -231,6 +234,9 @@ class ResultsCollector:
                 # the dataset's state, retrying cannot help, and the tool itself
                 # ran, so this must not fail the job. Surface the path/output so
                 # the reason is visible rather than a generic failure.
+                #
+                # Checked before the OSError branch below because
+                # requests.HTTPError is itself an OSError subclass.
                 log.warning(
                     "Galaxy refused output '%s' (HTTP 403) at %s; not failing the job. "
                     "This is expected when the output dataset was purged or deleted "
@@ -239,6 +245,14 @@ class ResultsCollector:
                     getattr(action, "url", None) or getattr(action, "path", action),
                 )
                 return False
+            if isinstance(e, OSError) and not isinstance(e, FileNotFoundError):
+                # Infrastructure OSErrors (disk full, I/O errors) must fail the
+                # job rather than be silently downgraded to a warning. A missing
+                # output file (FileNotFoundError) is excluded: it is an expected,
+                # recoverable condition — e.g. a ``from_work_dir`` output a tool
+                # legitimately did not produce, which Galaxy represents as an
+                # empty dataset — so it flows through the normal handling below.
+                raise
             if _allow_collect_failure(output_type):
                 log.warning(
                     "Allowed failure in postprocessing, will not force job failure but generally indicates a tool"

--- a/pulsar/client/staging/down.py
+++ b/pulsar/client/staging/down.py
@@ -245,15 +245,7 @@ class ResultsCollector:
                     getattr(action, "url", None) or getattr(action, "path", action),
                 )
                 return False
-            if isinstance(e, OSError) and not isinstance(e, FileNotFoundError):
-                # Infrastructure OSErrors (disk full, I/O errors) must fail the
-                # job rather than be silently downgraded to a warning. A missing
-                # output file (FileNotFoundError) is excluded: it is an expected,
-                # recoverable condition — e.g. a ``from_work_dir`` output a tool
-                # legitimately did not produce, which Galaxy represents as an
-                # empty dataset — so it flows through the normal handling below.
-                raise
-            if _allow_collect_failure(output_type):
+            if _allow_collect_failure(output_type, e):
                 log.warning(
                     "Allowed failure in postprocessing, will not force job failure but generally indicates a tool"
                     f" failure: {e}")
@@ -289,8 +281,25 @@ def _clean(collection_failure_exceptions, cleanup_job, client):
             log.warn("Failed to cleanup remote Pulsar job")
 
 
-def _allow_collect_failure(output_type):
-    return output_type in ['output_workdir']
+def _allow_collect_failure(output_type, exception):
+    """Whether a collection failure may be downgraded to a warning instead of failing the job.
+
+    Only working-directory outputs are eligible: a failure collecting one
+    generally indicates a tool problem rather than an infrastructure one, so it
+    should not force the job to fail.
+
+    Infrastructure ``OSError``s (disk full, I/O errors) are never downgraded,
+    even for working-directory outputs — they must fail the job. A missing
+    output file (``FileNotFoundError``) is excluded from that rule: it is an
+    expected, recoverable condition — e.g. a ``from_work_dir`` output a tool
+    legitimately did not produce, which Galaxy represents as an empty dataset —
+    so it remains an allowed failure.
+    """
+    if output_type not in ['output_workdir']:
+        return False
+    if isinstance(exception, OSError) and not isinstance(exception, FileNotFoundError):
+        return False
+    return True
 
 
 __all__ = ('finish_job',)

--- a/test/client_staging_test.py
+++ b/test/client_staging_test.py
@@ -231,3 +231,21 @@ def test_collect_output_reraises_non_403_for_fatal_output_type():
     action = SimpleNamespace(url="http://galaxy.test/api/jobs/1/files?path=/x&file_type=output")
     with pytest.raises(requests.HTTPError):
         rc._collect_output("output", action, "out1")
+
+
+def test_collect_output_reraises_infra_oserror_for_workdir_output():
+    """An infrastructure OSError (e.g. disk full) collecting a working-directory
+    output must fail the job rather than be downgraded to an allowed failure."""
+    rc = _results_collector_with_failing_collect(OSError("No space left on device"))
+    action = SimpleNamespace(path="/pulsar/working/out.dat")
+    with pytest.raises(OSError):
+        rc._collect_output("output_workdir", action, "out1")
+
+
+def test_collect_output_tolerates_missing_workdir_output():
+    """A missing from_work_dir output (FileNotFoundError) is an expected,
+    recoverable condition for a working-directory output, so it is an allowed
+    failure and must not raise."""
+    rc = _results_collector_with_failing_collect(FileNotFoundError("out.dat"))
+    action = SimpleNamespace(path="/pulsar/working/out.dat")
+    assert rc._collect_output("output_workdir", action, "out1") is None


### PR DESCRIPTION
Part of #465. 
Split out of #466

### What this does

`_collect_output` downgraded *all* collection exceptions to warnings for
`output_workdir` outputs (via `_allow_collect_failure`). That is correct for a missing
output, but it also swallowed genuine infrastructure failures — a disk-full or
out-of-memory during collection would surface as a "successful" job with empty outputs.

- Re-raise `ImportError`, `MemoryError`, `SystemError`, and infrastructure `OSError`s
  (disk full, I/O errors) so they fail the job.
- Two cases are deliberately **kept** recoverable and flow through the normal
  `_allow_collect_failure` handling:
  - `FileNotFoundError` — a missing output file is expected (e.g. a `from_work_dir`
    output a tool legitimately did not produce, which Galaxy represents as an empty
    dataset).
  - HTTP **403** — Galaxy authoritatively refused the upload (dataset purged mid-job);
    checked *before* the `OSError` test because `requests.HTTPError` is itself an
    `OSError` subclass.

Branch is based on current `master`.

