### PR TITLE
Interim mitigation for resilience relay bind: timeout bump + fixture retry

### DIFF
--- a/test/resilience/conftest.py
+++ b/test/resilience/conftest.py
@@ -134,9 +134,32 @@ def pulsar(compose_up, mq_mode):
     ctrl = PulsarControl(PROJECT_DIR, mode=mq_mode)
     # Wipe state at fixture entry only; tests that kill/restart reuse persisted
     # state to validate recovery semantics.
-    ctrl.start(wait_ready=True, fresh=True)
+    _start_fresh_with_retry(ctrl)
     yield ctrl
     ctrl.stop()
+
+
+def _start_fresh_with_retry(ctrl, attempts=2):
+    """Bring up a fresh Pulsar, retrying once if the consumer bind wait times out.
+
+    Interim mitigation for the intermittent relay bind-timeout flake
+    (``TimeoutError: Pulsar did not bind <mode> consumers``) that lands on a
+    different ``[mode=relay]`` scenario each run. A blanket setup retry is more
+    robust than marking individual scenarios rerun-eligible, since the flake is
+    not pinned to a fixed test. Each attempt force-recreates the container
+    (``fresh=True``), so a retry starts from a clean slate. Only the bind
+    ``TimeoutError`` is retried — a ``docker compose up`` failure still raises
+    immediately. The final ``TimeoutError`` propagates if every attempt times
+    out, so a genuine breakage still surfaces the original message.
+    """
+    last_exc = None
+    for _ in range(attempts):
+        try:
+            ctrl.start(wait_ready=True, fresh=True)
+            return
+        except TimeoutError as exc:
+            last_exc = exc
+    raise last_exc
 
 
 @pytest.fixture

--- a/test/resilience/harness/pulsar_control.py
+++ b/test/resilience/harness/pulsar_control.py
@@ -149,7 +149,7 @@ class PulsarControl:
         self.stop()
         self.start(wait_ready=wait_ready)
 
-    def wait_until_consuming(self, timeout=60.0, poll_interval=0.1):
+    def wait_until_consuming(self, timeout=120.0, poll_interval=0.1):
         """Block until Pulsar has bound consumers for the control queues.
 
         Both modes wait for a fresh ``bind_manager_to`` log line from the


### PR DESCRIPTION
Refs #469  #470

Interim mitigation for the intermittent `Resilience Suite` bind-timeout error
(`TimeoutError: Pulsar did not bind <mode> consumers`) This is a ~stopgap /~ safety net; the deterministic root-cause fix is proposed separately in the #470. The two are
non-overlapping and can land in either order.

## Changes

- **`harness/pulsar_control.py`**: bump the consumer bind timeout from `60.0` to `120.0` to give
  a slow startup more margin.
- **`conftest.py`**: `_start_fresh_with_retry()`. The `pulsar` fixture retries a fresh
  start once on the bind `TimeoutError`. A blanket setup retry is more robust than
  marking individual scenarios rerun-eligible, since the error is not pinned to a fixed
  test. Each attempt force-recreates the container (`fresh=True`), so a retry starts from
  a clean slate. Only the bind `TimeoutError` is retried — a `docker compose up` failure
  still raises immediately, and the final `TimeoutError` propagates if every attempt
  times out so a genuine breakage still surfaces.

No new test dependency (avoids pulling in `pytest-rerunfailures`); retries silently to
match the suite's existing no-logging style.

## Testing

- `py_compile` and `flake8` (max-line 150, complexity 14) pass.
- Not run against the live docker-compose stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)