### PR TITLE
Support a custom VM boot disk image and size for GCP Batch

### DIFF
--- a/pulsar/client/container_job_config.py
+++ b/pulsar/client/container_job_config.py
@@ -126,6 +126,9 @@ class GcpJobParams(BaseModel):
     machine_type: str = Field(
         "n1-standard-1", description="Machine type for the job's VM."
     )
+    custom_vm_image: Optional[str] = Field(
+        None, description="Custom VM boot disk image URI (e.g. 'projects/my-project/global/images/my-image'). When set, VMs boot from this image."
+    )
     labels: Optional[Dict[str, str]] = Field(None)
 
 
@@ -181,6 +184,11 @@ def gcp_job_template(params: GcpJobParams) -> "batch_v1.Job":
     # Read more about local disks here: https://cloud.google.com/compute/docs/disks/local-ssd#lssd_disk_options
     policy = batch_v1.AllocationPolicy.InstancePolicy()
     policy.machine_type = params.machine_type
+
+    if params.custom_vm_image:
+        boot_disk = batch_v1.AllocationPolicy.Disk()
+        boot_disk.image = params.custom_vm_image
+        policy.boot_disk = boot_disk
 
     attached_disk = batch_v1.AllocationPolicy.AttachedDisk()
     attached_disk.new_disk = disk

--- a/pulsar/client/container_job_config.py
+++ b/pulsar/client/container_job_config.py
@@ -129,6 +129,9 @@ class GcpJobParams(BaseModel):
     custom_vm_image: Optional[str] = Field(
         None, description="Custom VM boot disk image URI (e.g. 'projects/my-project/global/images/my-image'). When set, VMs boot from this image."
     )
+    boot_disk_size_gb: Optional[int] = Field(
+        None, description="Boot disk size in GB. Required when custom_vm_image is larger than the default 30 GB boot disk."
+    )
     labels: Optional[Dict[str, str]] = Field(None)
 
 
@@ -188,6 +191,8 @@ def gcp_job_template(params: GcpJobParams) -> "batch_v1.Job":
     if params.custom_vm_image:
         boot_disk = batch_v1.AllocationPolicy.Disk()
         boot_disk.image = params.custom_vm_image
+        if params.boot_disk_size_gb:
+            boot_disk.size_gb = params.boot_disk_size_gb
         policy.boot_disk = boot_disk
 
     attached_disk = batch_v1.AllocationPolicy.AttachedDisk()


### PR DESCRIPTION
# PR 2 — Support a custom VM boot disk image and size for GCP Batch

Part of #465.
Needs galaxyproject/galaxy#23068

## Summary

Adds the ability to boot GCP Batch VMs from a custom image instead of the default
Debian image. The motivating use case is a custom image with CVMFS pre-installed and
pre-configured, which avoids slow/fragile runtime installation. Because custom images
are often larger than the default 30 GB boot disk, the boot disk size is also made
configurable.

## What's included

**1. `custom_vm_image` field on `GcpJobParams`.**
When set, `gcp_job_template()` attaches a `boot_disk` with the given image URI
(e.g. `projects/my-project/global/images/my-image`) to the instance policy.

**2. `boot_disk_size_gb` field on `GcpJobParams`.**
When set alongside `custom_vm_image`, the boot disk's `size_gb` is configured
explicitly so larger images provision successfully.

Both fields are optional and backward compatible: with neither set, VMs boot exactly
as before.

## Files changed

- `pulsar/client/container_job_config.py`

## Companion Galaxy change

A [small companion change](galaxyproject/galaxy#23068) in Galaxy's `PulsarGcpBatchJobRunner` adds `custom_vm_image`
to `PULSAR_PARAM_SPECS` and a `PASSTHROUGH_PARAMS` mechanism so runner-level params
(from `job_conf.yml`) flow through to the Pulsar client destination params. This lets
the image URI be set once at the runner level instead of duplicating it in every TPV
destination. That PR will be opened against `galaxyproject/galaxy` and linked here.

## Testing

Verified a custom CVMFS-enabled image boots and mounts correctly on GCP Batch with
`boot_disk_size_gb` sized to the image. `flake8` clean.

## Notes

- Recommended to merge after [PR 1](#466).