### PR TITLE
Dynamic VM sizing, resource env injection, and job lifecycle controls for GCP Batch

### DIFF
--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -1152,6 +1152,14 @@ class GcpMessageCoexecutionJobClient(BaseMessageCoexecutionJobClient, LaunchesGc
         super().__init__(destination_params, job_id, client_manager)
         self._setup_gcp_batch_client_properties(destination_params)
 
+    def kill(self):
+        if str(self.destination_params.get("delete_batch_job", "true")).lower() not in ("false", "0", "no"):
+            gcp_job_params = self._gcp_job_params
+            try:
+                delete_gcp_job(gcp_job_params.project_id, gcp_job_params.region, self._job_name, gcp_job_params.credentials_file)
+            except Exception:
+                log.warning("Failed to delete GCP Batch job %s", self._job_name)
+
 
 class GcpPollingCoexecutionJobClient(BasePollingCoexecutionJobClient, LaunchesGcpContainersMixin):
     """A client that co-executes pods via GCP and doesn't depend on amqp."""
@@ -1161,8 +1169,12 @@ class GcpPollingCoexecutionJobClient(BasePollingCoexecutionJobClient, LaunchesGc
         self._setup_gcp_batch_client_properties(destination_params)
 
     def kill(self):
-        gcp_job_params = self._gcp_job_params
-        delete_gcp_job(gcp_job_params.project_id, gcp_job_params.region, self._job_name, gcp_job_params.credentials_file)
+        if str(self.destination_params.get("delete_batch_job", "true")).lower() not in ("false", "0", "no"):
+            gcp_job_params = self._gcp_job_params
+            try:
+                delete_gcp_job(gcp_job_params.project_id, gcp_job_params.region, self._job_name, gcp_job_params.credentials_file)
+            except Exception:
+                log.warning("Failed to delete GCP Batch job %s", self._job_name)
 
     def clean(self):
         pass

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -41,7 +41,7 @@ from pulsar.managers.util.gcp_util import (
 from pulsar.client.container_job_config import (
     CoexecutionContainerCommand,
     container_command_to_gcp_runnable,
-    gcp_galaxy_instance_id,
+    gcp_job_id_prefix,
     gcp_job_request,
     gcp_job_template,
     parse_gcp_job_params,
@@ -1110,7 +1110,7 @@ class LaunchesGcpContainersMixin(CoexecutionLaunchMixin):
         return f"/mnt/disks/{ssd_name}"
 
     def _setup_gcp_batch_client_properties(self, destination_params):
-        self.instance_id = gcp_galaxy_instance_id(destination_params)
+        self.job_id_prefix = gcp_job_id_prefix(destination_params)
 
     def _launch_containers(
         self,
@@ -1137,8 +1137,9 @@ class LaunchesGcpContainersMixin(CoexecutionLaunchMixin):
     def _job_name(self):
         if not hasattr(self, '_cached_job_name'):
             job_id = self.job_id
+            prefix = getattr(self, 'job_id_prefix', 'pulsar')
             timestamp = int(time.time())
-            self._cached_job_name = f"pulsar-{job_id}-{timestamp}"
+            self._cached_job_name = f"{prefix}-{job_id}-{timestamp}"
         return self._cached_job_name
 
     @property

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 from enum import Enum
 from typing import (
     Any,
@@ -1134,10 +1135,11 @@ class LaunchesGcpContainersMixin(CoexecutionLaunchMixin):
 
     @property
     def _job_name(self):
-        # currently just _k8s_job_prefix... which might be fine?
-        job_id = self.job_id
-        job_name = produce_unique_k8s_job_name(app_prefix="pulsar", job_id=job_id, instance_id=self.instance_id)
-        return job_name
+        if not hasattr(self, '_cached_job_name'):
+            job_id = self.job_id
+            timestamp = int(time.time())
+            self._cached_job_name = f"pulsar-{job_id}-{timestamp}"
+        return self._cached_job_name
 
     @property
     def _gcp_job_params(self):

--- a/pulsar/client/container_job_config.py
+++ b/pulsar/client/container_job_config.py
@@ -211,11 +211,26 @@ def gcp_job_template(params: GcpJobParams) -> "batch_v1.Job":
 
     # override the staging directory since we cannot set the location of this mount path
     # the way we can in K8S based on @jmchilton's initial testing.
-    environment = batch_v1.Environment(
-        variables={
-            "PULSAR_CONFIG_OVERRIDE_STAGING_DIRECTORY": mount_path,
-        }
-    )
+    env_vars = {
+        "PULSAR_CONFIG_OVERRIDE_STAGING_DIRECTORY": mount_path,
+    }
+
+    # Inject GALAXY_SLOTS and GALAXY_MEMORY_MB so that Galaxy tool wrappers
+    # (which read $GALAXY_SLOTS for -t/--threads) use the full available cores
+    # on the right-sized VM.  Without this, CLUSTER_SLOTS_STATEMENT.sh falls
+    # through to GALAXY_SLOTS="1" on GCP Batch VMs (no SLURM/PBS/SGE env).
+    if params.cores is not None:
+        cpu_milli = convert_cpu_to_milli(params.cores)
+        galaxy_slots = max(1, cpu_milli // 1000)
+        env_vars["GALAXY_SLOTS"] = str(galaxy_slots)
+    if params.mem is not None:
+        try:
+            memory_mib = int(float(params.mem) * 1024)
+        except (ValueError, TypeError):
+            memory_mib = convert_memory_to_mib(params.mem)
+        env_vars["GALAXY_MEMORY_MB"] = str(memory_mib)
+
+    environment = batch_v1.Environment(variables=env_vars)
     task.environment = environment
 
     # Tasks are grouped inside a job using TaskGroups.

--- a/pulsar/client/container_job_config.py
+++ b/pulsar/client/container_job_config.py
@@ -8,6 +8,7 @@ documents how to map Galaxy job environment configuration objects to the contain
 infrastructure.
 """
 import base64
+import logging
 import re
 from typing import (
     Dict,
@@ -33,6 +34,8 @@ from pulsar.managers.util.gcp_util import (
 )
 from pulsar.managers.util.tes import TesClient
 
+
+log = logging.getLogger(__name__)
 
 DEFAULT_GCP_WALLTIME_LIMIT = 60 * 60 * 24  # Default wall time limit in seconds
 
@@ -160,6 +163,36 @@ def parse_gcp_job_params(params: dict) -> GcpJobParams:
     return gcp_params
 
 
+def _validate_ssd_size(disk_size_gb, machine_type):
+    """Validate and adjust local SSD size for the given machine type.
+
+    Each local SSD is 375 GB. N1 machines accept any count from 1-24,
+    but N2/N2D machines require an even number of SSDs (multiples of 2).
+    See: https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds
+
+    Returns the adjusted disk_size_gb (rounded up if necessary).
+    """
+    if disk_size_gb % 375 != 0:
+        disk_size_gb = ((disk_size_gb + 374) // 375) * 375
+        log.warning("disk_size must be a multiple of 375 GB, rounded up to %d GB", disk_size_gb)
+
+    ssd_count = disk_size_gb // 375
+    family = machine_type.split("-")[0].lower() if machine_type else ""
+
+    # N2 and N2D require an even number of local SSDs
+    if family in ("n2", "n2d") and ssd_count % 2 != 0:
+        ssd_count += 1
+        adjusted = ssd_count * 375
+        log.info(
+            "Adjusted local SSD size from %d GB to %d GB (%d SSDs) for machine type %s "
+            "(n2/n2d require an even number of local SSDs)",
+            disk_size_gb, adjusted, ssd_count, machine_type,
+        )
+        disk_size_gb = adjusted
+
+    return disk_size_gb
+
+
 def gcp_job_template(params: GcpJobParams) -> "batch_v1.Job":
     ensure_gcp_client()
 
@@ -196,12 +229,12 @@ def gcp_job_template(params: GcpJobParams) -> "batch_v1.Job":
     # The size of all the local SSDs in GB. Each local SSD is 375 GB,
     # so this value must be a multiple of 375 GB.
     # For example, for 2 local SSDs, set this value to 750 GB.
-    disk.size_gb = params.disk_size
-    assert disk.size_gb % 375 == 0
+    # The allowed number of local SSDs depends on the machine type:
+    # n1 allows any count 1-24, n2/n2d require an even number.
+    disk.size_gb = _validate_ssd_size(params.disk_size, params.machine_type)
 
     # Policies are used to define on what kind of virtual machines the tasks will run on.
     # The allowed number of local SSDs depends on the machine type for your job's VMs.
-    # In this case, we tell the system to use "n1-standard-1" machine type, which require to attach local ssd manually.
     # Read more about local disks here: https://cloud.google.com/compute/docs/disks/local-ssd#lssd_disk_options
     policy = batch_v1.AllocationPolicy.InstancePolicy()
     policy.machine_type = params.machine_type

--- a/pulsar/client/container_job_config.py
+++ b/pulsar/client/container_job_config.py
@@ -26,6 +26,9 @@ from typing_extensions import Literal
 
 from pulsar.managers.util.gcp_util import (
     batch_v1,
+    compute_machine_type,
+    convert_cpu_to_milli,
+    convert_memory_to_mib,
     ensure_client as ensure_gcp_client,
 )
 from pulsar.managers.util.tes import TesClient
@@ -124,7 +127,13 @@ class GcpJobParams(BaseModel):
         375, description="Size of the shared local SSD disk in GB (must be a multiple of 375). Maps to AllocationPolicy.Disk.size_gb."
     )
     machine_type: str = Field(
-        "n1-standard-1", description="Machine type for the job's VM."
+        "n1-standard-1", description="Machine type for the job's VM. Overridden by dynamic sizing when cores/mem are provided."
+    )
+    cores: Optional[str] = Field(
+        None, description="CPU cores requested (e.g., '4', '1.5', '500m'). When set, machine_type is computed dynamically."
+    )
+    mem: Optional[str] = Field(
+        None, description="Memory requested in GB (e.g., '8', '16'). When set, machine_type is computed dynamically."
     )
     labels: Optional[Dict[str, str]] = Field(None)
 
@@ -132,8 +141,23 @@ class GcpJobParams(BaseModel):
 def parse_gcp_job_params(params: dict) -> GcpJobParams:
     """
     Parse GCP job parameters from a dictionary (e.g., Galaxy's job destination/environment params).
+
+    If cores and/or mem are provided, machine_type is computed dynamically
+    using compute_machine_type() to select an appropriate GCP VM size.
     """
-    return GcpJobParams(**params)
+    gcp_params = GcpJobParams(**params)
+    if gcp_params.cores is not None or gcp_params.mem is not None:
+        cpu_milli = convert_cpu_to_milli(gcp_params.cores)
+        # mem is in GB from TPV, convert to MiB
+        if gcp_params.mem is not None:
+            try:
+                memory_mib = int(float(gcp_params.mem) * 1024)
+            except (ValueError, TypeError):
+                memory_mib = convert_memory_to_mib(gcp_params.mem)
+        else:
+            memory_mib = convert_memory_to_mib(None)
+        gcp_params.machine_type = compute_machine_type(cpu_milli, memory_mib)
+    return gcp_params
 
 
 def gcp_job_template(params: GcpJobParams) -> "batch_v1.Job":

--- a/pulsar/client/container_job_config.py
+++ b/pulsar/client/container_job_config.py
@@ -295,8 +295,8 @@ def container_command_to_gcp_runnable(name: str, container: CoexecutionContainer
     return runnable
 
 
-def gcp_galaxy_instance_id(destination_params: Dict[str, str]) -> Optional[str]:
-    return destination_params.get("galaxy_instance_id")
+def gcp_job_id_prefix(destination_params: Dict[str, str]) -> str:
+    return destination_params.get("job_id_prefix") or destination_params.get("galaxy_instance_id") or "pulsar"
 
 
 class BasicAuth(BaseModel):

--- a/pulsar/managers/util/gcp_util.py
+++ b/pulsar/managers/util/gcp_util.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import (
     Any,
     Optional,
@@ -17,6 +18,166 @@ except ImportError as exc:
     )
 
 log = logging.getLogger(__name__)
+
+# Default values for GCP Batch resource configuration
+DEFAULT_MEMORY_MIB = 2048
+DEFAULT_CPU_MILLI = 1000
+
+
+def convert_cpu_to_milli(cpu_str):
+    """
+    Convert CPU specification to milli-cores.
+    Supports formats like: "1", "1.5", "500m", "0.5"
+    """
+    if not cpu_str:
+        return DEFAULT_CPU_MILLI
+
+    cpu_str = str(cpu_str).strip()
+
+    # Handle milli-core format (e.g., "500m")
+    if cpu_str.endswith("m"):
+        try:
+            return int(cpu_str[:-1])
+        except ValueError:
+            log.warning("Invalid CPU format: %s, using default", cpu_str)
+            return DEFAULT_CPU_MILLI
+
+    # Handle decimal format (e.g., "1.5", "0.5")
+    try:
+        cpu_float = float(cpu_str)
+        return int(cpu_float * 1000)
+    except ValueError:
+        log.warning("Invalid CPU format: %s, using default", cpu_str)
+        return DEFAULT_CPU_MILLI
+
+
+def convert_memory_to_mib(memory_str):
+    """
+    Convert memory specification to MiB.
+    Supports formats like: "1Gi", "512Mi", "1024M", "1G", "2048"
+    """
+    if not memory_str:
+        return DEFAULT_MEMORY_MIB
+
+    memory_str = str(memory_str).strip()
+
+    # Handle plain numbers (assume MiB)
+    if memory_str.isdigit():
+        return int(memory_str)
+
+    # Extract number and unit
+    match = re.match(r"^(\d+(?:\.\d+)?)\s*([A-Za-z]*)$", memory_str)
+    if not match:
+        log.warning("Invalid memory format: %s, using default", memory_str)
+        return DEFAULT_MEMORY_MIB
+
+    value = float(match.group(1))
+    unit = match.group(2).lower()
+
+    # Convert to MiB based on unit
+    if unit in ["", "mib", "mi"]:
+        return int(value)
+    elif unit in ["gib", "gi"]:
+        return int(value * 1024)  # GiB to MiB
+    elif unit in ["mb", "m"]:
+        return int(value * 1000 / 1024)  # MB to MiB (decimal to binary)
+    elif unit in ["gb", "g"]:
+        return int(value * 1000 * 1000 / 1024 / 1024)  # GB to MiB
+    elif unit in ["kib", "ki"]:
+        return int(value / 1024)  # KiB to MiB
+    elif unit in ["kb", "k"]:
+        return int(value * 1000 / 1024 / 1024)  # KB to MiB
+    else:
+        log.warning("Unknown memory unit: %s, treating as MiB", unit)
+        return int(value)
+
+
+def compute_machine_type(cpu_milli, memory_mib, machine_type_family="n2"):
+    """
+    Compute an appropriate GCP machine type based on resource requirements.
+
+    Selects the appropriate machine type variant based on CPU-to-memory ratio:
+    - highcpu: ~0.9 GB per vCPU (CPU-intensive workloads)
+    - standard: 4 GB per vCPU (balanced workloads)
+    - highmem: 8 GB per vCPU (memory-intensive workloads)
+
+    Args:
+        cpu_milli: CPU requirement in milli-cores (1000 = 1 vCPU)
+        memory_mib: Memory requirement in MiB
+        machine_type_family: Machine family prefix (default: n2)
+
+    Returns:
+        Machine type string (e.g., "n2-standard-8", "n2-highmem-16")
+    """
+    # Valid sizes for n2 machine types
+    valid_sizes = [2, 4, 8, 16, 32, 48, 64, 80, 96, 128]
+
+    # Memory per vCPU for each variant (in GB)
+    variants = {
+        "highcpu": 0.9,  # ~0.9 GB per vCPU
+        "standard": 4.0,  # 4 GB per vCPU
+        "highmem": 8.0,  # 8 GB per vCPU
+    }
+
+    # Calculate minimum vCPUs needed for CPU requirement
+    cpu_vcpus = max(1, (cpu_milli + 999) // 1000)  # Round up, minimum 1
+
+    # Convert memory to GB
+    memory_gb = memory_mib / 1024.0
+
+    # Calculate memory per vCPU ratio based on request
+    if cpu_vcpus > 0:
+        requested_mem_per_vcpu = memory_gb / cpu_vcpus
+    else:
+        requested_mem_per_vcpu = memory_gb
+
+    # Select variant based on memory-per-vCPU ratio
+    if requested_mem_per_vcpu <= 2.0:
+        variant = "highcpu"
+        mem_per_vcpu = variants["highcpu"]
+    elif requested_mem_per_vcpu <= 6.0:
+        variant = "standard"
+        mem_per_vcpu = variants["standard"]
+    else:
+        variant = "highmem"
+        mem_per_vcpu = variants["highmem"]
+
+    # Calculate minimum vCPUs needed for memory with selected variant
+    memory_vcpus = max(1, int((memory_gb + mem_per_vcpu - 0.001) // mem_per_vcpu))
+
+    # Take the larger of CPU and memory requirements
+    min_vcpus = max(cpu_vcpus, memory_vcpus)
+
+    # Find the smallest valid size that meets the requirement
+    selected_size = None
+    for size in valid_sizes:
+        if size >= min_vcpus:
+            selected_size = size
+            break
+
+    # If requirements exceed largest size, use the largest
+    if selected_size is None:
+        selected_size = valid_sizes[-1]
+        log.warning(
+            "Resource requirements (CPU: %d mCPU, Memory: %d MiB) exceed largest %s-%s size, using %s-%s-%d",
+            cpu_milli,
+            memory_mib,
+            machine_type_family,
+            variant,
+            machine_type_family,
+            variant,
+            selected_size,
+        )
+
+    machine_type = f"{machine_type_family}-{variant}-{selected_size}"
+    log.debug(
+        "Computed machine type %s for resources: %d mCPU, %d MiB (%.1f GB/vCPU ratio)",
+        machine_type,
+        cpu_milli,
+        memory_mib,
+        requested_mem_per_vcpu,
+    )
+    return machine_type
 
 
 def ensure_client():
@@ -72,9 +233,14 @@ def delete_gcp_job(
 
 
 __all__ = (
+    "DEFAULT_CPU_MILLI",
+    "DEFAULT_MEMORY_MIB",
+    "batch_v1",
+    "compute_machine_type",
+    "convert_cpu_to_milli",
+    "convert_memory_to_mib",
+    "delete_gcp_job",
     "ensure_client",
     "gcp_client",
-    "batch_v1",
     "get_gcp_job",
-    "delete_gcp_job",
 )


### PR DESCRIPTION
# PR 3 — Dynamic VM sizing, resource env injection, and job lifecycle controls for GCP Batch

Part of #465.

## Summary

Makes the GCP Batch runner size VMs from per-tool resource requests, gives tools the
full VM resources, and adds operational controls for job naming and cleanup. Before
this PR every job used a fixed `machine_type`, tools ran single-threaded regardless of
the VM, job names could collide, N2/N2D local-SSD counts were rejected, and jobs were
always deleted on cancel (losing Cloud Logging for debugging).

## What's included

**1. Dynamic VM sizing from `cores`/`mem`.**
Adds `cores` and `mem` fields to `GcpJobParams`. When either is set,
`parse_gcp_job_params()` computes an appropriate N2 machine type via a new
`compute_machine_type()` helper in `gcp_util.py` (with `convert_cpu_to_milli()` and
`convert_memory_to_mib()`), choosing between `highcpu`/`standard`/`highmem` variants.
These helpers are intentionally Galaxy-free so Galaxy's direct
`GoogleCloudBatchJobRunner` can import them from Pulsar in a follow-up and share one
implementation.

**2. Inject `GALAXY_SLOTS` / `GALAXY_MEMORY_MB` and set the container compute resource.**
On a Batch VM there is no scheduler environment, so `$GALAXY_SLOTS` fell through to `1`
and tools ran single-threaded. When `cores`/`mem` are set, these env vars are injected
into the task environment and `task.compute_resource` is set so the container gets the
full VM instead of Batch's default 2 vCPU / 2 GB.

**3. Validate local-SSD count for N2/N2D machine types.**
Replaces a bare `assert size_gb % 375 == 0` with `_validate_ssd_size()`, which rounds up
to the nearest 375 GB and adds one more SSD for N2/N2D when the count is odd (these
types require an even count), logging the adjustment instead of crashing.

**4. Collision-free job names with a configurable prefix.**
Replaces the K8s-style name generator with `{prefix}-{job_id}-{unix_timestamp}` and
caches it so submit/poll/delete agree. Renames the internal helper
`gcp_galaxy_instance_id` → `gcp_job_id_prefix`, resolving the prefix as
`job_id_prefix` > `galaxy_instance_id` > `"pulsar"` so jobs from different Galaxy
instances sharing a project are distinguishable.

**5. Optional job deletion and AMQP `kill()`.**
Both client `kill()` paths now honor a `delete_batch_job` destination param (default
`true`); set `false` to retain jobs and their Cloud Logging for debugging. Adds the
previously missing `kill()` to `GcpMessageCoexecutionJobClient` and wraps deletion in
try/except so a failed delete doesn't cascade.

## Files changed

- `pulsar/client/client.py`
- `pulsar/client/container_job_config.py`
- `pulsar/managers/util/gcp_util.py`

## Testing

Verified VMs are sized from TPV `cores`/`mem`, tools run multi-threaded with the
injected `GALAXY_SLOTS`, N2 jobs provision with corrected SSD counts, job names no
longer collide, and jobs are retained when `delete_batch_job: false`. `flake8` clean.

## Notes

- Renames the internal `gcp_galaxy_instance_id` helper to `gcp_job_id_prefix`; if [PR 1](#466)
  has merged first this PR may need a trivial rebase. Recommended to merge last of the
  three.
- Future work (separate PR): update Galaxy's
  `galaxy/jobs/runners/util/gcp_batch/helpers.py` to re-export the sizing helpers from
  `pulsar.managers.util.gcp_util` so both runners share one implementation.