### PR TITLE
Native cvmfsexec support for CVMFS-hosted Singularity/Apptainer containers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,15 @@ History
 0.15.16.dev0
 ---------------------
 
-
+* Add native ``cvmfsexec`` support to Pulsar managers (``mountrepo`` and
+  ``namespace`` modes), configured via a ``cvmfsexec`` manager option or a
+  per-job override, for accessing CVMFS repositories (and CVMFS-hosted
+  container images) on hosts without a system-wide ``/cvmfs``.
+* Add a dedicated ``container`` file-action path type for rewriting resolved
+  container image paths (e.g. a Singularity/Apptainer image on CVMFS) via a
+  ``rewrite`` action, without overloading the ``unstructured`` tool-parameter
+  path type. **Note:** ``path_types: "*any*"`` now also matches container image
+  paths.
 
 ---------------------
 0.15.15 (2026-07-13)

--- a/app.yml.sample
+++ b/app.yml.sample
@@ -17,20 +17,19 @@
 #    #  ## real /cvmfs) or "mountrepo" (bind-mounts repos under
 #    #  ## <job_directory>/.cvmfsexec/dist/cvmfs for hosts without namespaces).
 #    #  mode: mountrepo
-#    #  ## Path to the cvmfsexec launcher to install into each job directory.
+#    #  ## Path to the cvmfsexec self-contained distribution to install into each
+#    #  ## job directory. See the "Containers" section of Pulsar's docs for how
+#    #  ## to build it: https://pulsar.readthedocs.io/en/latest/containers.html
 #    #  path: /path/to/cvmfsexec
 #    #  ## CVMFS repositories to mount for each job.
 #    #  repositories:
 #    #    - data.galaxyproject.org
 #    #    - singularity.galaxyproject.org
-#    ## In mountrepo mode the host-side container image path (resolved by Galaxy
-#    ## against the real /cvmfs) must be remapped to the mounted dist location.
-#    ## That is an ordinary path rewrite: configure it on the Galaxy job
-#    ## destination as a file_actions `rewrite` rule (source /cvmfs/<repo>,
-#    ## destination __PULSAR_JOB_DIRECTORY__/.cvmfsexec/dist/cvmfs/<repo>), not
-#    ## here. The __PULSAR_JOB_DIRECTORY__ token is substituted server-side with
-#    ## the absolute job directory (a $CVMFSEXEC_DIR shell var would be broken by
-#    ## the client's shlex.quote of the image path).
+#    ## In mountrepo mode the host-side container image path must be rewritten to
+#    ## the mounted location. This is necessary and is configured on the Galaxy
+#    ## job destination (not here) with a file_actions rewrite rule; see the
+#    ## example in the "Galaxy Configuration" section of Pulsar's docs:
+#    ## https://pulsar.readthedocs.io/en/latest/galaxy_conf.html
 
 
 ## Mode to create job releated directories with. If unset

--- a/app.yml.sample
+++ b/app.yml.sample
@@ -8,6 +8,26 @@
 #  _default_:
 #    type: queued_python
 #    num_concurrent_jobs: 1
+#    ## Run jobs under cvmfsexec (https://github.com/cvmfs/cvmfsexec) so CVMFS
+#    ## repositories are available without a system-wide /cvmfs mount. This can
+#    ## also be set/overridden per-destination from Galaxy (a `cvmfsexec` job
+#    ## destination param with the same structure).
+#    #cvmfsexec:
+#    #  ## "namespace" (default requires unprivileged user namespaces; provides a
+#    #  ## real /cvmfs) or "mountrepo" (bind-mounts repos under
+#    #  ## $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs for hosts without namespaces).
+#    #  mode: mountrepo
+#    #  ## Path to the cvmfsexec launcher to install into each job directory.
+#    #  path: /path/to/cvmfsexec
+#    #  ## CVMFS repositories to mount for each job.
+#    #  repositories:
+#    #    - data.galaxyproject.org
+#    #    - singularity.galaxyproject.org
+#    #  ## mountrepo mode only: repositories holding host-side container images,
+#    #  ## whose paths are rewritten to the mounted location. Defaults to any
+#    #  ## repository whose name starts with "singularity".
+#    #  #image_repositories:
+#    #  #  - singularity.galaxyproject.org
 
 
 ## Mode to create job releated directories with. If unset

--- a/app.yml.sample
+++ b/app.yml.sample
@@ -15,7 +15,7 @@
 #    #cvmfsexec:
 #    #  ## "namespace" (default requires unprivileged user namespaces; provides a
 #    #  ## real /cvmfs) or "mountrepo" (bind-mounts repos under
-#    #  ## $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs for hosts without namespaces).
+#    #  ## <job_directory>/.cvmfsexec/dist/cvmfs for hosts without namespaces).
 #    #  mode: mountrepo
 #    #  ## Path to the cvmfsexec launcher to install into each job directory.
 #    #  path: /path/to/cvmfsexec
@@ -27,7 +27,10 @@
 #    ## against the real /cvmfs) must be remapped to the mounted dist location.
 #    ## That is an ordinary path rewrite: configure it on the Galaxy job
 #    ## destination as a file_actions `rewrite` rule (source /cvmfs/<repo>,
-#    ## destination $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/<repo>), not here.
+#    ## destination __PULSAR_JOB_DIRECTORY__/.cvmfsexec/dist/cvmfs/<repo>), not
+#    ## here. The __PULSAR_JOB_DIRECTORY__ token is substituted server-side with
+#    ## the absolute job directory (a $CVMFSEXEC_DIR shell var would be broken by
+#    ## the client's shlex.quote of the image path).
 
 
 ## Mode to create job releated directories with. If unset

--- a/app.yml.sample
+++ b/app.yml.sample
@@ -23,11 +23,11 @@
 #    #  repositories:
 #    #    - data.galaxyproject.org
 #    #    - singularity.galaxyproject.org
-#    #  ## mountrepo mode only: repositories holding host-side container images,
-#    #  ## whose paths are rewritten to the mounted location. Defaults to any
-#    #  ## repository whose name starts with "singularity".
-#    #  #image_repositories:
-#    #  #  - singularity.galaxyproject.org
+#    ## In mountrepo mode the host-side container image path (resolved by Galaxy
+#    ## against the real /cvmfs) must be remapped to the mounted dist location.
+#    ## That is an ordinary path rewrite: configure it on the Galaxy job
+#    ## destination as a file_actions `rewrite` rule (source /cvmfs/<repo>,
+#    ## destination $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/<repo>), not here.
 
 
 ## Mode to create job releated directories with. If unset

--- a/docs/containers.rst
+++ b/docs/containers.rst
@@ -4,6 +4,134 @@
 Containers
 -------------------------------
 
+Overview
+-------------------------------
+
+How a tool's container is best run with Pulsar depends on the container runtime:
+
+- **Docker** requires a container host, so containers are either launched by a
+  job script on a traditional batch manager (by setting ``docker_enabled`` on
+  the Galaxy job environment) or, more cleanly, scheduled directly by a
+  container-native backend - Kubernetes, GA4GH TES, GCP Batch, or AWS Batch.
+  These backends, and Pulsar's *co-execution* model for them, make up the bulk
+  of this page.
+
+- **Singularity/Apptainer** containers are unprivileged and run directly under
+  any traditional batch Pulsar manager (DRMAA, CLI, condor, etc.) with no
+  container scheduler required. The Galaxy Project distributes prebuilt images
+  for tools via CVMFS. See :ref:`singularity_cvmfs` below.
+
+.. _singularity_cvmfs:
+
+Singularity / Apptainer and CVMFS
+---------------------------------
+
+Unlike Docker, Singularity_ (and its fork Apptainer_) run containers without a
+privileged daemon, so a traditional batch Pulsar - a DRMAA, CLI, condor, or
+similar manager - can execute containerized tools directly, with no container
+scheduler. Enable it by setting ``singularity_enabled`` on the Galaxy job
+environment that targets Pulsar.
+
+Rather than pulling an image per job, the Galaxy Project publishes prebuilt
+Singularity images for Bioconda-based tools in a CVMFS repository,
+``singularity.galaxyproject.org`` - the ``/cvmfs/singularity.galaxyproject.org/all``
+directory holds one image file per tool/version. Pointing Galaxy's container
+resolvers at this cache lets jobs resolve to an existing image on ``/cvmfs``
+instead of building or pulling one.
+
+Container resolution happens on the Galaxy side, so the Galaxy server needs the
+CVMFS repository mounted at ``/cvmfs``. The compute nodes that run the job also
+need the image available at that path. The simplest way to provide it is to
+mount CVMFS on the compute nodes; the `Galaxy reference data repository
+documentation <https://galaxyproject.org/admin/reference-data-repo/>`_ discusses
+this and provides instructions. For compute environments where mounting CVMFS is
+not possible, ``cvmfsexec`` can access the images (and Galaxy reference data) as
+a fully unprivileged user, without root access or special permissions.
+
+Accessing CVMFS with cvmfsexec
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a compute node cannot mount ``/cvmfs`` system-wide, cvmfsexec_ provides
+per-user access to CVMFS repositories. Pulsar can utilize it for each job via a
+``cvmfsexec`` option on the job manager in ``app.yml``:
+
+.. code-block:: yaml
+
+   managers:
+     _default_:
+       type: queued_drmaa
+       cvmfsexec:
+         mode: mountrepo
+         path: /path/to/cvmfsexec
+         repositories:
+           - data.galaxyproject.org
+           - singularity.galaxyproject.org
+
+``path`` is the cvmfsexec self-contained distribution, and ``repositories``
+lists the CVMFS repositories to mount for the job. Two modes are supported:
+
+``namespace``
+    cvmfsexec mounts the repositories into a mount namespace so they are
+    available at the real ``/cvmfs``, and the job runs inside that namespace.
+    Requires unprivileged user namespaces (or a suitable setuid/fusermount
+    fallback) on the compute node. No path rewriting is needed.
+
+``mountrepo``
+    For nodes where the mount namespace cannot be created, cvmfsexec
+    bind-mounts each repository under ``<job_directory>/.cvmfsexec/dist/cvmfs``
+    instead of the real ``/cvmfs``. Because Galaxy resolves the container image
+    against the real ``/cvmfs`` and bakes that path into the job command, the
+    host-side image path must be rewritten to the mounted location with a Galaxy
+    ``file_actions`` rewrite rule on the job destination - see :ref:`galaxy_conf`
+    for the example.
+
+``namespace`` is the preferred mode; ``mountrepo`` should typically only be used
+when unprivileged user namespaces and fuse mounts are not enabled on the compute
+nodes, as discussed in the cvmfsexec_ documentation.
+
+Building the self-contained distribution
+''''''''''''''''''''''''''''''''''''''''
+
+Creating the self-contained distribution that ``path`` points to is the
+responsibility of the deployer; see the cvmfsexec_ documentation for full
+details. The simplest configuration that can access the
+``singularity.galaxyproject.org`` and ``data.galaxyproject.org`` repositories
+is:
+
+#. Run ``./makedist none`` to create a ``dist`` directory.
+
+#. Add the ``data.galaxyproject.org.pub`` and ``galaxyproject.org.pub`` keys
+   from the `Galaxy reference data repository documentation
+   <https://galaxyproject.org/admin/reference-data-repo/>`_ to
+   ``dist/etc/cvmfs/keys``.
+
+#. Place the following in ``dist/etc/cvmfs/default.local``:
+
+   .. code-block:: bash
+
+      CVMFS_HTTP_PROXY="DIRECT"
+      CVMFS_SERVER_URL="http://cvmfs1-tacc0.galaxyproject.org/cvmfs/@fqrn@;http://cvmfs1-iu0.galaxyproject.org/cvmfs/@fqrn@;http://cvmfs1-psu0.galaxyproject.org/cvmfs/@fqrn@;http://cvmfs1-ufr0.galaxyproject.eu/cvmfs/@fqrn@;http://cvmfs1-mel0.gvl.org.au/cvmfs/@fqrn@"
+
+#. Run ``./makedist -o /path/to/cvmfsexec`` to create the self-contained
+   distribution, and set ``path`` to ``/path/to/cvmfsexec``.
+
+The `galaxyproject.cvmfsexec
+<https://github.com/galaxyproject/ansible-role-cvmfsexec>`_ Ansible role can
+build the distribution on your Pulsar server for you. For a complete production
+example, see how usegalaxy.org `configures and deploys cvmfsexec
+<https://github.com/galaxyproject/infrastructure-playbook/blob/725401c30e1c02bc0b0bc1630777a557faad217b/group_vars/hpc_pulsar_servers/vars.yaml#L188>`_.
+
+In HPC scenarios with a shared scratch filesystem, configuring a CVMFS `alien
+cache <https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#alien-cache>`_
+can be beneficial.
+
+The ``cvmfsexec`` option can also be set (or overridden) per Galaxy job
+destination via a ``cvmfsexec`` param with the same structure.
+
+.. _Singularity: https://sylabs.io/singularity/
+.. _Apptainer: https://apptainer.org/
+.. _cvmfsexec: https://github.com/cvmfs/cvmfsexec
+
 Galaxy and Shared File Systems
 -------------------------------
 

--- a/docs/containers.rst
+++ b/docs/containers.rst
@@ -119,7 +119,7 @@ The `galaxyproject.cvmfsexec
 <https://github.com/galaxyproject/ansible-role-cvmfsexec>`_ Ansible role can
 build the distribution on your Pulsar server for you. For a complete production
 example, see how usegalaxy.org `configures and deploys cvmfsexec
-<https://github.com/galaxyproject/infrastructure-playbook/blob/725401c30e1c02bc0b0bc1630777a557faad217b/group_vars/hpc_pulsar_servers/vars.yaml#L188>`_.
+<https://github.com/galaxyproject/infrastructure-playbook/blob/4666707a5cfd7587ed5e9ec8f3c7a6b43933b0cb/group_vars/hpc_pulsar_servers/vars.yaml#L188>`_.
 
 In HPC scenarios with a shared scratch filesystem, configuring a CVMFS `alien
 cache <https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#alien-cache>`_

--- a/docs/galaxy_conf.rst
+++ b/docs/galaxy_conf.rst
@@ -193,4 +193,27 @@ supported JSON). The following captures available options:
 .. literalinclude:: files/file_actions_sample_1.yaml
    :language: yaml
 
+Rewriting Container Image Paths for cvmfsexec
+`````````````````````````````````````````````
+
+The ``rewrite`` action above is also how you remap a Singularity/Apptainer
+container image path when the compute node exposes CVMFS at a non-standard path
+via ``cvmfsexec`` in ``mountrepo`` mode (see :ref:`containers`). Galaxy resolves
+the image against the real ``/cvmfs`` on the Galaxy server, but on the compute
+node the repository is bind-mounted under the per-job directory, so the image
+path baked into the job command must be rewritten. Add the following to the
+destination's ``file_actions`` (or ``file_action_config``):
+
+.. code-block:: yaml
+
+   paths:
+     - path: /cvmfs/singularity.galaxyproject.org
+       path_types: unstructured
+       action: rewrite
+       source_directory: /cvmfs/singularity.galaxyproject.org
+       destination_directory: __PULSAR_JOB_DIRECTORY__/.cvmfsexec/dist/cvmfs/singularity.galaxyproject.org
+
+The ``__PULSAR_JOB_DIRECTORY__`` token is replaced by the Pulsar server with the
+absolute per-job directory.
+
 .. _app.yml.sample: https://github.com/galaxyproject/pulsar/blob/master/app.yml.sample

--- a/docs/galaxy_conf.rst
+++ b/docs/galaxy_conf.rst
@@ -196,24 +196,27 @@ supported JSON). The following captures available options:
 Rewriting Container Image Paths for cvmfsexec
 `````````````````````````````````````````````
 
-The ``rewrite`` action above is also how you remap a Singularity/Apptainer
-container image path when the compute node exposes CVMFS at a non-standard path
-via ``cvmfsexec`` in ``mountrepo`` mode (see :ref:`containers`). Galaxy resolves
-the image against the real ``/cvmfs`` on the Galaxy server, but on the compute
-node the repository is bind-mounted under the per-job directory, so the image
-path baked into the job command must be rewritten. Add the following to the
+The ``rewrite`` action is also how you remap a Singularity/Apptainer container
+image path when the compute node exposes CVMFS at a non-standard path via
+``cvmfsexec`` in ``mountrepo`` mode (see :ref:`containers`). Galaxy resolves the
+image against the real ``/cvmfs`` on the Galaxy server, but on the compute node
+the repository is bind-mounted under the per-job directory, so the image path
+baked into the job command must be rewritten. The resolved container image is
+remapped via the dedicated ``container`` path type (distinct from the
+``unstructured`` tool-parameter paths above). Add the following to the
 destination's ``file_actions`` (or ``file_action_config``):
 
 .. code-block:: yaml
 
    paths:
      - path: /cvmfs/singularity.galaxyproject.org
-       path_types: unstructured
+       path_types: container
        action: rewrite
        source_directory: /cvmfs/singularity.galaxyproject.org
        destination_directory: __PULSAR_JOB_DIRECTORY__/.cvmfsexec/dist/cvmfs/singularity.galaxyproject.org
 
-The ``__PULSAR_JOB_DIRECTORY__`` token is replaced by the Pulsar server with the
-absolute per-job directory.
+The ``container`` path type matches only the resolved container image path, so
+this rule never affects tool parameters. The ``__PULSAR_JOB_DIRECTORY__`` token
+is replaced by the Pulsar server with the absolute per-job directory.
 
 .. _app.yml.sample: https://github.com/galaxyproject/pulsar/blob/master/app.yml.sample

--- a/pulsar/client/action_mapper.py
+++ b/pulsar/client/action_mapper.py
@@ -79,6 +79,10 @@ path_type = Bunch(
     # Other fixed tool parameter paths (likely coming from tool data, but not
     # necessarily).
     UNSTRUCTURED="unstructured",
+    # Resolved container image path (e.g. a Singularity/Apptainer image on
+    # CVMFS). Resolved on the Galaxy host but read on the compute node, which
+    # may expose the image at a different path. Never staged.
+    CONTAINER="container",
 )
 
 
@@ -94,7 +98,7 @@ ACTION_DEFAULT_PATH_TYPES = [
     path_type.OUTPUT_METADATA,
     path_type.OUTPUT_JOBDIR,
 ]
-ALL_PATH_TYPES = ACTION_DEFAULT_PATH_TYPES + [path_type.UNSTRUCTURED]
+ALL_PATH_TYPES = ACTION_DEFAULT_PATH_TYPES + [path_type.UNSTRUCTURED, path_type.CONTAINER]
 
 MISSING_FILES_ENDPOINT_ERROR = "Attempted to use remote_transfer action without defining a files_endpoint."
 MISSING_SSH_KEY_ERROR = "Attempt to use file transfer action requiring an SSH key without specifying a ssh_key."

--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -115,6 +115,9 @@ class BaseJobClient:
         for attr in ["ssh_key", "ssh_user", "ssh_host", "ssh_port"]:
             setattr(self, attr, destination_params.get(attr, None))
         self.env = destination_params.get("env", [])
+        # Optional cvmfsexec configuration; delivered to the Pulsar manager via
+        # setup_params so it can override the manager's app.yml default.
+        self.cvmfsexec = destination_params.get("cvmfsexec", None)
         self.files_endpoint = destination_params.get("files_endpoint", None)
         self.token_endpoint = destination_params.get("token_endpoint", None)
 
@@ -210,6 +213,8 @@ class JobClient(BaseJobClient):
             launch_params['submit_extras'] = json_dumps({'touch_outputs': job_config['touch_outputs']})
         if token_endpoint is not None:
             launch_params["token_endpoint"] = json_dumps({'token_endpoint': token_endpoint})
+        if self.cvmfsexec is not None:
+            launch_params['cvmfsexec'] = json_dumps(self.cvmfsexec)
 
         if job_config and self.setup_handler.local:
             # Setup not yet called, job properties were inferred from
@@ -385,6 +390,8 @@ class BaseRemoteConfiguredJobClient(BaseJobClient):
             launch_params['remote_staging']['ssh_key'] = self.ssh_key
         launch_params['dynamic_file_sources'] = dynamic_file_sources
         launch_params['token_endpoint'] = token_endpoint
+        if self.cvmfsexec is not None:
+            launch_params['cvmfsexec'] = self.cvmfsexec
 
         if job_config and self.setup_handler.local:
             # Setup not yet called, job properties were inferred from

--- a/pulsar/client/path_mapper.py
+++ b/pulsar/client/path_mapper.py
@@ -70,6 +70,23 @@ class PathMapper:
         remote_path = self.path_helper.remote_join(self.unstructured_files_directory, name)
         return remote_path, unique_names
 
+    def check_for_container_rewrite(self, local_path):
+        """Rewrite a resolved container image path for the compute node.
+
+        Container images (e.g. a Singularity/Apptainer image on CVMFS) are
+        resolved against the Galaxy-side filesystem but read on the compute
+        node, which may expose the image at a different path. Unlike arbitrary
+        (unstructured) tool paths, container images are never staged, so this
+        only ever applies a ``rewrite`` action; any other action is a no-op.
+        """
+        path = str(local_path)
+        action = self.action_mapper.action({"path": path}, path_type.CONTAINER)
+        if action.staging_needed:
+            # Container images live on CVMFS or in a registry; they are not
+            # staged. A staging action here would be a misconfiguration.
+            return None
+        return action.path_rewrite(self.path_helper)
+
     def __remote_path_rewrite(self, dataset_path, dataset_path_type, name=None):
         """ Return remote path of this file (if staging is required) else None.
         """

--- a/pulsar/client/path_mapper.py
+++ b/pulsar/client/path_mapper.py
@@ -1,3 +1,4 @@
+import logging
 import os.path
 
 from galaxy.util import in_directory
@@ -8,6 +9,8 @@ from .action_mapper import (
 )
 from .staging import CLIENT_INPUT_PATH_TYPES
 from .util import PathHelper
+
+log = logging.getLogger(__name__)
 
 
 class PathMapper:
@@ -83,7 +86,16 @@ class PathMapper:
         action = self.action_mapper.action({"path": path}, path_type.CONTAINER)
         if action.staging_needed:
             # Container images live on CVMFS or in a registry; they are not
-            # staged. A staging action here would be a misconfiguration.
+            # staged. A staging action here is a misconfiguration - most likely a
+            # broad "*any*" file_actions rule that now also matches container
+            # paths. Warn and leave the image path untouched.
+            log.warning(
+                "Ignoring staging file action (%s) matched for container image path '%s'; "
+                "container images are never staged. Use a 'rewrite' action (or scope the rule "
+                "away from the 'container' path type) if this path needs remapping.",
+                action.action_type,
+                path,
+            )
             return None
         return action.path_rewrite(self.path_helper)
 

--- a/pulsar/manager_endpoint_util.py
+++ b/pulsar/manager_endpoint_util.py
@@ -107,11 +107,16 @@ def submit_job(manager, job_config):
             )
 
         if job_config is not None:
-            job_directory = job_config["job_directory"]
+            job_directory = os.path.abspath(job_config["job_directory"])
             jobs_directory = os.path.abspath(os.path.join(job_directory, os.pardir))
             command_line = command_line.replace('__PULSAR_JOBS_DIRECTORY__', jobs_directory)
+            # The absolute per-job directory. Lets the client emit a path that is
+            # relative to the (runtime-unknown) job directory without embedding a
+            # shell variable - important for tokens that pass through shlex.quote
+            # on the client (e.g. a container image path rewritten for cvmfsexec).
+            command_line = command_line.replace('__PULSAR_JOB_DIRECTORY__', job_directory)
 
-        # TODO: Handle __PULSAR_JOB_DIRECTORY__ config files, metadata files, etc...
+        # TODO: Handle __PULSAR_JOB_DIRECTORY__ in config files, metadata files, etc...
         # Deliver a per-job cvmfsexec override to the manager via setup_params.
         # Merged here (after the setup decision above) so it does not itself
         # trigger job setup.

--- a/pulsar/manager_endpoint_util.py
+++ b/pulsar/manager_endpoint_util.py
@@ -92,6 +92,7 @@ def submit_job(manager, job_config):
         touch_outputs = job_config.get('touch_outputs', [])
         dynamic_file_sources = job_config.get("dynamic_file_sources", None)
         token_endpoint = job_config.get("token_endpoint", None)
+        cvmfsexec = job_config.get("cvmfsexec", None)
 
         job_config = None
         if setup_params or force_setup:
@@ -111,6 +112,12 @@ def submit_job(manager, job_config):
             command_line = command_line.replace('__PULSAR_JOBS_DIRECTORY__', jobs_directory)
 
         # TODO: Handle __PULSAR_JOB_DIRECTORY__ config files, metadata files, etc...
+        # Deliver a per-job cvmfsexec override to the manager via setup_params.
+        # Merged here (after the setup decision above) so it does not itself
+        # trigger job setup.
+        if cvmfsexec is not None:
+            setup_params = {**setup_params, "cvmfsexec": cvmfsexec}
+
         manager.touch_outputs(job_id, touch_outputs)
         launch_config = {
             "remote_staging": remote_staging,

--- a/pulsar/managers/base/__init__.py
+++ b/pulsar/managers/base/__init__.py
@@ -31,6 +31,7 @@ from pulsar.client.job_directory import (
     RemoteJobDirectory,
 )
 from pulsar.managers import ManagerInterface
+from pulsar.managers.util.cvmfsexec import parse as parse_cvmfsexec_config
 
 JOB_DIRECTORY_INPUTS = "inputs"
 JOB_DIRECTORY_OUTPUTS = "outputs"
@@ -71,6 +72,9 @@ class BaseManager(ManagerInterface):
         self.maximum_stream_size = kwds.get("maximum_stream_size", -1)
         self.__init_galaxy_system_properties(kwds)
         self.tmp_dir = kwds.get("tmp_dir", None)
+        # Default cvmfsexec configuration for this manager (app.yml). May be
+        # overridden per job by a ``cvmfsexec`` entry in setup_params.
+        self.cvmfsexec_config = parse_cvmfsexec_config(kwds.get("cvmfsexec"))
         self.debug = str(kwds.get("debug", False)).lower() == "true"
         self.authorizer = app.authorizer
         self.user_auth_manager = app.user_auth_manager

--- a/pulsar/managers/base/directory.py
+++ b/pulsar/managers/base/directory.py
@@ -8,7 +8,10 @@ from pulsar.managers import PULSAR_UNKNOWN_RETURN_CODE
 from pulsar.managers.base import BaseManager
 from ..util import cvmfsexec
 from ..util.env import env_to_statement
-from ..util.job_script import job_script
+from ..util.job_script import (
+    ExitHandlers,
+    job_script,
+)
 
 log = logging.getLogger(__name__)
 
@@ -171,12 +174,19 @@ class DirectoryBaseManager(BaseManager):
             command_line = cvmfsexec.wrap_command(cvmfsexec_config, command_line)
         script_env = self._job_template_env(job_id, command_line=command_line, env=env, setup_params=setup_params)
         if cvmfsexec_config is not None:
-            # Mount preamble is injected directly into the job script template
-            # (after $prepare_dirs_statement), not via the env mechanism. Uses the
-            # absolute job directory so the mount location matches the image path
-            # the client rewrote to __PULSAR_JOB_DIRECTORY__ (substituted server-side).
+            # cvmfsexec preamble is injected directly into the job script template
+            # (the $cvmfsexec_setup slot), not via the env mechanism: for mountrepo
+            # mode the mount commands (using the absolute job directory so the mount
+            # location matches the image path the client rewrote to
+            # __PULSAR_JOB_DIRECTORY__), and for namespace mode the exports that let
+            # the wrapped command see the job script's shell state.
             job_directory = self.job_directory(job_id).job_directory
             script_env["cvmfsexec_setup"] = "\n".join(cvmfsexec.setup_commands(cvmfsexec_config, job_directory))
+            # Collect cleanup into the job script's single EXIT handler; cvmfsexec
+            # adds its unmount when running in mountrepo mode.
+            exit_handlers = ExitHandlers()
+            cvmfsexec.add_exit_handlers(exit_handlers, cvmfsexec_config, job_directory)
+            script_env["exit_handler_setup"] = exit_handlers.render()
         script = job_script(**script_env)
         return self._write_job_script(job_id, script)
 

--- a/pulsar/managers/base/directory.py
+++ b/pulsar/managers/base/directory.py
@@ -165,11 +165,10 @@ class DirectoryBaseManager(BaseManager):
         )
         cvmfsexec_config = self._cvmfsexec_config(setup_params)
         if cvmfsexec_config is not None:
-            # Rewrite the container image path (mountrepo mode) or wrap the
-            # command to run under cvmfsexec (namespace mode).
-            command_line = cvmfsexec.wrap_command(
-                cvmfsexec_config, cvmfsexec.rewrite_command(cvmfsexec_config, command_line)
-            )
+            # Wrap the command to run under cvmfsexec (namespace mode); no-op for
+            # mountrepo mode, where the container image path is remapped by a
+            # Galaxy file_actions rewrite rule instead.
+            command_line = cvmfsexec.wrap_command(cvmfsexec_config, command_line)
         script_env = self._job_template_env(job_id, command_line=command_line, env=env, setup_params=setup_params)
         if cvmfsexec_config is not None:
             # Mount preamble is injected directly into the job script template

--- a/pulsar/managers/base/directory.py
+++ b/pulsar/managers/base/directory.py
@@ -6,6 +6,7 @@ from galaxy.util import asbool
 
 from pulsar.managers import PULSAR_UNKNOWN_RETURN_CODE
 from pulsar.managers.base import BaseManager
+from ..util import cvmfsexec
 from ..util.env import env_to_statement
 from ..util.job_script import job_script
 
@@ -162,9 +163,28 @@ class DirectoryBaseManager(BaseManager):
         command_line = self._expand_command_line(
             job_id, command_line, dependencies_description, job_directory=self.job_directory(job_id).job_directory
         )
+        cvmfsexec_config = self._cvmfsexec_config(setup_params)
+        if cvmfsexec_config is not None:
+            # Rewrite the container image path (mountrepo mode) or wrap the
+            # command to run under cvmfsexec (namespace mode).
+            command_line = cvmfsexec.wrap_command(
+                cvmfsexec_config, cvmfsexec.rewrite_command(cvmfsexec_config, command_line)
+            )
         script_env = self._job_template_env(job_id, command_line=command_line, env=env, setup_params=setup_params)
+        if cvmfsexec_config is not None:
+            # Mount preamble is injected directly into the job script template
+            # (after $prepare_dirs_statement), not via the env mechanism.
+            script_env["cvmfsexec_setup"] = "\n".join(cvmfsexec.setup_commands(cvmfsexec_config))
         script = job_script(**script_env)
         return self._write_job_script(job_id, script)
+
+    def _cvmfsexec_config(self, setup_params):
+        # A per-job cvmfsexec override (delivered from the Galaxy job destination
+        # via setup_params) takes precedence over the manager default.
+        override = (setup_params or {}).get("cvmfsexec")
+        if override is not None:
+            return cvmfsexec.parse(override)
+        return self.cvmfsexec_config
 
     def _tmp_dir(self, job_id: str):
         # Code stolen from Galaxy's job wrapper.

--- a/pulsar/managers/base/directory.py
+++ b/pulsar/managers/base/directory.py
@@ -172,8 +172,11 @@ class DirectoryBaseManager(BaseManager):
         script_env = self._job_template_env(job_id, command_line=command_line, env=env, setup_params=setup_params)
         if cvmfsexec_config is not None:
             # Mount preamble is injected directly into the job script template
-            # (after $prepare_dirs_statement), not via the env mechanism.
-            script_env["cvmfsexec_setup"] = "\n".join(cvmfsexec.setup_commands(cvmfsexec_config))
+            # (after $prepare_dirs_statement), not via the env mechanism. Uses the
+            # absolute job directory so the mount location matches the image path
+            # the client rewrote to __PULSAR_JOB_DIRECTORY__ (substituted server-side).
+            job_directory = self.job_directory(job_id).job_directory
+            script_env["cvmfsexec_setup"] = "\n".join(cvmfsexec.setup_commands(cvmfsexec_config, job_directory))
         script = job_script(**script_env)
         return self._write_job_script(job_id, script)
 

--- a/pulsar/managers/util/cvmfsexec.py
+++ b/pulsar/managers/util/cvmfsexec.py
@@ -1,0 +1,206 @@
+"""Generate job-script shell for running under `cvmfsexec`.
+
+`cvmfsexec <https://github.com/cvmfs/cvmfsexec>`_ provides access to CVMFS
+repositories without root. Pulsar supports two execution modes, selected via a
+``cvmfsexec`` manager option (or a per-job override delivered in
+``setup_params``):
+
+``namespace``
+    ``cvmfsexec`` mounts the requested repositories into a mount namespace so
+    they are available at the real ``/cvmfs``. The job command is run under
+    ``cvmfsexec`` and no path rewriting is needed. Requires unprivileged user
+    namespaces (or a suitable setuid/fusermount fallback) on the execution host.
+
+``mountrepo``
+    For hosts where the mount namespace cannot be created, ``mountrepo``
+    bind-mounts each repository under
+    ``$CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/<repo>`` instead of the real
+    ``/cvmfs``. Because Galaxy resolves Singularity containers against the real
+    ``/cvmfs`` on the Galaxy host and bakes that path into the job command, the
+    host-side container image path must be rewritten to the ``dist`` location
+    (see :func:`rewrite_command`).
+
+This module only generates strings; it performs no I/O so it is trivially
+unit-testable.
+"""
+import shlex
+from typing import (
+    List,
+    Optional,
+)
+
+from galaxy.util import listify
+
+MODE_MOUNTREPO = "mountrepo"
+MODE_NAMESPACE = "namespace"
+VALID_MODES = (MODE_MOUNTREPO, MODE_NAMESPACE)
+DEFAULT_MODE = MODE_MOUNTREPO
+
+# Expression evaluated in the job script to locate the per-job cvmfsexec
+# directory. ``_GALAXY_JOB_DIR`` is set to the working directory near the top of
+# the job script template, so its parent is the job directory that Pulsar stages
+# under - the same value the previous hand-written destination config computed.
+DEFAULT_CVMFSEXEC_DIR_EXPR = '$(dirname "$_GALAXY_JOB_DIR")'
+
+# Where ``mountrepo`` places bind-mounted repositories, relative to CVMFSEXEC_DIR.
+DIST_CVMFS_SUBPATH = ".cvmfsexec/dist/cvmfs"
+
+# Repositories whose names start with this are assumed to hold host-side
+# container images and are rewritten in ``mountrepo`` mode by default.
+DEFAULT_IMAGE_REPOSITORY_PREFIX = "singularity"
+
+
+class CvmfsExecConfig:
+
+    def __init__(
+        self,
+        mode: str,
+        path: str,
+        repositories: List[str],
+        image_repositories: Optional[List[str]] = None,
+        cvmfsexec_dir_expr: str = DEFAULT_CVMFSEXEC_DIR_EXPR,
+    ):
+        self.mode = mode
+        self.path = path
+        self.repositories = repositories
+        if image_repositories is None:
+            image_repositories = [
+                r for r in repositories if r.startswith(DEFAULT_IMAGE_REPOSITORY_PREFIX)
+            ]
+        self.image_repositories = image_repositories
+        self.cvmfsexec_dir_expr = cvmfsexec_dir_expr
+
+    @property
+    def _dist_cvmfs_dir(self) -> str:
+        return "$CVMFSEXEC_DIR/" + DIST_CVMFS_SUBPATH
+
+
+def parse(raw) -> Optional[CvmfsExecConfig]:
+    """Build a :class:`CvmfsExecConfig` from a raw mapping (or ``None``).
+
+    Returns ``None`` when cvmfsexec is not configured.
+
+    >>> parse(None) is None
+    True
+    >>> c = parse({"path": "/opt/cvmfsexec", "repositories": ["singularity.galaxyproject.org", "data.galaxyproject.org"]})
+    >>> c.mode
+    'mountrepo'
+    >>> c.image_repositories
+    ['singularity.galaxyproject.org']
+    >>> parse({"repositories": ["a"]})
+    Traceback (most recent call last):
+    ...
+    ValueError: cvmfsexec configuration requires a 'path'
+    >>> parse({"mode": "bogus", "path": "/x", "repositories": ["a"]})
+    Traceback (most recent call last):
+    ...
+    ValueError: Invalid cvmfsexec mode 'bogus', must be one of: mountrepo, namespace
+    """
+    if not raw:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("cvmfsexec configuration must be a mapping")
+
+    mode = raw.get("mode") or DEFAULT_MODE
+    if mode not in VALID_MODES:
+        raise ValueError(
+            "Invalid cvmfsexec mode '%s', must be one of: %s" % (mode, ", ".join(VALID_MODES))
+        )
+
+    path = raw.get("path")
+    if not path:
+        raise ValueError("cvmfsexec configuration requires a 'path'")
+
+    repositories = listify(raw.get("repositories"))
+    if not repositories:
+        raise ValueError("cvmfsexec configuration requires at least one repository")
+
+    image_repositories = raw.get("image_repositories")
+    if image_repositories is not None:
+        image_repositories = listify(image_repositories)
+
+    cvmfsexec_dir_expr = raw.get("cvmfsexec_dir") or DEFAULT_CVMFSEXEC_DIR_EXPR
+
+    return CvmfsExecConfig(
+        mode=mode,
+        path=path,
+        repositories=repositories,
+        image_repositories=image_repositories,
+        cvmfsexec_dir_expr=cvmfsexec_dir_expr,
+    )
+
+
+def setup_commands(config: CvmfsExecConfig) -> List[str]:
+    """Shell statements that prepare cvmfsexec before the job command runs.
+
+    For ``mountrepo`` mode this reproduces the previously hand-maintained
+    destination ``env``/``execute`` block: locate ``CVMFSEXEC_DIR``, install the
+    cvmfsexec launcher, bootstrap the ``.cvmfsexec`` dist tree, register cleanup,
+    and mount each repository. ``namespace`` mode needs no preamble - the command
+    is wrapped instead (see :func:`wrap_command`).
+
+    >>> c = parse({"path": "/opt/cvmfsexec", "repositories": ["singularity.galaxyproject.org"]})
+    >>> setup_commands(c)  # doctest: +NORMALIZE_WHITESPACE
+    ['export CVMFSEXEC_DIR="$(dirname "$_GALAXY_JOB_DIR")"',
+     'cp "/opt/cvmfsexec" "$CVMFSEXEC_DIR/cvmfsexec"',
+     '"$CVMFSEXEC_DIR/cvmfsexec" -v >/dev/null',
+     'trap "$CVMFSEXEC_DIR/.cvmfsexec/umountrepo -a" EXIT',
+     '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" singularity.galaxyproject.org']
+    """
+    if config.mode != MODE_MOUNTREPO:
+        return []
+    commands = [
+        'export CVMFSEXEC_DIR="%s"' % config.cvmfsexec_dir_expr,
+        'cp "%s" "$CVMFSEXEC_DIR/cvmfsexec"' % config.path,
+        '"$CVMFSEXEC_DIR/cvmfsexec" -v >/dev/null',
+        'trap "$CVMFSEXEC_DIR/.cvmfsexec/umountrepo -a" EXIT',
+    ]
+    for repository in config.repositories:
+        commands.append('"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" %s' % repository)
+    return commands
+
+
+def rewrite_command(config: CvmfsExecConfig, command: str) -> str:
+    """Rewrite host-side image paths for ``mountrepo`` mode.
+
+    Only the configured ``image_repositories`` prefixes are rewritten. Other
+    ``/cvmfs`` references are left untouched: they are read *inside* the
+    container (where ``singularity_volumes`` bind-mounts the dist tree back onto
+    ``/cvmfs``), and rewriting them would corrupt the in-container paths and the
+    bind-mount target.
+
+    >>> c = parse({"path": "/x", "repositories": ["singularity.galaxyproject.org", "data.galaxyproject.org"]})
+    >>> rewrite_command(c, "singularity exec /cvmfs/singularity.galaxyproject.org/all/img sh")
+    'singularity exec $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/singularity.galaxyproject.org/all/img sh'
+    >>> rewrite_command(c, "cat /cvmfs/data.galaxyproject.org/x.loc")
+    'cat /cvmfs/data.galaxyproject.org/x.loc'
+    """
+    if config.mode != MODE_MOUNTREPO:
+        return command
+    for repository in config.image_repositories:
+        source = "/cvmfs/%s/" % repository
+        destination = "%s/%s/" % (config._dist_cvmfs_dir, repository)
+        command = command.replace(source, destination)
+    return command
+
+
+def wrap_command(config: CvmfsExecConfig, command: str) -> str:
+    """Wrap the job command to run under cvmfsexec for ``namespace`` mode.
+
+    The whole command is executed under ``cvmfsexec <repos> -- /bin/bash -c
+    ...`` so the real ``/cvmfs`` is available throughout. ``mountrepo`` mode
+    returns the command unchanged (its repositories are mounted by the preamble).
+
+    Note: exported environment and the working directory are inherited by the
+    wrapped shell, but non-exported shell variables set earlier in the job
+    script are not visible inside it. Namespace mode should be validated on a
+    namespace-capable host before production use.
+
+    >>> c = parse({"mode": "namespace", "path": "/opt/cvmfsexec", "repositories": ["data.galaxyproject.org"]})
+    >>> wrap_command(c, "run_tool --flag")
+    '"/opt/cvmfsexec" data.galaxyproject.org -- /bin/bash -c \\'run_tool --flag\\''
+    """
+    if config.mode != MODE_NAMESPACE:
+        return command
+    repositories = " ".join(config.repositories)
+    return '"%s" %s -- /bin/bash -c %s' % (config.path, repositories, shlex.quote(command))

--- a/pulsar/managers/util/cvmfsexec.py
+++ b/pulsar/managers/util/cvmfsexec.py
@@ -17,8 +17,13 @@ repositories without root. Pulsar supports two execution modes, selected via a
     ``$CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/<repo>`` instead of the real
     ``/cvmfs``. Because Galaxy resolves Singularity containers against the real
     ``/cvmfs`` on the Galaxy host and bakes that path into the job command, the
-    host-side container image path must be rewritten to the ``dist`` location
-    (see :func:`rewrite_command`).
+    host-side container image path must be remapped to the ``dist`` location.
+    That rewrite is *not* done here: it is an ordinary path rewrite handled by
+    Galaxy via a destination ``file_actions``/``file_action_config`` ``rewrite``
+    rule (source ``/cvmfs/<repo>``, destination
+    ``$CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/<repo>``). This module only owns the
+    cvmfsexec runtime setup (mount preamble and, for namespace mode, wrapping
+    the command).
 
 This module only generates strings; it performs no I/O so it is trivially
 unit-testable.
@@ -42,13 +47,6 @@ DEFAULT_MODE = MODE_MOUNTREPO
 # under - the same value the previous hand-written destination config computed.
 DEFAULT_CVMFSEXEC_DIR_EXPR = '$(dirname "$_GALAXY_JOB_DIR")'
 
-# Where ``mountrepo`` places bind-mounted repositories, relative to CVMFSEXEC_DIR.
-DIST_CVMFS_SUBPATH = ".cvmfsexec/dist/cvmfs"
-
-# Repositories whose names start with this are assumed to hold host-side
-# container images and are rewritten in ``mountrepo`` mode by default.
-DEFAULT_IMAGE_REPOSITORY_PREFIX = "singularity"
-
 
 class CvmfsExecConfig:
 
@@ -57,22 +55,12 @@ class CvmfsExecConfig:
         mode: str,
         path: str,
         repositories: List[str],
-        image_repositories: Optional[List[str]] = None,
         cvmfsexec_dir_expr: str = DEFAULT_CVMFSEXEC_DIR_EXPR,
     ):
         self.mode = mode
         self.path = path
         self.repositories = repositories
-        if image_repositories is None:
-            image_repositories = [
-                r for r in repositories if r.startswith(DEFAULT_IMAGE_REPOSITORY_PREFIX)
-            ]
-        self.image_repositories = image_repositories
         self.cvmfsexec_dir_expr = cvmfsexec_dir_expr
-
-    @property
-    def _dist_cvmfs_dir(self) -> str:
-        return "$CVMFSEXEC_DIR/" + DIST_CVMFS_SUBPATH
 
 
 def parse(raw) -> Optional[CvmfsExecConfig]:
@@ -85,8 +73,8 @@ def parse(raw) -> Optional[CvmfsExecConfig]:
     >>> c = parse({"path": "/opt/cvmfsexec", "repositories": ["singularity.galaxyproject.org", "data.galaxyproject.org"]})
     >>> c.mode
     'mountrepo'
-    >>> c.image_repositories
-    ['singularity.galaxyproject.org']
+    >>> c.repositories
+    ['singularity.galaxyproject.org', 'data.galaxyproject.org']
     >>> parse({"repositories": ["a"]})
     Traceback (most recent call last):
     ...
@@ -115,17 +103,12 @@ def parse(raw) -> Optional[CvmfsExecConfig]:
     if not repositories:
         raise ValueError("cvmfsexec configuration requires at least one repository")
 
-    image_repositories = raw.get("image_repositories")
-    if image_repositories is not None:
-        image_repositories = listify(image_repositories)
-
     cvmfsexec_dir_expr = raw.get("cvmfsexec_dir") or DEFAULT_CVMFSEXEC_DIR_EXPR
 
     return CvmfsExecConfig(
         mode=mode,
         path=path,
         repositories=repositories,
-        image_repositories=image_repositories,
         cvmfsexec_dir_expr=cvmfsexec_dir_expr,
     )
 
@@ -158,30 +141,6 @@ def setup_commands(config: CvmfsExecConfig) -> List[str]:
     for repository in config.repositories:
         commands.append('"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" %s' % repository)
     return commands
-
-
-def rewrite_command(config: CvmfsExecConfig, command: str) -> str:
-    """Rewrite host-side image paths for ``mountrepo`` mode.
-
-    Only the configured ``image_repositories`` prefixes are rewritten. Other
-    ``/cvmfs`` references are left untouched: they are read *inside* the
-    container (where ``singularity_volumes`` bind-mounts the dist tree back onto
-    ``/cvmfs``), and rewriting them would corrupt the in-container paths and the
-    bind-mount target.
-
-    >>> c = parse({"path": "/x", "repositories": ["singularity.galaxyproject.org", "data.galaxyproject.org"]})
-    >>> rewrite_command(c, "singularity exec /cvmfs/singularity.galaxyproject.org/all/img sh")
-    'singularity exec $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/singularity.galaxyproject.org/all/img sh'
-    >>> rewrite_command(c, "cat /cvmfs/data.galaxyproject.org/x.loc")
-    'cat /cvmfs/data.galaxyproject.org/x.loc'
-    """
-    if config.mode != MODE_MOUNTREPO:
-        return command
-    for repository in config.image_repositories:
-        source = "/cvmfs/%s/" % repository
-        destination = "%s/%s/" % (config._dist_cvmfs_dir, repository)
-        command = command.replace(source, destination)
-    return command
 
 
 def wrap_command(config: CvmfsExecConfig, command: str) -> str:

--- a/pulsar/managers/util/cvmfsexec.py
+++ b/pulsar/managers/util/cvmfsexec.py
@@ -14,16 +14,18 @@ repositories without root. Pulsar supports two execution modes, selected via a
 ``mountrepo``
     For hosts where the mount namespace cannot be created, ``mountrepo``
     bind-mounts each repository under
-    ``$CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/<repo>`` instead of the real
+    ``<job_directory>/.cvmfsexec/dist/cvmfs/<repo>`` instead of the real
     ``/cvmfs``. Because Galaxy resolves Singularity containers against the real
     ``/cvmfs`` on the Galaxy host and bakes that path into the job command, the
     host-side container image path must be remapped to the ``dist`` location.
     That rewrite is *not* done here: it is an ordinary path rewrite handled by
     Galaxy via a destination ``file_actions``/``file_action_config`` ``rewrite``
     rule (source ``/cvmfs/<repo>``, destination
-    ``$CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/<repo>``). This module only owns the
-    cvmfsexec runtime setup (mount preamble and, for namespace mode, wrapping
-    the command).
+    ``__PULSAR_JOB_DIRECTORY__/.cvmfsexec/dist/cvmfs/<repo>``). The
+    ``__PULSAR_JOB_DIRECTORY__`` token is substituted by the Pulsar server with
+    the absolute job directory (it survives ``shlex.quote`` on the client, unlike
+    a ``$VAR``). This module only owns the cvmfsexec runtime setup (mount
+    preamble and, for namespace mode, wrapping the command).
 
 This module only generates strings; it performs no I/O so it is trivially
 unit-testable.
@@ -41,12 +43,6 @@ MODE_NAMESPACE = "namespace"
 VALID_MODES = (MODE_MOUNTREPO, MODE_NAMESPACE)
 DEFAULT_MODE = MODE_MOUNTREPO
 
-# Expression evaluated in the job script to locate the per-job cvmfsexec
-# directory. ``_GALAXY_JOB_DIR`` is set to the working directory near the top of
-# the job script template, so its parent is the job directory that Pulsar stages
-# under - the same value the previous hand-written destination config computed.
-DEFAULT_CVMFSEXEC_DIR_EXPR = '$(dirname "$_GALAXY_JOB_DIR")'
-
 
 class CvmfsExecConfig:
 
@@ -55,12 +51,10 @@ class CvmfsExecConfig:
         mode: str,
         path: str,
         repositories: List[str],
-        cvmfsexec_dir_expr: str = DEFAULT_CVMFSEXEC_DIR_EXPR,
     ):
         self.mode = mode
         self.path = path
         self.repositories = repositories
-        self.cvmfsexec_dir_expr = cvmfsexec_dir_expr
 
 
 def parse(raw) -> Optional[CvmfsExecConfig]:
@@ -103,43 +97,45 @@ def parse(raw) -> Optional[CvmfsExecConfig]:
     if not repositories:
         raise ValueError("cvmfsexec configuration requires at least one repository")
 
-    cvmfsexec_dir_expr = raw.get("cvmfsexec_dir") or DEFAULT_CVMFSEXEC_DIR_EXPR
-
     return CvmfsExecConfig(
         mode=mode,
         path=path,
         repositories=repositories,
-        cvmfsexec_dir_expr=cvmfsexec_dir_expr,
     )
 
 
-def setup_commands(config: CvmfsExecConfig) -> List[str]:
+def setup_commands(config: CvmfsExecConfig, job_directory: str) -> List[str]:
     """Shell statements that prepare cvmfsexec before the job command runs.
 
     For ``mountrepo`` mode this reproduces the previously hand-maintained
-    destination ``env``/``execute`` block: locate ``CVMFSEXEC_DIR``, install the
-    cvmfsexec launcher, bootstrap the ``.cvmfsexec`` dist tree, register cleanup,
-    and mount each repository. ``namespace`` mode needs no preamble - the command
-    is wrapped instead (see :func:`wrap_command`).
+    destination ``env``/``execute`` block: install the cvmfsexec launcher into
+    the (absolute) per-job directory, bootstrap the ``.cvmfsexec`` dist tree,
+    register cleanup, and mount each repository. ``namespace`` mode needs no
+    preamble - the command is wrapped instead (see :func:`wrap_command`).
+
+    ``job_directory`` is the absolute job directory (Pulsar knows it at
+    job-script generation time), used directly instead of a ``$CVMFSEXEC_DIR``
+    shell variable so the mount location matches the ``__PULSAR_JOB_DIRECTORY__``
+    the client rewrites the container image path to.
 
     >>> c = parse({"path": "/opt/cvmfsexec", "repositories": ["singularity.galaxyproject.org"]})
-    >>> setup_commands(c)  # doctest: +NORMALIZE_WHITESPACE
-    ['export CVMFSEXEC_DIR="$(dirname "$_GALAXY_JOB_DIR")"',
-     'cp "/opt/cvmfsexec" "$CVMFSEXEC_DIR/cvmfsexec"',
-     '"$CVMFSEXEC_DIR/cvmfsexec" -v >/dev/null',
-     'trap "$CVMFSEXEC_DIR/.cvmfsexec/umountrepo -a" EXIT',
-     '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" singularity.galaxyproject.org']
+    >>> setup_commands(c, "/jobs/7")  # doctest: +NORMALIZE_WHITESPACE
+    ['cp "/opt/cvmfsexec" "/jobs/7/cvmfsexec"',
+     '"/jobs/7/cvmfsexec" -v >/dev/null',
+     'trap "/jobs/7/.cvmfsexec/umountrepo -a" EXIT',
+     '"/jobs/7/.cvmfsexec/mountrepo" singularity.galaxyproject.org']
     """
     if config.mode != MODE_MOUNTREPO:
         return []
+    launcher = "%s/cvmfsexec" % job_directory
+    dist = "%s/.cvmfsexec" % job_directory
     commands = [
-        'export CVMFSEXEC_DIR="%s"' % config.cvmfsexec_dir_expr,
-        'cp "%s" "$CVMFSEXEC_DIR/cvmfsexec"' % config.path,
-        '"$CVMFSEXEC_DIR/cvmfsexec" -v >/dev/null',
-        'trap "$CVMFSEXEC_DIR/.cvmfsexec/umountrepo -a" EXIT',
+        'cp "%s" "%s"' % (config.path, launcher),
+        '"%s" -v >/dev/null' % launcher,
+        'trap "%s/umountrepo -a" EXIT' % dist,
     ]
     for repository in config.repositories:
-        commands.append('"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" %s' % repository)
+        commands.append('"%s/mountrepo" %s' % (dist, repository))
     return commands
 
 

--- a/pulsar/managers/util/cvmfsexec.py
+++ b/pulsar/managers/util/cvmfsexec.py
@@ -104,14 +104,39 @@ def parse(raw) -> Optional[CvmfsExecConfig]:
     )
 
 
+# Shell state the job-script template sets but does not export, which the
+# namespace-mode wrap (a fresh ``/bin/bash -c``) would otherwise lose. The
+# ``TMP*`` vars are read by the ``singularity`` invocation (``SINGULARITYENV_*``
+# pass-through); the ``GALAXY_*`` vars and the ``_galaxy_setup_environment``
+# function are used by the in-job (remote) metadata segment. ``export -f`` is a
+# bash builtin (the wrap uses ``/bin/bash``).
+NAMESPACE_EXPORT_COMMANDS = [
+    "export TMP TEMP TMPDIR",
+    "export GALAXY_VIRTUAL_ENV _GALAXY_VIRTUAL_ENV GALAXY_LIB GALAXY_PYTHON",
+    "export -f _galaxy_setup_environment",
+]
+
+
+def _guarded(command: str, message: str) -> str:
+    """Abort the job script with ``message`` if ``command`` exits non-zero."""
+    return "%s || { echo %s >&2; exit 1; }" % (command, shlex.quote(message))
+
+
 def setup_commands(config: CvmfsExecConfig, job_directory: str) -> List[str]:
     """Shell statements that prepare cvmfsexec before the job command runs.
 
     For ``mountrepo`` mode this reproduces the previously hand-maintained
     destination ``env``/``execute`` block: install the cvmfsexec launcher into
-    the (absolute) per-job directory, bootstrap the ``.cvmfsexec`` dist tree,
-    register cleanup, and mount each repository. ``namespace`` mode needs no
-    preamble - the command is wrapped instead (see :func:`wrap_command`).
+    the (absolute) per-job directory, bootstrap the ``.cvmfsexec`` dist tree, and
+    mount each repository. Each step aborts the job script with a diagnostic on
+    failure rather than letting the job continue and die later on a missing image
+    path. The matching unmount is registered separately as an EXIT handler (see
+    :func:`add_exit_handlers`).
+
+    For ``namespace`` mode the command is wrapped instead (see
+    :func:`wrap_command`); the preamble only exports the shell state that wrap
+    would otherwise drop across the ``/bin/bash -c`` boundary
+    (:data:`NAMESPACE_EXPORT_COMMANDS`).
 
     ``job_directory`` is the absolute job directory (Pulsar knows it at
     job-script generation time), used directly instead of a ``$CVMFSEXEC_DIR``
@@ -120,23 +145,66 @@ def setup_commands(config: CvmfsExecConfig, job_directory: str) -> List[str]:
 
     >>> c = parse({"path": "/opt/cvmfsexec", "repositories": ["singularity.galaxyproject.org"]})
     >>> setup_commands(c, "/jobs/7")  # doctest: +NORMALIZE_WHITESPACE
-    ['cp "/opt/cvmfsexec" "/jobs/7/cvmfsexec"',
-     '"/jobs/7/cvmfsexec" -v >/dev/null',
-     'trap "/jobs/7/.cvmfsexec/umountrepo -a" EXIT',
-     '"/jobs/7/.cvmfsexec/mountrepo" singularity.galaxyproject.org']
+    ["cp /opt/cvmfsexec /jobs/7/cvmfsexec || { echo 'cvmfsexec: failed to install launcher' >&2; exit 1; }",
+     "/jobs/7/cvmfsexec -v >/dev/null || { echo 'cvmfsexec: failed to bootstrap dist tree' >&2; exit 1; }",
+     "/jobs/7/.cvmfsexec/mountrepo singularity.galaxyproject.org || { echo 'cvmfsexec: failed to mount singularity.galaxyproject.org' >&2; exit 1; }"]
+
+    >>> ns = parse({"mode": "namespace", "path": "/opt/cvmfsexec", "repositories": ["data.galaxyproject.org"]})
+    >>> setup_commands(ns, "/jobs/7")
+    ['export TMP TEMP TMPDIR', 'export GALAXY_VIRTUAL_ENV _GALAXY_VIRTUAL_ENV GALAXY_LIB GALAXY_PYTHON', 'export -f _galaxy_setup_environment']
     """
+    if config.mode == MODE_NAMESPACE:
+        return list(NAMESPACE_EXPORT_COMMANDS)
     if config.mode != MODE_MOUNTREPO:
         return []
     launcher = "%s/cvmfsexec" % job_directory
     dist = "%s/.cvmfsexec" % job_directory
+    mountrepo = "%s/mountrepo" % dist
     commands = [
-        'cp "%s" "%s"' % (config.path, launcher),
-        '"%s" -v >/dev/null' % launcher,
-        'trap "%s/umountrepo -a" EXIT' % dist,
+        _guarded(
+            "cp %s %s" % (shlex.quote(config.path), shlex.quote(launcher)),
+            "cvmfsexec: failed to install launcher",
+        ),
+        _guarded(
+            "%s -v >/dev/null" % shlex.quote(launcher),
+            "cvmfsexec: failed to bootstrap dist tree",
+        ),
     ]
     for repository in config.repositories:
-        commands.append('"%s/mountrepo" %s' % (dist, repository))
+        commands.append(
+            _guarded(
+                "%s %s" % (shlex.quote(mountrepo), shlex.quote(repository)),
+                "cvmfsexec: failed to mount %s" % repository,
+            )
+        )
     return commands
+
+
+def add_exit_handlers(exit_handlers, config: CvmfsExecConfig, job_directory: str) -> None:
+    """Add cvmfsexec cleanup to the job script's exit handlers.
+
+    For ``mountrepo`` mode this unmounts everything mounted by
+    :func:`setup_commands` when the job script exits. ``namespace`` mode needs no
+    cleanup (the mount namespace is torn down with the wrapped process).
+
+    ``exit_handlers`` is a ``pulsar.managers.util.job_script.ExitHandlers`` (the
+    generic collector); cvmfsexec only contributes to it rather than owning the
+    EXIT-handling machinery.
+
+    >>> from pulsar.managers.util.job_script import ExitHandlers
+    >>> handlers = ExitHandlers()
+    >>> c = parse({"path": "/opt/cvmfsexec", "repositories": ["singularity.galaxyproject.org"]})
+    >>> add_exit_handlers(handlers, c, "/jobs/7")
+    >>> handlers.commands
+    ['/jobs/7/.cvmfsexec/umountrepo -a']
+    >>> ns = parse({"mode": "namespace", "path": "/opt/cvmfsexec", "repositories": ["a"]})
+    >>> add_exit_handlers(handlers, ns, "/jobs/7")
+    >>> handlers.commands
+    ['/jobs/7/.cvmfsexec/umountrepo -a']
+    """
+    if config.mode != MODE_MOUNTREPO:
+        return
+    exit_handlers.add("%s -a" % shlex.quote("%s/.cvmfsexec/umountrepo" % job_directory))
 
 
 def wrap_command(config: CvmfsExecConfig, command: str) -> str:
@@ -146,16 +214,17 @@ def wrap_command(config: CvmfsExecConfig, command: str) -> str:
     ...`` so the real ``/cvmfs`` is available throughout. ``mountrepo`` mode
     returns the command unchanged (its repositories are mounted by the preamble).
 
-    Note: exported environment and the working directory are inherited by the
-    wrapped shell, but non-exported shell variables set earlier in the job
-    script are not visible inside it. Namespace mode should be validated on a
-    namespace-capable host before production use.
+    The shell state the wrapped command needs (``TMP*``, ``GALAXY_*``, and the
+    ``_galaxy_setup_environment`` function) is exported by the namespace-mode
+    preamble (:func:`setup_commands`) so it crosses into the wrapped shell.
+    Namespace mode should still be validated on a namespace-capable host before
+    production use.
 
     >>> c = parse({"mode": "namespace", "path": "/opt/cvmfsexec", "repositories": ["data.galaxyproject.org"]})
     >>> wrap_command(c, "run_tool --flag")
-    '"/opt/cvmfsexec" data.galaxyproject.org -- /bin/bash -c \\'run_tool --flag\\''
+    "/opt/cvmfsexec data.galaxyproject.org -- /bin/bash -c 'run_tool --flag'"
     """
     if config.mode != MODE_NAMESPACE:
         return command
-    repositories = " ".join(config.repositories)
-    return '"%s" %s -- /bin/bash -c %s' % (config.path, repositories, shlex.quote(command))
+    repositories = " ".join(shlex.quote(repository) for repository in config.repositories)
+    return "%s %s -- /bin/bash -c %s" % (shlex.quote(config.path), repositories, shlex.quote(command))

--- a/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -25,6 +25,10 @@ _galaxy_setup_environment() {
     fi
 }
 
+# Cleanup registered at job-script generation time collected into a single
+# _galaxy_on_exit function run from one EXIT trap.
+$exit_handler_setup
+
 $integrity_injection
 $slots_statement
 export PYTHONWARNINGS="ignore"

--- a/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/pulsar/managers/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -51,6 +51,7 @@ TMPDIR="${TMPDIR:-$_GALAXY_JOB_TMP_DIR}"
 
 GALAXY_PYTHON=`command -v python`
 $prepare_dirs_statement
+$cvmfsexec_setup
 cd $working_directory
 $memory_statement
 $instrument_pre_commands

--- a/pulsar/managers/util/job_script/__init__.py
+++ b/pulsar/managers/util/job_script/__init__.py
@@ -6,6 +6,7 @@ from string import Template
 from typing import (
     Any,
     Dict,
+    List,
 )
 
 from typing_extensions import Protocol
@@ -67,7 +68,59 @@ OPTIONAL_TEMPLATE_PARAMS: Dict[str, Any] = {
     "tmp_dir_creation_statement": '""',
     "prepare_dirs_statement": PREPARE_DIRS,
     "cvmfsexec_setup": "",
+    "exit_handler_setup": "",
 }
+
+
+def exit_handler_setup(commands: List[str]) -> str:
+    """Render an EXIT trap running each of ``commands`` when the job exits.
+
+    Cleanup that is known at job-script generation time is collected into a
+    single ``_galaxy_on_exit`` function driven by one ``trap`` rather than each
+    mechanism clobbering the single EXIT slot. Returns an empty string (no
+    function, no trap) when there is nothing to run.
+
+    >>> exit_handler_setup([])
+    ''
+    >>> print(exit_handler_setup(["/jobs/7/.cvmfsexec/umountrepo -a"]))
+    _galaxy_on_exit() {
+        /jobs/7/.cvmfsexec/umountrepo -a
+    }
+    trap _galaxy_on_exit EXIT
+    """
+    if not commands:
+        return ""
+    body = "\n".join("    %s" % command for command in commands)
+    return "_galaxy_on_exit() {\n%s\n}\ntrap _galaxy_on_exit EXIT" % body
+
+
+class ExitHandlers:
+    """Shell commands to run when the job script exits.
+
+    Job-setup mechanisms that need cleanup (e.g. cvmfsexec unmounting) ``add``
+    commands here; :meth:`render` collapses them into a single ``_galaxy_on_exit``
+    function driven by one ``trap`` (see :func:`exit_handler_setup`), suitable for
+    the template's ``$exit_handler_setup`` slot.
+
+    >>> handlers = ExitHandlers()
+    >>> handlers.render()
+    ''
+    >>> handlers.add("/jobs/7/.cvmfsexec/umountrepo -a")
+    >>> print(handlers.render())
+    _galaxy_on_exit() {
+        /jobs/7/.cvmfsexec/umountrepo -a
+    }
+    trap _galaxy_on_exit EXIT
+    """
+
+    def __init__(self) -> None:
+        self.commands: List[str] = []
+
+    def add(self, command: str) -> None:
+        self.commands.append(command)
+
+    def render(self) -> str:
+        return exit_handler_setup(self.commands)
 
 
 def job_script(template=DEFAULT_JOB_FILE_TEMPLATE, **kwds):

--- a/pulsar/managers/util/job_script/__init__.py
+++ b/pulsar/managers/util/job_script/__init__.py
@@ -66,6 +66,7 @@ OPTIONAL_TEMPLATE_PARAMS: Dict[str, Any] = {
     "preserve_python_environment": True,
     "tmp_dir_creation_statement": '""',
     "prepare_dirs_statement": PREPARE_DIRS,
+    "cvmfsexec_setup": "",
 }
 
 

--- a/pulsar/web/routes.py
+++ b/pulsar/web/routes.py
@@ -62,7 +62,7 @@ def clean(manager, job_id):
 
 @PulsarController(path="/jobs/{job_id}/submit", method="POST")
 def submit(manager, job_id, command_line, params='{}', dependencies_description='null', setup_params='{}',
-           remote_staging='{}', env='[]', submit_extras='{}', dynamic_file_sources='null'):
+           remote_staging='{}', env='[]', submit_extras='{}', dynamic_file_sources='null', cvmfsexec='null'):
     submit_params = loads(params)
     setup_params = loads(setup_params)
     dependencies_description = loads(dependencies_description)
@@ -70,6 +70,7 @@ def submit(manager, job_id, command_line, params='{}', dependencies_description=
     remote_staging = loads(remote_staging)
     submit_extras = loads(submit_extras)
     dynamic_file_sources = loads(dynamic_file_sources)
+    cvmfsexec = loads(cvmfsexec)
     submit_config = dict(
         job_id=job_id,
         command_line=command_line,
@@ -79,6 +80,7 @@ def submit(manager, job_id, command_line, params='{}', dependencies_description=
         env=env,
         remote_staging=remote_staging,
         dynamic_file_sources=dynamic_file_sources,
+        cvmfsexec=cvmfsexec,
     )
     submit_config.update(submit_extras)
     submit_job(manager, submit_config)

--- a/test/cvmfsexec_test.py
+++ b/test/cvmfsexec_test.py
@@ -39,12 +39,14 @@ def test_setup_commands_mountrepo():
         "path": "/opt/cvmfsexec",
         "repositories": ["data.galaxyproject.org", "singularity.galaxyproject.org"],
     })
-    commands = cvmfsexec.setup_commands(config)
-    assert commands[0] == 'export CVMFSEXEC_DIR="$(dirname "$_GALAXY_JOB_DIR")"'
-    assert 'cp "/opt/cvmfsexec" "$CVMFSEXEC_DIR/cvmfsexec"' in commands
-    assert 'trap "$CVMFSEXEC_DIR/.cvmfsexec/umountrepo -a" EXIT' in commands
-    assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" data.galaxyproject.org' in commands
-    assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in commands
+    commands = cvmfsexec.setup_commands(config, "/jobs/7")
+    # Absolute job directory used directly (no $CVMFSEXEC_DIR shell variable).
+    assert commands[0] == 'cp "/opt/cvmfsexec" "/jobs/7/cvmfsexec"'
+    assert '"/jobs/7/cvmfsexec" -v >/dev/null' in commands
+    assert 'trap "/jobs/7/.cvmfsexec/umountrepo -a" EXIT' in commands
+    assert '"/jobs/7/.cvmfsexec/mountrepo" data.galaxyproject.org' in commands
+    assert '"/jobs/7/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in commands
+    assert not any("CVMFSEXEC_DIR" in c for c in commands)
 
 
 def test_setup_commands_namespace_is_empty():
@@ -53,7 +55,7 @@ def test_setup_commands_namespace_is_empty():
         "path": "/opt/cvmfsexec",
         "repositories": ["data.galaxyproject.org"],
     })
-    assert cvmfsexec.setup_commands(config) == []
+    assert cvmfsexec.setup_commands(config, "/jobs/7") == []
 
 
 def test_wrap_command_namespace():

--- a/test/cvmfsexec_test.py
+++ b/test/cvmfsexec_test.py
@@ -9,24 +9,14 @@ def test_parse_none_disabled():
     assert cvmfsexec.parse({}) is None
 
 
-def test_parse_defaults_and_image_repository_inference():
+def test_parse_defaults():
     config = cvmfsexec.parse({
         "path": "/opt/cvmfsexec",
         "repositories": ["data.galaxyproject.org", "singularity.galaxyproject.org"],
     })
     assert config.mode == cvmfsexec.MODE_MOUNTREPO
     assert config.path == "/opt/cvmfsexec"
-    # Only repos prefixed "singularity" are treated as host-side image repos.
-    assert config.image_repositories == ["singularity.galaxyproject.org"]
-
-
-def test_parse_explicit_image_repositories():
-    config = cvmfsexec.parse({
-        "path": "/opt/cvmfsexec",
-        "repositories": ["a.example.org", "b.example.org"],
-        "image_repositories": ["b.example.org"],
-    })
-    assert config.image_repositories == ["b.example.org"]
+    assert config.repositories == ["data.galaxyproject.org", "singularity.galaxyproject.org"]
 
 
 def test_parse_requires_path():
@@ -64,36 +54,6 @@ def test_setup_commands_namespace_is_empty():
         "repositories": ["data.galaxyproject.org"],
     })
     assert cvmfsexec.setup_commands(config) == []
-
-
-def test_rewrite_command_only_touches_image_repositories():
-    config = cvmfsexec.parse({
-        "path": "/opt/cvmfsexec",
-        "repositories": ["singularity.galaxyproject.org", "data.galaxyproject.org"],
-    })
-    command = (
-        "singularity exec -B $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs:/cvmfs "
-        "/cvmfs/singularity.galaxyproject.org/all/img "
-        "tool --ref /cvmfs/data.galaxyproject.org/genome.fa"
-    )
-    rewritten = cvmfsexec.rewrite_command(config, command)
-    # Host-side image path is rewritten to the dist location...
-    assert "exec -B $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs:/cvmfs " \
-           "$CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/singularity.galaxyproject.org/all/img" in rewritten
-    assert "exec -B $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs:/cvmfs /cvmfs/singularity" not in rewritten
-    # ...but the in-container reference-data path (resolved via the bind mount)
-    # is left untouched.
-    assert "/cvmfs/data.galaxyproject.org/genome.fa" in rewritten
-
-
-def test_rewrite_command_namespace_is_noop():
-    config = cvmfsexec.parse({
-        "mode": "namespace",
-        "path": "/opt/cvmfsexec",
-        "repositories": ["singularity.galaxyproject.org"],
-    })
-    command = "singularity exec /cvmfs/singularity.galaxyproject.org/all/img sh"
-    assert cvmfsexec.rewrite_command(config, command) == command
 
 
 def test_wrap_command_namespace():

--- a/test/cvmfsexec_test.py
+++ b/test/cvmfsexec_test.py
@@ -41,21 +41,71 @@ def test_setup_commands_mountrepo():
     })
     commands = cvmfsexec.setup_commands(config, "/jobs/7")
     # Absolute job directory used directly (no $CVMFSEXEC_DIR shell variable).
-    assert commands[0] == 'cp "/opt/cvmfsexec" "/jobs/7/cvmfsexec"'
-    assert '"/jobs/7/cvmfsexec" -v >/dev/null' in commands
-    assert 'trap "/jobs/7/.cvmfsexec/umountrepo -a" EXIT' in commands
-    assert '"/jobs/7/.cvmfsexec/mountrepo" data.galaxyproject.org' in commands
-    assert '"/jobs/7/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in commands
+    assert commands[0].startswith("cp /opt/cvmfsexec /jobs/7/cvmfsexec ")
+    assert any(c.startswith("/jobs/7/cvmfsexec -v >/dev/null ") for c in commands)
+    # Unmount cleanup is an EXIT handler (exit_handler_commands), not part of the
+    # setup preamble, and nothing here claims the trap slot directly.
+    assert not any("umountrepo" in c for c in commands)
+    assert not any(c.startswith("trap ") for c in commands)
+    # Each mount aborts the job with a diagnostic on failure (point 4).
+    assert (
+        "/jobs/7/.cvmfsexec/mountrepo data.galaxyproject.org "
+        "|| { echo 'cvmfsexec: failed to mount data.galaxyproject.org' >&2; exit 1; }"
+    ) in commands
+    assert any(c.startswith("/jobs/7/.cvmfsexec/mountrepo singularity.galaxyproject.org ") for c in commands)
     assert not any("CVMFSEXEC_DIR" in c for c in commands)
 
 
-def test_setup_commands_namespace_is_empty():
+def test_add_exit_handlers_mountrepo_unmounts():
+    from pulsar.managers.util.job_script import ExitHandlers
+    handlers = ExitHandlers()
+    config = cvmfsexec.parse({
+        "path": "/opt/cvmfsexec",
+        "repositories": ["data.galaxyproject.org", "singularity.galaxyproject.org"],
+    })
+    cvmfsexec.add_exit_handlers(handlers, config, "/jobs/7")
+    # cvmfsexec only contributes to the generic ExitHandlers collector.
+    assert handlers.commands == ["/jobs/7/.cvmfsexec/umountrepo -a"]
+
+
+def test_add_exit_handlers_namespace_is_noop():
+    from pulsar.managers.util.job_script import ExitHandlers
+    handlers = ExitHandlers()
     config = cvmfsexec.parse({
         "mode": "namespace",
         "path": "/opt/cvmfsexec",
         "repositories": ["data.galaxyproject.org"],
     })
-    assert cvmfsexec.setup_commands(config, "/jobs/7") == []
+    cvmfsexec.add_exit_handlers(handlers, config, "/jobs/7")
+    assert handlers.commands == []
+
+
+def test_setup_commands_quotes_shell_metacharacters():
+    # A per-job override arrives over the wire; a repository (or path) carrying
+    # shell metacharacters must be quoted, never interpolated raw.
+    config = cvmfsexec.parse({
+        "path": "/opt/cvmfsexec",
+        "repositories": ["$(touch pwned)"],
+    })
+    commands = cvmfsexec.setup_commands(config, "/jobs/7")
+    mount = next(c for c in commands if c.startswith("/jobs/7/.cvmfsexec/mountrepo "))
+    assert mount.startswith("/jobs/7/.cvmfsexec/mountrepo '$(touch pwned)'")
+
+
+def test_setup_commands_namespace_exports_env():
+    config = cvmfsexec.parse({
+        "mode": "namespace",
+        "path": "/opt/cvmfsexec",
+        "repositories": ["data.galaxyproject.org"],
+    })
+    # Namespace mode wraps the command in a fresh `bash -c`; the preamble exports
+    # the shell state (tmp dirs, Galaxy env, and the setup function) that would
+    # otherwise not cross the boundary.
+    assert cvmfsexec.setup_commands(config, "/jobs/7") == [
+        "export TMP TEMP TMPDIR",
+        "export GALAXY_VIRTUAL_ENV _GALAXY_VIRTUAL_ENV GALAXY_LIB GALAXY_PYTHON",
+        "export -f _galaxy_setup_environment",
+    ]
 
 
 def test_wrap_command_namespace():
@@ -66,7 +116,7 @@ def test_wrap_command_namespace():
     })
     wrapped = cvmfsexec.wrap_command(config, "run_tool --flag")
     assert wrapped == (
-        '"/opt/cvmfsexec" data.galaxyproject.org singularity.galaxyproject.org '
+        "/opt/cvmfsexec data.galaxyproject.org singularity.galaxyproject.org "
         "-- /bin/bash -c 'run_tool --flag'"
     )
 

--- a/test/cvmfsexec_test.py
+++ b/test/cvmfsexec_test.py
@@ -1,0 +1,117 @@
+"""Unit tests for the cvmfsexec job-script helper (pulsar.managers.util.cvmfsexec)."""
+import pytest
+
+from pulsar.managers.util import cvmfsexec
+
+
+def test_parse_none_disabled():
+    assert cvmfsexec.parse(None) is None
+    assert cvmfsexec.parse({}) is None
+
+
+def test_parse_defaults_and_image_repository_inference():
+    config = cvmfsexec.parse({
+        "path": "/opt/cvmfsexec",
+        "repositories": ["data.galaxyproject.org", "singularity.galaxyproject.org"],
+    })
+    assert config.mode == cvmfsexec.MODE_MOUNTREPO
+    assert config.path == "/opt/cvmfsexec"
+    # Only repos prefixed "singularity" are treated as host-side image repos.
+    assert config.image_repositories == ["singularity.galaxyproject.org"]
+
+
+def test_parse_explicit_image_repositories():
+    config = cvmfsexec.parse({
+        "path": "/opt/cvmfsexec",
+        "repositories": ["a.example.org", "b.example.org"],
+        "image_repositories": ["b.example.org"],
+    })
+    assert config.image_repositories == ["b.example.org"]
+
+
+def test_parse_requires_path():
+    with pytest.raises(ValueError):
+        cvmfsexec.parse({"repositories": ["a"]})
+
+
+def test_parse_requires_repositories():
+    with pytest.raises(ValueError):
+        cvmfsexec.parse({"path": "/opt/cvmfsexec"})
+
+
+def test_parse_rejects_invalid_mode():
+    with pytest.raises(ValueError):
+        cvmfsexec.parse({"mode": "bogus", "path": "/x", "repositories": ["a"]})
+
+
+def test_setup_commands_mountrepo():
+    config = cvmfsexec.parse({
+        "path": "/opt/cvmfsexec",
+        "repositories": ["data.galaxyproject.org", "singularity.galaxyproject.org"],
+    })
+    commands = cvmfsexec.setup_commands(config)
+    assert commands[0] == 'export CVMFSEXEC_DIR="$(dirname "$_GALAXY_JOB_DIR")"'
+    assert 'cp "/opt/cvmfsexec" "$CVMFSEXEC_DIR/cvmfsexec"' in commands
+    assert 'trap "$CVMFSEXEC_DIR/.cvmfsexec/umountrepo -a" EXIT' in commands
+    assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" data.galaxyproject.org' in commands
+    assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in commands
+
+
+def test_setup_commands_namespace_is_empty():
+    config = cvmfsexec.parse({
+        "mode": "namespace",
+        "path": "/opt/cvmfsexec",
+        "repositories": ["data.galaxyproject.org"],
+    })
+    assert cvmfsexec.setup_commands(config) == []
+
+
+def test_rewrite_command_only_touches_image_repositories():
+    config = cvmfsexec.parse({
+        "path": "/opt/cvmfsexec",
+        "repositories": ["singularity.galaxyproject.org", "data.galaxyproject.org"],
+    })
+    command = (
+        "singularity exec -B $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs:/cvmfs "
+        "/cvmfs/singularity.galaxyproject.org/all/img "
+        "tool --ref /cvmfs/data.galaxyproject.org/genome.fa"
+    )
+    rewritten = cvmfsexec.rewrite_command(config, command)
+    # Host-side image path is rewritten to the dist location...
+    assert "exec -B $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs:/cvmfs " \
+           "$CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/singularity.galaxyproject.org/all/img" in rewritten
+    assert "exec -B $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs:/cvmfs /cvmfs/singularity" not in rewritten
+    # ...but the in-container reference-data path (resolved via the bind mount)
+    # is left untouched.
+    assert "/cvmfs/data.galaxyproject.org/genome.fa" in rewritten
+
+
+def test_rewrite_command_namespace_is_noop():
+    config = cvmfsexec.parse({
+        "mode": "namespace",
+        "path": "/opt/cvmfsexec",
+        "repositories": ["singularity.galaxyproject.org"],
+    })
+    command = "singularity exec /cvmfs/singularity.galaxyproject.org/all/img sh"
+    assert cvmfsexec.rewrite_command(config, command) == command
+
+
+def test_wrap_command_namespace():
+    config = cvmfsexec.parse({
+        "mode": "namespace",
+        "path": "/opt/cvmfsexec",
+        "repositories": ["data.galaxyproject.org", "singularity.galaxyproject.org"],
+    })
+    wrapped = cvmfsexec.wrap_command(config, "run_tool --flag")
+    assert wrapped == (
+        '"/opt/cvmfsexec" data.galaxyproject.org singularity.galaxyproject.org '
+        "-- /bin/bash -c 'run_tool --flag'"
+    )
+
+
+def test_wrap_command_mountrepo_is_noop():
+    config = cvmfsexec.parse({
+        "path": "/opt/cvmfsexec",
+        "repositories": ["singularity.galaxyproject.org"],
+    })
+    assert cvmfsexec.wrap_command(config, "run_tool") == "run_tool"

--- a/test/manager_cvmfsexec_test.py
+++ b/test/manager_cvmfsexec_test.py
@@ -36,17 +36,16 @@ class CvmfsExecManagerTest(BaseManagerTestCase):
         assert "mountrepo" not in contents
         assert "/cvmfs/singularity.galaxyproject.org/all/img" in contents
 
-    def test_mountrepo_preamble_and_image_rewrite(self):
+    def test_mountrepo_preamble(self):
         contents = self._script_for(SINGULARITY_COMMAND, manager_kwds={"cvmfsexec": MOUNTREPO_CONFIG})
         # Mount preamble generated for every repository.
         assert 'export CVMFSEXEC_DIR="$(dirname "$_GALAXY_JOB_DIR")"' in contents
         assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" data.galaxyproject.org' in contents
         assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in contents
-        # Host-side container image path rewritten to the dist location...
-        assert "exec $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/singularity.galaxyproject.org/all/img" in contents
-        assert "exec /cvmfs/singularity.galaxyproject.org/all/img" not in contents
-        # ...reference-data path (resolved inside the container) left untouched.
-        assert "/cvmfs/data.galaxyproject.org/genome.fa" in contents
+        # The container image path is NOT rewritten here - in mountrepo mode that
+        # is a Galaxy file_actions rewrite rule. The command passes through as-is.
+        assert SINGULARITY_COMMAND in contents
+        assert ".cvmfsexec/dist/cvmfs/singularity" not in contents
         # Preamble is injected into the template (after dir prep, before cd), not
         # via the env setup mechanism.
         assert contents.index("export CVMFSEXEC_DIR=") < contents.index("\ncd ")
@@ -64,4 +63,4 @@ class CvmfsExecManagerTest(BaseManagerTestCase):
         # Override install path used; the manager-default data repo is not mounted.
         assert 'cp "/scratch/cvmfsexec" "$CVMFSEXEC_DIR/cvmfsexec"' in contents
         assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" data.galaxyproject.org' not in contents
-        assert "exec $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/singularity.galaxyproject.org/all/img" in contents
+        assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in contents

--- a/test/manager_cvmfsexec_test.py
+++ b/test/manager_cvmfsexec_test.py
@@ -21,46 +21,48 @@ SINGULARITY_COMMAND = (
 class CvmfsExecManagerTest(BaseManagerTestCase):
 
     def _script_for(self, command, manager_kwds=None, setup_params=None):
+        """Return (script_contents, absolute_job_directory)."""
         manager = Manager("_default_", self.app, **(manager_kwds or {}))
         job_id = manager.setup_job("300", "tool1", "1.0.0")
+        job_dir = manager.job_directory(job_id).job_directory
         try:
             script_path = manager._setup_job_file(job_id, command, setup_params=setup_params)
             with open(script_path) as fh:
-                return fh.read()
+                return fh.read(), job_dir
         finally:
             manager.clean(job_id)
 
     def test_disabled_by_default_is_noop(self):
-        contents = self._script_for(SINGULARITY_COMMAND)
-        assert "CVMFSEXEC_DIR" not in contents
+        contents, _ = self._script_for(SINGULARITY_COMMAND)
+        assert "cvmfsexec" not in contents
         assert "mountrepo" not in contents
         assert "/cvmfs/singularity.galaxyproject.org/all/img" in contents
 
     def test_mountrepo_preamble(self):
-        contents = self._script_for(SINGULARITY_COMMAND, manager_kwds={"cvmfsexec": MOUNTREPO_CONFIG})
-        # Mount preamble generated for every repository.
-        assert 'export CVMFSEXEC_DIR="$(dirname "$_GALAXY_JOB_DIR")"' in contents
-        assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" data.galaxyproject.org' in contents
-        assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in contents
+        contents, job_dir = self._script_for(SINGULARITY_COMMAND, manager_kwds={"cvmfsexec": MOUNTREPO_CONFIG})
+        # Mount preamble uses the absolute job directory (no $CVMFSEXEC_DIR).
+        assert f'cp "/opt/cvmfsexec" "{job_dir}/cvmfsexec"' in contents
+        assert f'"{job_dir}/.cvmfsexec/mountrepo" data.galaxyproject.org' in contents
+        assert f'"{job_dir}/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in contents
+        assert "CVMFSEXEC_DIR" not in contents
         # The container image path is NOT rewritten here - in mountrepo mode that
         # is a Galaxy file_actions rewrite rule. The command passes through as-is.
         assert SINGULARITY_COMMAND in contents
         assert ".cvmfsexec/dist/cvmfs/singularity" not in contents
-        # Preamble is injected into the template (after dir prep, before cd), not
-        # via the env setup mechanism.
-        assert contents.index("export CVMFSEXEC_DIR=") < contents.index("\ncd ")
+        # Preamble is injected into the template (after dir prep, before cd).
+        assert contents.index('cp "/opt/cvmfsexec"') < contents.index("\ncd ")
 
     def test_setup_params_override_takes_precedence(self):
         override = {
             "path": "/scratch/cvmfsexec",
             "repositories": ["singularity.galaxyproject.org"],
         }
-        contents = self._script_for(
+        contents, job_dir = self._script_for(
             SINGULARITY_COMMAND,
             manager_kwds={"cvmfsexec": MOUNTREPO_CONFIG},
             setup_params={"cvmfsexec": override},
         )
         # Override install path used; the manager-default data repo is not mounted.
-        assert 'cp "/scratch/cvmfsexec" "$CVMFSEXEC_DIR/cvmfsexec"' in contents
-        assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" data.galaxyproject.org' not in contents
-        assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in contents
+        assert f'cp "/scratch/cvmfsexec" "{job_dir}/cvmfsexec"' in contents
+        assert f'"{job_dir}/.cvmfsexec/mountrepo" data.galaxyproject.org' not in contents
+        assert f'"{job_dir}/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in contents

--- a/test/manager_cvmfsexec_test.py
+++ b/test/manager_cvmfsexec_test.py
@@ -12,6 +12,11 @@ MOUNTREPO_CONFIG = {
     "path": "/opt/cvmfsexec",
     "repositories": ["data.galaxyproject.org", "singularity.galaxyproject.org"],
 }
+NAMESPACE_CONFIG = {
+    "mode": "namespace",
+    "path": "/opt/cvmfsexec",
+    "repositories": ["data.galaxyproject.org", "singularity.galaxyproject.org"],
+}
 SINGULARITY_COMMAND = (
     "singularity exec /cvmfs/singularity.galaxyproject.org/all/img "
     "tool --ref /cvmfs/data.galaxyproject.org/genome.fa"
@@ -34,23 +39,45 @@ class CvmfsExecManagerTest(BaseManagerTestCase):
 
     def test_disabled_by_default_is_noop(self):
         contents, _ = self._script_for(SINGULARITY_COMMAND)
-        assert "cvmfsexec" not in contents
-        assert "mountrepo" not in contents
+        # No cvmfsexec machinery, no EXIT handler, and no wrap when unconfigured.
+        assert "mountrepo" not in contents  # also covers umountrepo
+        assert "_galaxy_on_exit() {" not in contents  # no EXIT handler defined
+        assert "trap _galaxy_on_exit EXIT" not in contents  # no EXIT trap set
+        assert "-- /bin/bash -c" not in contents  # no namespace wrap
+        assert "/opt/cvmfsexec" not in contents  # no configured install copied
         assert "/cvmfs/singularity.galaxyproject.org/all/img" in contents
 
     def test_mountrepo_preamble(self):
         contents, job_dir = self._script_for(SINGULARITY_COMMAND, manager_kwds={"cvmfsexec": MOUNTREPO_CONFIG})
         # Mount preamble uses the absolute job directory (no $CVMFSEXEC_DIR).
-        assert f'cp "/opt/cvmfsexec" "{job_dir}/cvmfsexec"' in contents
-        assert f'"{job_dir}/.cvmfsexec/mountrepo" data.galaxyproject.org' in contents
-        assert f'"{job_dir}/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in contents
+        assert f"cp /opt/cvmfsexec {job_dir}/cvmfsexec" in contents
+        assert f"{job_dir}/.cvmfsexec/mountrepo data.galaxyproject.org" in contents
+        assert f"{job_dir}/.cvmfsexec/mountrepo singularity.galaxyproject.org" in contents
         assert "CVMFSEXEC_DIR" not in contents
+        # Unmount runs from the single generation-time EXIT handler.
+        assert "_galaxy_on_exit() {" in contents
+        assert f"{job_dir}/.cvmfsexec/umountrepo -a" in contents
+        assert "trap _galaxy_on_exit EXIT" in contents
+        # Mounts abort the job with a diagnostic on failure.
+        assert "|| { echo 'cvmfsexec: failed to mount data.galaxyproject.org' >&2; exit 1; }" in contents
         # The container image path is NOT rewritten here - in mountrepo mode that
         # is a Galaxy file_actions rewrite rule. The command passes through as-is.
         assert SINGULARITY_COMMAND in contents
         assert ".cvmfsexec/dist/cvmfs/singularity" not in contents
         # Preamble is injected into the template (after dir prep, before cd).
-        assert contents.index('cp "/opt/cvmfsexec"') < contents.index("\ncd ")
+        assert contents.index("cp /opt/cvmfsexec") < contents.index("\ncd ")
+
+    def test_namespace_exports_and_wraps(self):
+        contents, _ = self._script_for(SINGULARITY_COMMAND, manager_kwds={"cvmfsexec": NAMESPACE_CONFIG})
+        # Namespace preamble exports the shell state the wrap would otherwise drop.
+        assert "export TMP TEMP TMPDIR" in contents
+        assert "export -f _galaxy_setup_environment" in contents
+        # The whole job command is wrapped to run under cvmfsexec.
+        assert (
+            "/opt/cvmfsexec data.galaxyproject.org singularity.galaxyproject.org -- /bin/bash -c '"
+        ) in contents
+        # No bind-mount preamble in namespace mode.
+        assert "mountrepo" not in contents
 
     def test_setup_params_override_takes_precedence(self):
         override = {
@@ -63,6 +90,6 @@ class CvmfsExecManagerTest(BaseManagerTestCase):
             setup_params={"cvmfsexec": override},
         )
         # Override install path used; the manager-default data repo is not mounted.
-        assert f'cp "/scratch/cvmfsexec" "{job_dir}/cvmfsexec"' in contents
-        assert f'"{job_dir}/.cvmfsexec/mountrepo" data.galaxyproject.org' not in contents
-        assert f'"{job_dir}/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in contents
+        assert f"cp /scratch/cvmfsexec {job_dir}/cvmfsexec" in contents
+        assert f"{job_dir}/.cvmfsexec/mountrepo data.galaxyproject.org" not in contents
+        assert f"{job_dir}/.cvmfsexec/mountrepo singularity.galaxyproject.org" in contents

--- a/test/manager_cvmfsexec_test.py
+++ b/test/manager_cvmfsexec_test.py
@@ -1,0 +1,67 @@
+"""Manager-level tests for cvmfsexec integration.
+
+Exercises job-script generation (``_setup_job_file``) directly rather than
+launching jobs, so the assertions are deterministic and do not depend on the
+execution environment.
+"""
+from pulsar.managers.unqueued import Manager
+
+from .test_utils import BaseManagerTestCase
+
+MOUNTREPO_CONFIG = {
+    "path": "/opt/cvmfsexec",
+    "repositories": ["data.galaxyproject.org", "singularity.galaxyproject.org"],
+}
+SINGULARITY_COMMAND = (
+    "singularity exec /cvmfs/singularity.galaxyproject.org/all/img "
+    "tool --ref /cvmfs/data.galaxyproject.org/genome.fa"
+)
+
+
+class CvmfsExecManagerTest(BaseManagerTestCase):
+
+    def _script_for(self, command, manager_kwds=None, setup_params=None):
+        manager = Manager("_default_", self.app, **(manager_kwds or {}))
+        job_id = manager.setup_job("300", "tool1", "1.0.0")
+        try:
+            script_path = manager._setup_job_file(job_id, command, setup_params=setup_params)
+            with open(script_path) as fh:
+                return fh.read()
+        finally:
+            manager.clean(job_id)
+
+    def test_disabled_by_default_is_noop(self):
+        contents = self._script_for(SINGULARITY_COMMAND)
+        assert "CVMFSEXEC_DIR" not in contents
+        assert "mountrepo" not in contents
+        assert "/cvmfs/singularity.galaxyproject.org/all/img" in contents
+
+    def test_mountrepo_preamble_and_image_rewrite(self):
+        contents = self._script_for(SINGULARITY_COMMAND, manager_kwds={"cvmfsexec": MOUNTREPO_CONFIG})
+        # Mount preamble generated for every repository.
+        assert 'export CVMFSEXEC_DIR="$(dirname "$_GALAXY_JOB_DIR")"' in contents
+        assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" data.galaxyproject.org' in contents
+        assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" singularity.galaxyproject.org' in contents
+        # Host-side container image path rewritten to the dist location...
+        assert "exec $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/singularity.galaxyproject.org/all/img" in contents
+        assert "exec /cvmfs/singularity.galaxyproject.org/all/img" not in contents
+        # ...reference-data path (resolved inside the container) left untouched.
+        assert "/cvmfs/data.galaxyproject.org/genome.fa" in contents
+        # Preamble is injected into the template (after dir prep, before cd), not
+        # via the env setup mechanism.
+        assert contents.index("export CVMFSEXEC_DIR=") < contents.index("\ncd ")
+
+    def test_setup_params_override_takes_precedence(self):
+        override = {
+            "path": "/scratch/cvmfsexec",
+            "repositories": ["singularity.galaxyproject.org"],
+        }
+        contents = self._script_for(
+            SINGULARITY_COMMAND,
+            manager_kwds={"cvmfsexec": MOUNTREPO_CONFIG},
+            setup_params={"cvmfsexec": override},
+        )
+        # Override install path used; the manager-default data repo is not mounted.
+        assert 'cp "/scratch/cvmfsexec" "$CVMFSEXEC_DIR/cvmfsexec"' in contents
+        assert '"$CVMFSEXEC_DIR/.cvmfsexec/mountrepo" data.galaxyproject.org' not in contents
+        assert "exec $CVMFSEXEC_DIR/.cvmfsexec/dist/cvmfs/singularity.galaxyproject.org/all/img" in contents

--- a/test/path_mapper_test.py
+++ b/test/path_mapper_test.py
@@ -45,6 +45,29 @@ class PathMapperTestCase(TempDirectoryTestCase):
         new_path = path_mapper.remote_version_path_rewrite(local_path)
         assert new_path == "/scratch/staging/1/outputs/COMMAND_VERSION"
 
+    def test_container_rewrite_applies_rewrite_action(self):
+        action = Bunch(staging_needed=False, action_type="rewrite", path_rewrite=lambda helper: "/dist/cvmfs/img")
+        path_mapper = self._container_path_mapper(action)
+        assert path_mapper.check_for_container_rewrite("/cvmfs/img") == "/dist/cvmfs/img"
+
+    def test_container_rewrite_warns_and_skips_staging_action(self):
+        # A staging action matched for a container image (e.g. a broad "*any*"
+        # rule) is a misconfiguration: warn and leave the path untouched.
+        action = Bunch(staging_needed=True, action_type="remote_transfer")
+        path_mapper = self._container_path_mapper(action)
+        with self.assertLogs("pulsar.client.path_mapper", level="WARNING") as captured:
+            assert path_mapper.check_for_container_rewrite("/cvmfs/img") is None
+        assert any("container image path" in message for message in captured.output)
+
+    def _container_path_mapper(self, action):
+        path_mapper = PathMapper(
+            client=None,
+            remote_job_config=self.__test_remote_config(),
+            local_working_directory=self.temp_directory,
+            action_mapper=_ContainerActionMapper(action),
+        )
+        return path_mapper
+
     def _path_mapper(self, expected_path, expected_type, staging_needed=True):
         action_mapper = TestActionMapper(expected_path, expected_type, staging_needed)
         path_mapper = PathMapper(
@@ -78,4 +101,15 @@ class TestActionMapper:
     def action(self, source, type):
         assert self.expected_path == source["path"]
         assert self.expected_type == type
+        return self._action
+
+
+class _ContainerActionMapper:
+    """Returns a fixed action for CONTAINER lookups (container-rewrite tests)."""
+
+    def __init__(self, action):
+        self._action = action
+
+    def action(self, source, type):
+        assert type == path_type.CONTAINER
         return self._action


### PR DESCRIPTION
Adds first-class support for running jobs under [cvmfsexec](https://github.com/cvmfs/cvmfsexec), so Singularity/Apptainer containers (and Galaxy reference data) hosted on CVMFS can be used on compute nodes that cannot mount `/cvmfs` system-wide, without root or special privileges. I've already been using this with great effect by hacking `env` `execute` statements in job destinations, but this is much better, plus it documents it and doesn't need a dirty hack for rewriting the container path when `mountrepo` mode is required.

## How it works

A `cvmfsexec` option on the job manager (`app.yml`), overridable per Galaxy destination:

```yaml
managers:
  _default_:
    type: queued_drmaa
    cvmfsexec:
      mode: mountrepo        # or "namespace"
      path: /path/to/cvmfsexec
      repositories:
        - data.galaxyproject.org
        - singularity.galaxyproject.org
```

Two modes:

- **namespace** (preferred): cvmfsexec provides a real `/cvmfs` inside a mount namespace and the job runs inside it. No path rewriting needed.
- **mountrepo**: for nodes without unprivileged user namespaces / fuse, repositories are bind-mounted under `<job_directory>/.cvmfsexec/dist/cvmfs`. The container image path (resolved by Galaxy against the real `/cvmfs`) is rewritten to the mounted location via an ordinary Galaxy `file_actions` `rewrite` rule.

The mount preamble is injected into the job script template (after dir prep); namespace mode wraps the command.

## Dependent Galaxy PR

mountrepo mode's image-path rewrite depends on a companion Galaxy change (https://github.com/galaxyproject/galaxy/pull/23129) that routes the resolved container image path through the compute environment's `unstructured_path_rewrite` (so a `file_actions` `rewrite` rule applies to it, the same way it applies to tool parameters).

## Docs & tests

- New Containers "Overview" and "Singularity / Apptainer and CVMFS" sections (cvmfsexec modes, building the self-contained distribution, the `galaxyproject.cvmfsexec` role, a usegalaxy.org example), plus the mountrepo rewrite example in the Galaxy Configuration docs.
- Unit and manager tests for config parsing, mount-preamble generation, namespace command wrapping, and the per-job `setup_params` override.