### PR TITLE
Fix --daemon flag being silently dropped in webless mode

### DIFF
--- a/scripts/pulsar
+++ b/scripts/pulsar
@@ -137,13 +137,6 @@ elif [ "$MODE" == "paster" ]; then
     echo "Starting pulsar with command [pulsar-serve \"$PULSAR_CONFIG_FILE\" \"$@\"]"
     pulsar-serve "$PULSAR_CONFIG_FILE" "$@"
 elif [ "$MODE" == "webless" ]; then
-    # Unlike the other modes above, this branch used to ignore "$@"
-    # entirely, so flags such as --daemon were silently dropped and Pulsar
-    # ran attached to the caller's terminal instead of backgrounding itself.
-    # pulsar-main also does not share pulsar-serve's flag names: it exposes
-    # -d/--daemonize (not --daemon) and has no --stop-daemon support at all,
-    # so translate/validate before forwarding rather than passing "$@"
-    # through unchanged.
     WEBLESS_ARGS=()
     for arg in "$@"; do
         case "$arg" in

--- a/scripts/pulsar
+++ b/scripts/pulsar
@@ -137,18 +137,40 @@ elif [ "$MODE" == "paster" ]; then
     echo "Starting pulsar with command [pulsar-serve \"$PULSAR_CONFIG_FILE\" \"$@\"]"
     pulsar-serve "$PULSAR_CONFIG_FILE" "$@"
 elif [ "$MODE" == "webless" ]; then
+    # Unlike the other modes above, this branch used to ignore "$@"
+    # entirely, so flags such as --daemon were silently dropped and Pulsar
+    # ran attached to the caller's terminal instead of backgrounding itself.
+    # pulsar-main also does not share pulsar-serve's flag names: it exposes
+    # -d/--daemonize (not --daemon) and has no --stop-daemon support at all,
+    # so translate/validate before forwarding rather than passing "$@"
+    # through unchanged.
+    WEBLESS_ARGS=()
+    for arg in "$@"; do
+        case "$arg" in
+          --daemon)
+              WEBLESS_ARGS+=("--daemonize")
+              ;;
+          --stop-daemon)
+              echo "pulsar-main does not support --stop-daemon. Stop the process directly (see its --pid-file), or manage it with a process supervisor, e.g. 'pulsar-config --supervisor'." 1>&2
+              exit 1
+              ;;
+          *)
+              WEBLESS_ARGS+=("$arg")
+              ;;
+        esac
+    done
     if hash pulsar-main 2>/dev/null; then
         # Running from pip install since
         # pulsar-main is available on PATH.
-        echo "Starting pulsar with command [pulsar-main]"
-        pulsar-main
+        echo "Starting pulsar with command [pulsar-main ${WEBLESS_ARGS[@]}]"
+        pulsar-main "${WEBLESS_ARGS[@]}"
     else
         # Running locally.
         PROJECT_DIRECTORY=$PULSAR_SCRIPTS_DIR/..
         cd $PROJECT_DIRECTORY
         export PYTHONPATH=.:$PYTHONPATH
-        echo "Starting pulsar with command [python pulsar/main.py]"
-        python pulsar/main.py
+        echo "Starting pulsar with command [python pulsar/main.py ${WEBLESS_ARGS[@]}]"
+        python pulsar/main.py "${WEBLESS_ARGS[@]}"
     fi
 else
     echo "Unknown mode passed to --mode argument." 1>&2


### PR DESCRIPTION
<h2>Summary</h2>
<p><code>scripts/pulsar</code> forwards <code>"$@"</code> to the underlying command for every launch
mode (<code>gunicorn</code>, <code>uwsgi</code>, <code>chaussette</code>, <code>circusd</code>, <code>paster</code>) <strong>except</strong>
<code>webless</code>, where the arguments are dropped entirely. As a result,
<code>pulsar --mode webless --daemon</code> silently starts <code>pulsar-main</code> in the
<strong>foreground</strong>, attached to the caller's shell, instead of daemonizing it.
No error is raised, so this is easy to miss — the process looks like it
started fine until the terminal session closes and it dies with it.</p>
<p>This came up while standing up a webless/AMQP-driven Pulsar deployment
talking to a RabbitMQ broker: the AMQP consumers bound and started
heartbeating correctly, but the process wasn't actually backgrounded despite
<code>--daemon</code> being passed.</p>
<h2>Root cause</h2>
<pre><code class="language-bash">elif [ "$MODE" == "webless" ]; then
    if hash pulsar-main 2&gt;/dev/null; then
        echo "Starting pulsar with command [pulsar-main]"
        pulsar-main          # &lt;-- "$@" never referenced
    else
        ...
        python pulsar/main.py    # &lt;-- same here
    fi
</code></pre>
<p>Compare to every other branch, e.g. gunicorn mode:</p>
<pre><code class="language-bash">elif [ "$MODE" == "gunicorn" ]; then
    echo "Starting pulsar with command [pulsar-serve \"$PULSAR_CONFIG_FILE\" \"$@\"]"
    pulsar-serve "$PULSAR_CONFIG_FILE" "$@"
</code></pre>
<p>Simply adding <code>"$@"</code> to the webless branch isn't quite enough on its own,
though, because <code>pulsar-main</code> doesn't share <code>pulsar-serve</code>'s flag names:</p>

  | pulsar-serve (gunicorn) | pulsar-main (webless)
-- | -- | --
Daemonize | --daemon | -d / --daemonize
Stop a running daemon | --stop-daemon | (not implemented)


<h2>Testing</h2>
<p>Manually tested against a live webless deployment connecting to RabbitMQ
over AMQPS (password auth, TLS via <code>amqp_connect_ssl_ca_certs</code>):</p>
<ul>
<li><code>pulsar --mode webless --daemon</code> now correctly forks into the background
and writes to the expected log file, instead of staying attached to the
invoking shell.</li>
<li><code>bash -n scripts/pulsar</code> passes.</li>
<li>Confirmed via <code>ps</code>/process inspection that the daemonized process survives
the originating SSH session closing.</li>
</ul>
<h2>Related</h2>
<p>None found — searched existing issues/PRs for <code>webless</code> + <code>daemon</code> without a
match before opening this.</p></body></html>