### PR TITLE
Fix DRMAA FAILED job state reported as COMPLETE

### DIFF
--- a/pulsar/managers/base/base_drmaa.py
+++ b/pulsar/managers/base/base_drmaa.py
@@ -46,7 +46,7 @@ class BaseDrmaaManager(ExternalBaseManager):
             JobState.SYSTEM_SUSPENDED: status.QUEUED,
             JobState.USER_SUSPENDED: status.QUEUED,
             JobState.DONE: status.COMPLETE,
-            JobState.FAILED: status.COMPLETE,  # Should be a FAILED state here as well
+            JobState.FAILED: status.FAILED,
         }[drmaa_state]
 
     def _build_template_attributes(self, job_id, command_line, dependencies_description=None, env=[], submit_params={}, setup_params=None):


### PR DESCRIPTION
## Summary

`BaseDrmaaManager._get_status_external()` maps `JobState.FAILED` to
`status.COMPLETE`, with a comment already acknowledging this is wrong:

```python
JobState.FAILED: status.COMPLETE,  # Should be a FAILED state here as well
```

Any job that fails at the DRM submission or execution level (e.g. rejected
by Slurm for a missing/invalid account, or any other DRM-side failure) is
reported back to the Galaxy client as a successful completion, with no
output and no indication anything went wrong. We hit this concretely: jobs
submitted via `queued_drmaa` to Slurm through `slurm-drmaa` that got
`CANCELLED` for lacking `--account` were reported to Galaxy as `complete`
with an empty output directory.

`status.FAILED` already exists and `status.is_job_done()` treats `FAILED`
and `COMPLETE` identically for job-done detection, so this change only
affects the terminal status surfaced to the client, not job-done detection.

## Test plan

- [x] Confirmed via `git blame` this mapping (and stale comment) has been
      unchanged since it was introduced.
- [x] Grepped `test/` for references to `_get_status_external` /
      `JobState.FAILED` -- none found, so no existing tests assume the old
      (incorrect) behavior.
- [x] Reproduced against a real Slurm cluster via `slurm-drmaa`: a job
      submitted without an account is `CANCELLED` by Slurm and previously
      surfaced to the client as `complete`; with this change it correctly
      surfaces as `failed`.