### PR TITLE
Handle DRMAA failures as terminal job statuses

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,8 +20,7 @@ History
   paths.
 * Report DRM-side job failures as ``failed`` instead of ``complete`` (thanks to
   `@gkr0110`_), and make ``failed`` terminal in ``StatefulManagerProxy`` so such
-  jobs are deactivated, staged back, and pushed to the client rather than polled
-  forever with no notification.
+  jobs are deactivated, staged back, and reported to the client.
 
 ---------------------
 0.15.15 (2026-07-13)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,10 @@ History
   ``rewrite`` action, without overloading the ``unstructured`` tool-parameter
   path type. **Note:** ``path_types: "*any*"`` now also matches container image
   paths.
+* Report DRM-side job failures as ``failed`` instead of ``complete`` (thanks to
+  `@gkr0110`_), and make ``failed`` terminal in ``StatefulManagerProxy`` so such
+  jobs are deactivated, staged back, and pushed to the client rather than polled
+  forever with no notification.
 
 ---------------------
 0.15.15 (2026-07-13)
@@ -857,3 +861,4 @@ History
 .. _@ksuderman: https://github.com/ksuderman
 .. _@dSizovs: https://github.com/dSizovs
 .. _@jeis4wpi: https://github.com/jeis4wpi
+.. _@gkr0110: https://github.com/gkr0110

--- a/pulsar/managers/base/base_drmaa.py
+++ b/pulsar/managers/base/base_drmaa.py
@@ -46,7 +46,7 @@ class BaseDrmaaManager(ExternalBaseManager):
             JobState.SYSTEM_SUSPENDED: status.QUEUED,
             JobState.USER_SUSPENDED: status.QUEUED,
             JobState.DONE: status.COMPLETE,
-            JobState.FAILED: status.COMPLETE,  # Should be a FAILED state here as well
+            JobState.FAILED: status.FAILED,
         }[drmaa_state]
 
     def _build_template_attributes(self, job_id, command_line, dependencies_description=None, env=[], submit_params={}, setup_params=None):

--- a/pulsar/managers/queued_external_drmaa.py
+++ b/pulsar/managers/queued_external_drmaa.py
@@ -61,8 +61,7 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
         if not external_id:
             raise KeyError("Failed to find external id for job_id %s" % job_id)
         external_status = super()._get_status_external(external_id)
-        # Any terminal status means the job is done with the working directory -
-        # a DRM-side failure needs it chowned back just as much as a success does.
+        # Reclaim the working directory before Pulsar reads terminal job data.
         if status.is_job_done(external_status) and job_id not in self.reclaimed:
             self.reclaimed[job_id] = True
             self.__change_ownership(job_id, getuser())

--- a/pulsar/managers/queued_external_drmaa.py
+++ b/pulsar/managers/queued_external_drmaa.py
@@ -61,7 +61,9 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
         if not external_id:
             raise KeyError("Failed to find external id for job_id %s" % job_id)
         external_status = super()._get_status_external(external_id)
-        if external_status == status.COMPLETE and job_id not in self.reclaimed:
+        # Any terminal status means the job is done with the working directory -
+        # a DRM-side failure needs it chowned back just as much as a success does.
+        if status.is_job_done(external_status) and job_id not in self.reclaimed:
             self.reclaimed[job_id] = True
             self.__change_ownership(job_id, getuser())
         return external_status

--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -39,6 +39,18 @@ JOB_FILE_PREPROCESSED = "preprocessed"
 JOB_FILE_PREPROCESSING_FAILED = "preprocessing_failed"
 JOB_METADATA_RUNNING = "running"
 
+# Statuses that end a job's life under this proxy. status.is_job_done() also
+# counts LOST, which is deliberately left out: ExternalBaseManager reports LOST
+# for a job whose external id has not been recovered yet, and the monitor is
+# bound before recover_active_jobs runs, so treating it as terminal would race a
+# restart into abandoning jobs that are fine.
+TERMINAL_STATUSES = (status.COMPLETE, status.CANCELLED, status.FAILED)
+
+# Of those, the ones whose outputs are staged back before the status is reported
+# to the client. CANCELLED is left out because the client initiated it and is
+# not waiting to be told.
+POSTPROCESSED_STATUSES = (status.COMPLETE, status.FAILED)
+
 ACTIVE_STATUS_PREPROCESSING = "preprocessing"
 ACTIVE_STATUS_LAUNCHED = "launched"
 
@@ -168,7 +180,11 @@ class StatefulManagerProxy(ManagerProxy):
             proxy_status, state_change = self.__proxy_status(job_directory, job_id)
 
         if state_change == "to_complete":
-            self.__deactivate(job_id, proxy_status)
+            self.__handle_terminal_status(job_id, proxy_status)
+        elif state_change == "to_preprocessing_failed":
+            # Preprocessing already fired the failure callback and the job never
+            # launched, so there is nothing to stage back and nobody to notify.
+            self.__deactivate(job_id)
         elif state_change == "to_running":
             self.__state_change_callback(status.RUNNING, job_id)
 
@@ -182,8 +198,9 @@ class StatefulManagerProxy(ManagerProxy):
         state_change = None
         if job_directory.has_metadata(JOB_FILE_PREPROCESSING_FAILED):
             proxy_status = status.FAILED
-            job_directory.store_metadata(JOB_FILE_FINAL_STATUS, proxy_status)
-            state_change = "to_complete"
+            if not job_directory.has_metadata(JOB_FILE_FINAL_STATUS):
+                job_directory.store_metadata(JOB_FILE_FINAL_STATUS, proxy_status)
+                state_change = "to_preprocessing_failed"
         elif not job_directory.has_metadata(JOB_FILE_PREPROCESSED):
             proxy_status = status.PREPROCESSING
         elif job_directory.has_metadata(JOB_FILE_FINAL_STATUS):
@@ -194,7 +211,7 @@ class StatefulManagerProxy(ManagerProxy):
                 if not job_directory.has_metadata(JOB_METADATA_RUNNING):
                     job_directory.store_metadata(JOB_METADATA_RUNNING, True)
                     state_change = "to_running"
-            elif proxy_status in [status.COMPLETE, status.CANCELLED]:
+            elif proxy_status in TERMINAL_STATUSES:
                 job_directory.store_metadata(JOB_FILE_FINAL_STATUS, proxy_status)
                 state_change = "to_complete"
         return proxy_status, state_change
@@ -203,16 +220,27 @@ class StatefulManagerProxy(ManagerProxy):
         """ Use proxied manager's status to compute the real
         (stateful) status of job.
         """
-        if proxy_status == status.COMPLETE:
-            if not job_directory.has_metadata(JOB_FILE_POSTPROCESSED):
-                job_status = status.POSTPROCESSING
-            else:
-                job_status = status.COMPLETE
-        else:
-            job_status = proxy_status
-        return job_status
+        if proxy_status in POSTPROCESSED_STATUSES and self.__postprocessing_pending(job_directory):
+            return status.POSTPROCESSING
+        return proxy_status
 
-    def __deactivate(self, job_id, proxy_status):
+    def __postprocessing_pending(self, job_directory):
+        if job_directory.has_metadata(JOB_FILE_POSTPROCESSED):
+            return False
+        # A job that failed before it launched is never postprocessed, so it is
+        # terminal as soon as it is reported.
+        return not job_directory.has_metadata(JOB_FILE_PREPROCESSING_FAILED)
+
+    def __handle_terminal_status(self, job_id, proxy_status):
+        self.__deactivate(job_id)
+        if proxy_status in POSTPROCESSED_STATUSES:
+            # Postprocessing fires the terminal callback itself once outputs are
+            # staged, so a failed job still returns whatever the job produced -
+            # and message-driven clients never poll, so without that callback the
+            # job just hangs.
+            self.__handle_postprocessing(job_id, proxy_status)
+
+    def __deactivate(self, job_id):
         self.active_jobs.deactivate_job(job_id)
         deactivate_method = getattr(self._proxied_manager, "_deactivate_job", None)
         if deactivate_method:
@@ -220,10 +248,8 @@ class StatefulManagerProxy(ManagerProxy):
                 deactivate_method(job_id)
             except Exception:
                 log.exception("Failed to deactivate via proxied manager job %s" % job_id)
-        if proxy_status == status.COMPLETE:
-            self.__handle_postprocessing(job_id)
 
-    def __handle_postprocessing(self, job_id):
+    def __handle_postprocessing(self, job_id, terminal_status):
         def do_postprocess():
             postprocess_success = False
             job_directory = self._proxied_manager.job_directory(job_id)
@@ -232,7 +258,7 @@ class StatefulManagerProxy(ManagerProxy):
                 postprocess_success = postprocess(job_directory, self.__postprocess_action_executor, was_cancelled)
             except Exception:
                 log.exception("Failed to postprocess results for job id %s" % job_id)
-            final_status = status.COMPLETE if postprocess_success else status.FAILED
+            final_status = terminal_status if postprocess_success else status.FAILED
             if job_directory.has_metadata(JOB_FILE_PREPROCESSING_FAILED):
                 final_status = status.FAILED
             self.__state_change_callback(final_status, job_id)

--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -39,16 +39,11 @@ JOB_FILE_PREPROCESSED = "preprocessed"
 JOB_FILE_PREPROCESSING_FAILED = "preprocessing_failed"
 JOB_METADATA_RUNNING = "running"
 
-# Statuses that end a job's life under this proxy. status.is_job_done() also
-# counts LOST, which is deliberately left out: ExternalBaseManager reports LOST
-# for a job whose external id has not been recovered yet, and the monitor is
-# bound before recover_active_jobs runs, so treating it as terminal would race a
-# restart into abandoning jobs that are fine.
+# LOST is excluded because the monitor starts before external job IDs are
+# recovered; treating it as terminal could discard recoverable jobs at startup.
 TERMINAL_STATUSES = (status.COMPLETE, status.CANCELLED, status.FAILED)
 
-# Of those, the ones whose outputs are staged back before the status is reported
-# to the client. CANCELLED is left out because the client initiated it and is
-# not waiting to be told.
+# Stage outputs before reporting completion or failure to the client.
 POSTPROCESSED_STATUSES = (status.COMPLETE, status.FAILED)
 
 ACTIVE_STATUS_PREPROCESSING = "preprocessing"
@@ -182,8 +177,7 @@ class StatefulManagerProxy(ManagerProxy):
         if state_change == "to_complete":
             self.__handle_terminal_status(job_id, proxy_status)
         elif state_change == "to_preprocessing_failed":
-            # Preprocessing already fired the failure callback and the job never
-            # launched, so there is nothing to stage back and nobody to notify.
+            # The launch failure callback was already sent during preprocessing.
             self.__deactivate(job_id)
         elif state_change == "to_running":
             self.__state_change_callback(status.RUNNING, job_id)
@@ -227,17 +221,13 @@ class StatefulManagerProxy(ManagerProxy):
     def __postprocessing_pending(self, job_directory):
         if job_directory.has_metadata(JOB_FILE_POSTPROCESSED):
             return False
-        # A job that failed before it launched is never postprocessed, so it is
-        # terminal as soon as it is reported.
+        # Preprocessing failures never launch and have no outputs to stage.
         return not job_directory.has_metadata(JOB_FILE_PREPROCESSING_FAILED)
 
     def __handle_terminal_status(self, job_id, proxy_status):
         self.__deactivate(job_id)
         if proxy_status in POSTPROCESSED_STATUSES:
-            # Postprocessing fires the terminal callback itself once outputs are
-            # staged, so a failed job still returns whatever the job produced -
-            # and message-driven clients never poll, so without that callback the
-            # job just hangs.
+            # Postprocessing stages outputs before sending the terminal callback.
             self.__handle_postprocessing(job_id, proxy_status)
 
     def __deactivate(self, job_id):

--- a/test/integration_test_state.py
+++ b/test/integration_test_state.py
@@ -58,7 +58,9 @@ class StateIntegrationTestCase(TempDirectoryTestCase):
 
             consumer.join()
             assert len(consumer.messages) == 1, len(consumer.messages)
-            assert consumer.messages[0]["status"] == "complete"
+            # Killed through the DRMAA session rather than through the manager,
+            # so this is a DRM-side failure and not a cancellation.
+            assert consumer.messages[0]["status"] == "failed"
 
     @skip_unless_module("drmaa")
     @skip_unless_module("kombu")

--- a/test/manager_drmaa_test.py
+++ b/test/manager_drmaa_test.py
@@ -1,8 +1,15 @@
+try:
+    from drmaa import JobState
+except (OSError, ImportError, RuntimeError):
+    # Mirrors base_drmaa - the bindings are optional, the module still imports.
+    JobState = None
+
 from .test_utils import (
     BaseManagerTestCase,
     skip_unless_module
 )
 
+from pulsar.managers import status
 from pulsar.managers.queued_drmaa import DrmaaQueueManager
 
 
@@ -13,7 +20,7 @@ class DrmaaManagerTest(BaseManagerTestCase):
         self._set_manager()
 
     def tearDown(self):
-        super().setUp()
+        super().tearDown()
         self.manager.shutdown()
 
     def _set_manager(self, **kwds):
@@ -26,3 +33,37 @@ class DrmaaManagerTest(BaseManagerTestCase):
     @skip_unless_module("drmaa")
     def test_cancel(self):
         self._test_cancelling(self.manager)
+
+    @skip_unless_module("drmaa")
+    def test_drmaa_state_to_pulsar_status(self):
+        # The whole table, not just the entry of the day - a status the stateful
+        # manager does not recognize as terminal leaves the job hanging forever.
+        expected = {
+            JobState.UNDETERMINED: status.COMPLETE,
+            JobState.QUEUED_ACTIVE: status.QUEUED,
+            JobState.SYSTEM_ON_HOLD: status.QUEUED,
+            JobState.USER_ON_HOLD: status.QUEUED,
+            JobState.USER_SYSTEM_ON_HOLD: status.QUEUED,
+            JobState.RUNNING: status.RUNNING,
+            JobState.SYSTEM_SUSPENDED: status.QUEUED,
+            JobState.USER_SUSPENDED: status.QUEUED,
+            JobState.DONE: status.COMPLETE,
+            JobState.FAILED: status.FAILED,
+        }
+        drmaa_session = _StubDrmaaSession()
+        self.manager.drmaa_session = drmaa_session
+        for drmaa_state, expected_status in expected.items():
+            drmaa_session.state = drmaa_state
+            assert self.manager._get_status_external("1234") == expected_status
+
+
+class _StubDrmaaSession:
+
+    def __init__(self):
+        self.state = None
+
+    def job_status(self, external_id):
+        return self.state
+
+    def close(self):
+        pass

--- a/test/manager_drmaa_test.py
+++ b/test/manager_drmaa_test.py
@@ -1,7 +1,7 @@
 try:
     from drmaa import JobState
 except (OSError, ImportError, RuntimeError):
-    # Mirrors base_drmaa - the bindings are optional, the module still imports.
+    # DRMAA bindings are optional.
     JobState = None
 
 from .test_utils import (
@@ -36,8 +36,7 @@ class DrmaaManagerTest(BaseManagerTestCase):
 
     @skip_unless_module("drmaa")
     def test_drmaa_state_to_pulsar_status(self):
-        # The whole table, not just the entry of the day - a status the stateful
-        # manager does not recognize as terminal leaves the job hanging forever.
+        # Cover the full mapping so every DRMAA state uses Pulsar's vocabulary.
         expected = {
             JobState.UNDETERMINED: status.COMPLETE,
             JobState.QUEUED_ACTIVE: status.QUEUED,

--- a/test/stateful_test.py
+++ b/test/stateful_test.py
@@ -1,10 +1,4 @@
-"""Tests for terminal status handling in :class:`StatefulManagerProxy`.
-
-Every manager runs behind this proxy, so this is where a status returned by a
-proxied manager becomes deactivation, staging, and the state-change callback
-that message-driven clients depend on - they never poll for status, so a
-terminal status that fires no callback is a job that hangs forever.
-"""
+"""Tests for terminal status handling in :class:`StatefulManagerProxy`."""
 import time
 from contextlib import contextmanager
 from shutil import rmtree
@@ -15,9 +9,7 @@ from pulsar.managers.stateful import StatefulManagerProxy
 from .test_utils import minimal_app_for_managers
 
 TEST_JOB_ID = "4"
-# An empty remote staging config is enough for postprocessing to find nothing to
-# collect and report success, without dragging a real action mapper into these
-# tests.
+# An empty staging config exercises postprocessing without external transfers.
 TEST_LAUNCH_CONFIG = {"command_line": "true", "remote_staging": {}}
 
 
@@ -37,7 +29,7 @@ class _ScriptedStatusManager(QueueManager):
 
 
 class _FailingLaunchManager(_ScriptedStatusManager):
-    """Fails at launch, the way a manager that cannot reach its DRM would."""
+    """Raises during launch."""
 
     def launch(self, *args, **kwds):
         raise Exception("Test failure launching job")
@@ -61,8 +53,7 @@ class _RecordingStatefulManagerProxy(StatefulManagerProxy):
 def test_failed_status_deactivates_and_notifies():
     with _launched_job() as (proxy, manager, job_id):
         manager.scripted_status = status.FAILED
-        # Outputs are staged back before the job is reported terminal, so a job
-        # killed for walltime or memory still returns its partial stdout/stderr.
+        # Outputs are staged before the terminal callback.
         assert proxy.get_status(job_id) == status.POSTPROCESSING
         _wait_for_callback(proxy)
         assert proxy.callbacks == [(status.FAILED, job_id)]
@@ -75,9 +66,7 @@ def test_lost_status_is_not_terminal():
     with _launched_job() as (proxy, manager, job_id):
         manager.scripted_status = status.LOST
         assert proxy.get_status(job_id) == status.LOST
-        # A manager reports LOST for a job whose external id it has not recovered
-        # yet, and the monitor is bound before recover_active_jobs runs, so the
-        # job has to stay active and be allowed to come back.
+        # LOST can be transient while an external job ID is being recovered.
         assert proxy.active_jobs.active_job_ids() == [job_id]
         assert manager.deactivated == []
         time.sleep(.1)
@@ -105,7 +94,7 @@ def test_cancelled_status_deactivates_without_notification():
         assert proxy.get_status(job_id) == status.CANCELLED
         assert proxy.active_jobs.active_job_ids() == []
         assert manager.deactivated == [job_id]
-        # The client asked for the cancellation, so it is not waiting to be told.
+        # Cancellation is client-initiated and requires no callback.
         time.sleep(.1)
         assert proxy.callbacks == []
 
@@ -115,8 +104,7 @@ def test_terminal_status_is_reported_once():
         manager.scripted_status = status.FAILED
         proxy.get_status(job_id)
         _wait_for_callback(proxy)
-        # A terminal status is recorded, so the proxied manager is never asked
-        # again and cannot walk the job back out of it.
+        # Persisted terminal status takes precedence over later manager results.
         manager.scripted_status = status.RUNNING
         for _ in range(3):
             assert proxy.get_status(job_id) == status.FAILED
@@ -130,7 +118,7 @@ def test_preprocessing_failure_is_reported_once():
         assert proxy.callbacks == [(status.FAILED, job_id)]
         for _ in range(3):
             assert proxy.get_status(job_id) == status.FAILED
-        # Nothing ran, so there is nothing to stage back and nothing more to say.
+        # No postprocessing or second callback is needed before launch.
         time.sleep(.1)
         assert proxy.callbacks == [(status.FAILED, job_id)]
 

--- a/test/stateful_test.py
+++ b/test/stateful_test.py
@@ -1,9 +1,14 @@
 """Tests for terminal status handling in :class:`StatefulManagerProxy`."""
+import threading
 import time
 from contextlib import contextmanager
 from shutil import rmtree
+from unittest import mock
 
-from pulsar.managers import status
+from pulsar.managers import (
+    stateful,
+    status,
+)
 from pulsar.managers.queued import QueueManager
 from pulsar.managers.stateful import StatefulManagerProxy
 from .test_utils import minimal_app_for_managers
@@ -54,7 +59,9 @@ def test_failed_status_deactivates_and_notifies():
     with _launched_job() as (proxy, manager, job_id):
         manager.scripted_status = status.FAILED
         # Outputs are staged before the terminal callback.
-        assert proxy.get_status(job_id) == status.POSTPROCESSING
+        with _postprocessing_held() as release:
+            assert proxy.get_status(job_id) == status.POSTPROCESSING
+            release.set()
         _wait_for_callback(proxy)
         assert proxy.callbacks == [(status.FAILED, job_id)]
         assert proxy.active_jobs.active_job_ids() == []
@@ -73,7 +80,9 @@ def test_lost_status_is_not_terminal():
         assert proxy.callbacks == []
 
         manager.scripted_status = status.COMPLETE
-        assert proxy.get_status(job_id) == status.POSTPROCESSING
+        with _postprocessing_held() as release:
+            assert proxy.get_status(job_id) == status.POSTPROCESSING
+            release.set()
         _wait_for_callback(proxy)
         assert proxy.callbacks == [(status.COMPLETE, job_id)]
 
@@ -81,7 +90,9 @@ def test_lost_status_is_not_terminal():
 def test_complete_status_postprocesses_and_notifies():
     with _launched_job() as (proxy, manager, job_id):
         manager.scripted_status = status.COMPLETE
-        assert proxy.get_status(job_id) == status.POSTPROCESSING
+        with _postprocessing_held() as release:
+            assert proxy.get_status(job_id) == status.POSTPROCESSING
+            release.set()
         _wait_for_callback(proxy)
         assert proxy.callbacks == [(status.COMPLETE, job_id)]
         assert proxy.active_jobs.active_job_ids() == []
@@ -145,6 +156,28 @@ def _launched_job():
         proxy.preprocess_and_launch(job_id, TEST_LAUNCH_CONFIG)
         assert proxy.active_jobs.active_job_ids() == [job_id]
         yield proxy, manager, job_id
+
+
+@contextmanager
+def _postprocessing_held(timeout=5):
+    """Hold postprocessing until the test releases it.
+
+    ``get_status`` starts postprocessing on its own thread and then reports
+    POSTPROCESSING only while that thread has not finished.  These jobs have
+    nothing to stage, so the thread can finish first and ``get_status`` returns
+    the terminal status instead - correct behaviour, but it makes any assertion
+    on POSTPROCESSING a race.
+    """
+    release = threading.Event()
+    real_postprocess = stateful.postprocess
+
+    def held_postprocess(*args, **kwds):
+        if not release.wait(timeout):
+            raise AssertionError("Timed out waiting for postprocessing to be released.")
+        return real_postprocess(*args, **kwds)
+
+    with mock.patch.object(stateful, "postprocess", held_postprocess):
+        yield release
 
 
 def _wait_for_callback(proxy, timeout=5):

--- a/test/stateful_test.py
+++ b/test/stateful_test.py
@@ -1,0 +1,168 @@
+"""Tests for terminal status handling in :class:`StatefulManagerProxy`.
+
+Every manager runs behind this proxy, so this is where a status returned by a
+proxied manager becomes deactivation, staging, and the state-change callback
+that message-driven clients depend on - they never poll for status, so a
+terminal status that fires no callback is a job that hangs forever.
+"""
+import time
+from contextlib import contextmanager
+from shutil import rmtree
+
+from pulsar.managers import status
+from pulsar.managers.queued import QueueManager
+from pulsar.managers.stateful import StatefulManagerProxy
+from .test_utils import minimal_app_for_managers
+
+TEST_JOB_ID = "4"
+# An empty remote staging config is enough for postprocessing to find nothing to
+# collect and report success, without dragging a real action mapper into these
+# tests.
+TEST_LAUNCH_CONFIG = {"command_line": "true", "remote_staging": {}}
+
+
+class _ScriptedStatusManager(QueueManager):
+    """Runs nothing, reports whatever status the test scripts."""
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        self.scripted_status = status.QUEUED
+        self.deactivated = []
+
+    def get_status(self, job_id):
+        return self.scripted_status
+
+    def _deactivate_job(self, job_id):
+        self.deactivated.append(job_id)
+
+
+class _FailingLaunchManager(_ScriptedStatusManager):
+    """Fails at launch, the way a manager that cannot reach its DRM would."""
+
+    def launch(self, *args, **kwds):
+        raise Exception("Test failure launching job")
+
+
+class _RecordingStatefulManagerProxy(StatefulManagerProxy):
+    """Records state changes without starting a monitor thread.
+
+    ``set_state_change_callback`` would also build a ``ManagerMonitor``, whose
+    polling would race the explicit ``get_status`` calls these tests make.
+    """
+
+    def __init__(self, manager, **kwds):
+        super().__init__(manager, **kwds)
+        self.callbacks = []
+
+    def _default_status_change_callback(self, job_status, job_id):
+        self.callbacks.append((job_status, job_id))
+
+
+def test_failed_status_deactivates_and_notifies():
+    with _launched_job() as (proxy, manager, job_id):
+        manager.scripted_status = status.FAILED
+        # Outputs are staged back before the job is reported terminal, so a job
+        # killed for walltime or memory still returns its partial stdout/stderr.
+        assert proxy.get_status(job_id) == status.POSTPROCESSING
+        _wait_for_callback(proxy)
+        assert proxy.callbacks == [(status.FAILED, job_id)]
+        assert proxy.active_jobs.active_job_ids() == []
+        assert manager.deactivated == [job_id]
+        assert proxy.get_status(job_id) == status.FAILED
+
+
+def test_lost_status_is_not_terminal():
+    with _launched_job() as (proxy, manager, job_id):
+        manager.scripted_status = status.LOST
+        assert proxy.get_status(job_id) == status.LOST
+        # A manager reports LOST for a job whose external id it has not recovered
+        # yet, and the monitor is bound before recover_active_jobs runs, so the
+        # job has to stay active and be allowed to come back.
+        assert proxy.active_jobs.active_job_ids() == [job_id]
+        assert manager.deactivated == []
+        time.sleep(.1)
+        assert proxy.callbacks == []
+
+        manager.scripted_status = status.COMPLETE
+        assert proxy.get_status(job_id) == status.POSTPROCESSING
+        _wait_for_callback(proxy)
+        assert proxy.callbacks == [(status.COMPLETE, job_id)]
+
+
+def test_complete_status_postprocesses_and_notifies():
+    with _launched_job() as (proxy, manager, job_id):
+        manager.scripted_status = status.COMPLETE
+        assert proxy.get_status(job_id) == status.POSTPROCESSING
+        _wait_for_callback(proxy)
+        assert proxy.callbacks == [(status.COMPLETE, job_id)]
+        assert proxy.active_jobs.active_job_ids() == []
+        assert proxy.get_status(job_id) == status.COMPLETE
+
+
+def test_cancelled_status_deactivates_without_notification():
+    with _launched_job() as (proxy, manager, job_id):
+        manager.scripted_status = status.CANCELLED
+        assert proxy.get_status(job_id) == status.CANCELLED
+        assert proxy.active_jobs.active_job_ids() == []
+        assert manager.deactivated == [job_id]
+        # The client asked for the cancellation, so it is not waiting to be told.
+        time.sleep(.1)
+        assert proxy.callbacks == []
+
+
+def test_terminal_status_is_reported_once():
+    with _launched_job() as (proxy, manager, job_id):
+        manager.scripted_status = status.FAILED
+        proxy.get_status(job_id)
+        _wait_for_callback(proxy)
+        # A terminal status is recorded, so the proxied manager is never asked
+        # again and cannot walk the job back out of it.
+        manager.scripted_status = status.RUNNING
+        for _ in range(3):
+            assert proxy.get_status(job_id) == status.FAILED
+        assert proxy.callbacks == [(status.FAILED, job_id)]
+
+
+def test_preprocessing_failure_is_reported_once():
+    with _proxy(_FailingLaunchManager) as (proxy, manager):
+        job_id = proxy.setup_job(TEST_JOB_ID, "tool1", "1.0.0")
+        proxy.preprocess_and_launch(job_id, TEST_LAUNCH_CONFIG)
+        assert proxy.callbacks == [(status.FAILED, job_id)]
+        for _ in range(3):
+            assert proxy.get_status(job_id) == status.FAILED
+        # Nothing ran, so there is nothing to stage back and nothing more to say.
+        time.sleep(.1)
+        assert proxy.callbacks == [(status.FAILED, job_id)]
+
+
+@contextmanager
+def _proxy(manager_class=_ScriptedStatusManager):
+    app = minimal_app_for_managers()
+    manager = manager_class("test", app, num_concurrent_jobs=0)
+    proxy = _RecordingStatefulManagerProxy(manager)
+    try:
+        yield proxy, manager
+    finally:
+        try:
+            proxy.shutdown()
+        except Exception:
+            pass
+        rmtree(app.staging_directory, ignore_errors=True)
+
+
+@contextmanager
+def _launched_job():
+    with _proxy() as (proxy, manager):
+        job_id = proxy.setup_job(TEST_JOB_ID, "tool1", "1.0.0")
+        proxy.preprocess_and_launch(job_id, TEST_LAUNCH_CONFIG)
+        assert proxy.active_jobs.active_job_ids() == [job_id]
+        yield proxy, manager, job_id
+
+
+def _wait_for_callback(proxy, timeout=5):
+    time_end = time.time() + timeout
+    while time.time() < time_end:
+        if proxy.callbacks:
+            return
+        time.sleep(.01)
+    raise AssertionError("Timed out waiting for a state change callback.")


### PR DESCRIPTION
## Summary

- map DRMAA `JobState.FAILED` to Pulsar's `failed` status
- treat failed jobs as terminal in `StatefulManagerProxy`
- stage partial outputs before sending the terminal failure callback
- deactivate failed jobs and reclaim external-DRMAA working-directory ownership
- add regression coverage for terminal lifecycle behavior and the DRMAA state mapping

This builds on and supersedes #482. The original mapping fix is retained as its own commit with Govind's authorship, and the changelog credits @gkr0110.

## Root cause

PR #482 corrects the DRMAA-to-Pulsar mapping, but `StatefulManagerProxy` previously recognized only `complete` and `cancelled` as terminal. A DRMAA failure would therefore remain active, continue being polled, and never notify message-driven clients. The external DRMAA manager also reclaimed directory ownership only for successful completion.

The stateful terminal path now handles `failed` explicitly while leaving `lost` recoverable during startup. Both successful and failed jobs are postprocessed before their terminal callback is sent.

## User impact

DRM-side failures such as scheduler submission rejection, walltime expiration, or resource-limit termination are reported as failed instead of complete. Message-driven Galaxy clients receive the terminal update, partial outputs can still be staged, and Pulsar releases the associated manager and working-directory state.

## Validation

- `tox -e test-unit -- test/stateful_test.py test/manager_drmaa_test.py` — 6 passed, 3 skipped locally because no DRMAA library is configured
- Flake8 passed for `pulsar` and `test`
- mypy passed for the changed Python modules and tests
- `git diff --check` passed
