### PR TITLE
Drop meaningless --port from resilience webless entrypoint

### DIFF
--- a/test/resilience/entrypoint.sh
+++ b/test/resilience/entrypoint.sh
@@ -21,4 +21,6 @@ cp /etc/pulsar/server.ini "$runtime/server.ini"
 cp "$src" "$runtime/app.yml"
 
 export PULSAR_CONFIG_DIR="$runtime"
-exec pulsar --mode webless --config_dir "$runtime" --port 8913
+# No --port: webless mode binds no port, so the flag is not one of the
+# pulsar-main arguments this mode accepts.
+exec pulsar --mode webless --config_dir "$runtime"


### PR DESCRIPTION
> **Note:** this PR description was prepared and posted by Claude (AI assistant) on jmchilton's behalf, not authored by them personally.

`test/resilience/entrypoint.sh` launches Pulsar with a `--port` it cannot use:

```sh
exec pulsar --mode webless --config_dir "$runtime" --port 8913
```

webless mode binds no port — `scripts/pulsar --help` says so explicitly ("In webless mode Pulsar will not attempt to bind to a port") — and `pulsar-main` declares no `--port` argument.

### Why this is a no-op today

`scripts/pulsar` consumes `-h`, `-m|--mode` and `-c|--config`, then forwards the rest. `--port` and `--config_dir` both survive into `"$@"`, and the webless branch runs a bare `pulsar-main` that never references `"$@"`. So the flag is discarded unread, and the command line `pulsar-main` actually sees is identical before and after this change. The config directory reaches Pulsar through the `PULSAR_CONFIG_DIR` export on the preceding line.

Nothing in the suite talks to Pulsar on 8913 either: the `pulsar` service in `test/resilience/docker-compose.yml` publishes no ports, and readiness is docker-compose logs plus the RabbitMQ management API (`_amqp_setup_has_consumer`), never HTTP. The flag looks copied from the gunicorn/chaussette invocations, where a port *is* meaningful.

### Why it stops being a no-op

#480 makes the webless branch forward `"$@"` to `pulsar-main`, which is what `docs/scripts/pulsar.rst` has always documented:

> See the documentation for the ``pulsar-main`` for the arguments that may be supplied to ``pulsar`` in this mode.

With that change in place, argparse rejects the flag and the container dies at startup:

```
Starting pulsar with command [pulsar-main --config_dir /tmp/pulsar-runtime --port 8913]
usage: pulsar-main [-h] [-c CONFIG_DIR] [--ini_path INI_PATH] ...
pulsar-main: error: unrecognized arguments: --port 8913
```

No AMQP consumers ever bind, and the first scenario test times out:

```
E   TimeoutError: Pulsar did not bind amqp consumers within 60.0s
ERROR test/resilience/scenarios/test_broker_outage.py::test_b1_outage_during_preprocessing[mode=amqp]
```

Because the job runs `pytest test/resilience -v -x`, that first error blocks every scenario after it. The `9 passed` in that run is `mock_galaxy/recorder_test.py`, which never touches a container — the scenario suite is entirely blocked.

### Verification

Checked out #480's branch locally with only this one-line change applied and brought up the stack (Docker 29.7.2). The `pulsar` container stays up and logs:

```
pulsar.messaging.bind_amqp INFO bind_manager_to_queue called for [amqp://guest:********@toxiproxy:5672//] and manager [_default_]
```

which is the exact `bind_marker` string `harness/pulsar_control.py` polls for. Pre-fix that line never appeared, because the process exited at argparse.

Landing this separately keeps the harness fix independent of the behaviour change in #480 — it is a pre-existing bug in the harness, and it costs #480 nothing to have it already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
