### PR TITLE
Fix relay readiness and drain checks in the resilience harness

### DIFF
--- a/test/resilience/docker-compose.yml
+++ b/test/resilience/docker-compose.yml
@@ -35,10 +35,8 @@ services:
     networks: [pulsar-net]
 
   relay:
-    # Pinned by digest: the readiness checks in harness/pulsar_control.py
-    # depend on the shape of /messages/poll/stats, so an unpinned :latest
-    # can change harness behaviour with no commit here. Override with
-    # RELAY_IMAGE to test against a newer relay.
+    # The harness depends on the undocumented /messages/poll/stats response.
+    # RELAY_IMAGE can override this pin when testing newer relay versions.
     image: ${RELAY_IMAGE:-ghcr.io/mvdbeek/pulsar-relay:0.2.1@sha256:b677658c3585bc21a1a3eb8ed7403d55dea3b72d0dd859b2c3b606abf876fb78}
     volumes:
       - ./config/relay-config.yaml:/etc/pulsar-relay/config.yaml:ro

--- a/test/resilience/docker-compose.yml
+++ b/test/resilience/docker-compose.yml
@@ -35,7 +35,11 @@ services:
     networks: [pulsar-net]
 
   relay:
-    image: ghcr.io/mvdbeek/pulsar-relay:latest
+    # Pinned by digest: the readiness checks in harness/pulsar_control.py
+    # depend on the shape of /messages/poll/stats, so an unpinned :latest
+    # can change harness behaviour with no commit here. Override with
+    # RELAY_IMAGE to test against a newer relay.
+    image: ${RELAY_IMAGE:-ghcr.io/mvdbeek/pulsar-relay:0.2.1@sha256:b677658c3585bc21a1a3eb8ed7403d55dea3b72d0dd859b2c3b606abf876fb78}
     volumes:
       - ./config/relay-config.yaml:/etc/pulsar-relay/config.yaml:ro
     ports:

--- a/test/resilience/harness/pulsar_control.py
+++ b/test/resilience/harness/pulsar_control.py
@@ -26,23 +26,12 @@ RABBITMQ_AUTH = ("guest", "guest")
 RELAY_HTTP = "http://localhost:8081"
 RELAY_ADMIN_USERNAME = "admin"
 RELAY_ADMIN_PASSWORD = "admin1234"
-# Has to cover the time the relay takes to notice the dropped consumer plus
-# RELAY_DRAIN_CONFIRM_SECONDS below.
-RELAY_DRAIN_TIMEOUT = 10.0
-# The relay registers a poll-waiter only while a long poll is parked in its
-# storage loop, so /messages/poll/stats reports a live consumer intermittently:
-# holding a single long poll open and sampling every 50ms showed the waiter in
-# 16-60% of samples, with gaps up to ~0.5s. Neither readiness nor drain may
-# treat one sample as the truth.
-#
-# Readiness therefore jitters its poll interval. A fixed interval can beat
-# against the relay's ~2s poll cycle and land in the invisible part of every
-# one - the failure mode this replaces spent 60s reporting no consumer while
-# the relay was creating a waiter every 2.004s without a break.
+# Poll stats expose a waiter only while its long poll is parked, not for the
+# consumer's entire lifetime. Jitter avoids repeatedly sampling between polls.
 RELAY_WAITER_POLL_JITTER = 0.5
-# Zeros have to persist well past the largest gap observed above before the
-# old waiter counts as gone.
+# Live consumers have produced gaps of up to 0.5 seconds in poll stats.
 RELAY_DRAIN_CONFIRM_SECONDS = 2.0
+RELAY_DRAIN_TIMEOUT = 10.0
 _admin_token_cache = {"token": None, "exp": 0.0}
 
 
@@ -227,12 +216,15 @@ class PulsarControl:
                     # AMQP modes: also confirm the broker sees the consumer.
                     if _amqp_setup_has_consumer():
                         return
-            # Jittered so the sampling cannot lock to the relay's poll cycle.
-            time.sleep(poll_interval * random.uniform(1 - RELAY_WAITER_POLL_JITTER, 1 + RELAY_WAITER_POLL_JITTER))
+            jitter = 1
+            if self.mode == "relay":
+                jitter = random.uniform(1 - RELAY_WAITER_POLL_JITTER, 1 + RELAY_WAITER_POLL_JITTER)
+            time.sleep(poll_interval * jitter)
+        details = f"bind log seen: {bind_seen}, consumer checks: {samples}"
+        if self.mode == "relay":
+            details += f", last relay stats: {last_stats!r}"
         raise TimeoutError(
-            f"Pulsar did not bind {self.mode} consumers within {timeout}s "
-            f"(bind log seen: {bind_seen}, consumer checks: {samples}, "
-            f"last relay stats: {last_stats!r})"
+            f"Pulsar did not bind {self.mode} consumers within {timeout}s ({details})"
         )
 
 
@@ -266,11 +258,7 @@ def _relay_admin_token():
 
 
 def _relay_poll_stats():
-    """Body of the relay's ``/messages/poll/stats``, or None if unreachable.
-
-    Returned rather than reduced to a count so a readiness timeout can report
-    what the relay actually said.
-    """
+    """Return the relay's poll stats, or ``None`` if unavailable."""
     try:
         token = _relay_admin_token()
     except Exception:
@@ -285,19 +273,23 @@ def _relay_poll_stats():
         return None
     if r.status_code != 200:
         return None
-    return r.json()
+    try:
+        return r.json()
+    except ValueError:
+        return None
 
 
 def _setup_waiter_count(stats):
-    """Poll-waiters across all ``*/job_setup`` topics in a stats body.
-
-    Topics are namespaced per client (``<uuid>/job_setup``).  Returns None for
-    an unusable body so callers can tell "unknown" apart from a confirmed zero.
-    """
-    if stats is None:
+    """Count ``*/job_setup`` waiters, preserving invalid data as unknown."""
+    if not isinstance(stats, dict):
         return None
-    counts = stats.get("topic_subscriber_counts") or {}
-    return sum(n for t, n in counts.items() if t.endswith("/job_setup"))
+    counts = stats.get("topic_subscriber_counts")
+    if not isinstance(counts, dict):
+        return None
+    try:
+        return sum(n for t, n in counts.items() if t.endswith("/job_setup"))
+    except (AttributeError, TypeError):
+        return None
 
 
 def _relay_setup_waiter_count():
@@ -316,8 +308,6 @@ def _wait_relay_setup_waiters_drained(timeout=RELAY_DRAIN_TIMEOUT, poll_interval
     zero_since = None
     while time.time() < deadline:
         if _relay_setup_waiter_count() == 0:
-            # One zero proves nothing - a live consumer reads as zero between
-            # long polls. Require the zeros to persist.
             if zero_since is None:
                 zero_since = time.time()
             if time.time() - zero_since >= RELAY_DRAIN_CONFIRM_SECONDS:

--- a/test/resilience/harness/pulsar_control.py
+++ b/test/resilience/harness/pulsar_control.py
@@ -5,6 +5,7 @@ Python SDK to keep the dependency surface small and to make the commands easy
 to reproduce by hand when debugging a flaky scenario.
 """
 import os
+import random
 import subprocess
 import time
 
@@ -25,7 +26,23 @@ RABBITMQ_AUTH = ("guest", "guest")
 RELAY_HTTP = "http://localhost:8081"
 RELAY_ADMIN_USERNAME = "admin"
 RELAY_ADMIN_PASSWORD = "admin1234"
-RELAY_DRAIN_TIMEOUT = 7.0
+# Has to cover the time the relay takes to notice the dropped consumer plus
+# RELAY_DRAIN_CONFIRM_SECONDS below.
+RELAY_DRAIN_TIMEOUT = 10.0
+# The relay registers a poll-waiter only while a long poll is parked in its
+# storage loop, so /messages/poll/stats reports a live consumer intermittently:
+# holding a single long poll open and sampling every 50ms showed the waiter in
+# 16-60% of samples, with gaps up to ~0.5s. Neither readiness nor drain may
+# treat one sample as the truth.
+#
+# Readiness therefore jitters its poll interval. A fixed interval can beat
+# against the relay's ~2s poll cycle and land in the invisible part of every
+# one - the failure mode this replaces spent 60s reporting no consumer while
+# the relay was creating a waiter every 2.004s without a break.
+RELAY_WAITER_POLL_JITTER = 0.5
+# Zeros have to persist well past the largest gap observed above before the
+# old waiter counts as gone.
+RELAY_DRAIN_CONFIRM_SECONDS = 2.0
 _admin_token_cache = {"token": None, "exp": 0.0}
 
 
@@ -191,22 +208,31 @@ class PulsarControl:
         bind_marker = "bind_manager_to"
         deadline = time.time() + timeout
         start_ts = time.time()
+        bind_seen = False
+        samples = 0
+        last_stats = None
         while time.time() < deadline:
             res = _docker_compose(
                 "logs", "--since", f"{int(time.time() - start_ts) + 2}s",
                 self.service, project_dir=self.project_dir,
             )
             if bind_marker in (res.stdout or ""):
+                bind_seen = True
+                samples += 1
                 if self.mode == "relay":
-                    if _relay_has_pulsar_setup_waiter():
+                    last_stats = _relay_poll_stats()
+                    if _setup_waiter_count(last_stats):
                         return
                 else:
                     # AMQP modes: also confirm the broker sees the consumer.
                     if _amqp_setup_has_consumer():
                         return
-            time.sleep(poll_interval)
+            # Jittered so the sampling cannot lock to the relay's poll cycle.
+            time.sleep(poll_interval * random.uniform(1 - RELAY_WAITER_POLL_JITTER, 1 + RELAY_WAITER_POLL_JITTER))
         raise TimeoutError(
-            f"Pulsar did not bind {self.mode} consumers within {timeout}s"
+            f"Pulsar did not bind {self.mode} consumers within {timeout}s "
+            f"(bind log seen: {bind_seen}, consumer checks: {samples}, "
+            f"last relay stats: {last_stats!r})"
         )
 
 
@@ -239,11 +265,11 @@ def _relay_admin_token():
     return _admin_token_cache["token"]
 
 
-def _relay_setup_waiter_count():
-    """Number of relay poll-waiters across all ``*/job_setup`` topics.
+def _relay_poll_stats():
+    """Body of the relay's ``/messages/poll/stats``, or None if unreachable.
 
-    Returns ``None`` when the relay can't be queried, so callers can tell
-    "unknown" apart from a confirmed zero.
+    Returned rather than reduced to a count so a readiness timeout can report
+    what the relay actually said.
     """
     try:
         token = _relay_admin_token()
@@ -259,13 +285,24 @@ def _relay_setup_waiter_count():
         return None
     if r.status_code != 200:
         return None
-    counts = r.json().get("topic_subscriber_counts") or {}
+    return r.json()
+
+
+def _setup_waiter_count(stats):
+    """Poll-waiters across all ``*/job_setup`` topics in a stats body.
+
+    Topics are namespaced per client (``<uuid>/job_setup``).  Returns None for
+    an unusable body so callers can tell "unknown" apart from a confirmed zero.
+    """
+    if stats is None:
+        return None
+    counts = stats.get("topic_subscriber_counts") or {}
     return sum(n for t, n in counts.items() if t.endswith("/job_setup"))
 
 
-def _relay_has_pulsar_setup_waiter():
-    """True iff the relay shows a poll-waiter on a ``job_setup`` topic."""
-    return bool(_relay_setup_waiter_count())
+def _relay_setup_waiter_count():
+    """Number of relay poll-waiters across all ``*/job_setup`` topics."""
+    return _setup_waiter_count(_relay_poll_stats())
 
 
 def _wait_relay_setup_waiters_drained(timeout=RELAY_DRAIN_TIMEOUT, poll_interval=0.25):
@@ -276,9 +313,17 @@ def _wait_relay_setup_waiters_drained(timeout=RELAY_DRAIN_TIMEOUT, poll_interval
     test-configured poll times out. ``None`` is treated as "keep polling".
     """
     deadline = time.time() + timeout
+    zero_since = None
     while time.time() < deadline:
         if _relay_setup_waiter_count() == 0:
-            return True
+            # One zero proves nothing - a live consumer reads as zero between
+            # long polls. Require the zeros to persist.
+            if zero_since is None:
+                zero_since = time.time()
+            if time.time() - zero_since >= RELAY_DRAIN_CONFIRM_SECONDS:
+                return True
+        else:
+            zero_since = None
         time.sleep(poll_interval)
     return False
 

--- a/test/resilience/harness/pulsar_control_test.py
+++ b/test/resilience/harness/pulsar_control_test.py
@@ -1,0 +1,39 @@
+import pytest
+
+from harness import pulsar_control
+
+
+@pytest.mark.parametrize(
+    "stats, expected",
+    [
+        (None, None),
+        ({}, None),
+        ({"topic_subscriber_counts": None}, None),
+        ({"topic_subscriber_counts": {}}, 0),
+        ({"topic_subscriber_counts": {"owner/job_setup": 1, "owner/job_kill": 2}}, 1),
+        ({"topic_subscriber_counts": {"job_setup": 1}}, 0),
+        ({"topic_subscriber_counts": {"owner/job_setup": "invalid"}}, None),
+    ],
+)
+def test_setup_waiter_count(stats, expected):
+    assert pulsar_control._setup_waiter_count(stats) == expected
+
+
+def test_wait_for_drain_requires_uninterrupted_zeros(monkeypatch):
+    now = 0.0
+    counts = iter([0, 0, 1, 0, 0, 0])
+
+    def time():
+        return now
+
+    def sleep(seconds):
+        nonlocal now
+        now += seconds
+
+    monkeypatch.setattr(pulsar_control.time, "time", time)
+    monkeypatch.setattr(pulsar_control.time, "sleep", sleep)
+    monkeypatch.setattr(pulsar_control, "_relay_setup_waiter_count", lambda: next(counts))
+    monkeypatch.setattr(pulsar_control, "RELAY_DRAIN_CONFIRM_SECONDS", 0.5)
+
+    assert pulsar_control._wait_relay_setup_waiters_drained(timeout=2, poll_interval=0.25)
+    assert now == 1.25


### PR DESCRIPTION
*This PR description was drafted and posted by Claude (AI assistant) on jmchilton's behalf.*

## Summary

The resilience harness treats the relay's `/messages/poll/stats` as a steady-state "is a consumer attached" signal. It isn't. Both readiness and drain read it wrong, in opposite directions.

## Evidence

Holding a **single** long poll open against `ghcr.io/mvdbeek/pulsar-relay:0.2.1` and sampling the stats endpoint every 50ms:

```
samples: 010010000000000001000000100000001000000100000000001000001000000100000000000000000000001000000011000000101000101000000001010001001001100000000000000010110000
nonzero 25/156 = 16.0% duty cycle
```

A second run of the same experiment measured 59.5%, with the longest run of zeros at 0.51s. The relay registers a poll-waiter only while a long poll is parked in its storage loop, so a live consumer reads as *absent* in most samples.

That breaks two checks:

**`wait_until_consuming` can time out against a healthy Pulsar.** Seen on CI: `TimeoutError: Pulsar did not bind relay consumers within 60.0s` while the relay log shows an unbroken chain of 34 poll waiters, one every 2.004s, across the whole 60s. The harness polled every ~0.198s and got HTTP 200 every time, so it was sampling a live consumer ~300 times and reading zero each time. A fixed poll interval can beat against the relay's ~2s cycle and land in the invisible part of every one.

**`_wait_relay_setup_waiters_drained` returns immediately, always.** It took a single zero as proof the old waiter was gone. With this duty cycle it reports "drained" on the first sample even when a consumer is fully alive — so the guard it exists to provide (don't let readiness pass against a stale registration) has not been doing anything.

## Changes

- Jitter the readiness poll interval so the sampling cannot lock to the relay's cycle.
- Require zeros to persist for `RELAY_DRAIN_CONFIRM_SECONDS` (2s, ~4x the largest observed gap) before calling the waiters drained. `RELAY_DRAIN_TIMEOUT` goes 7s → 10s to make room.
- Put the bind-marker state, the sample count, and the last stats body into the `TimeoutError`, so the next occurrence diagnoses itself instead of needing this investigation again.
- Split `_relay_setup_waiter_count()` into `_relay_poll_stats()` + `_setup_waiter_count(stats)` so the raw body is available for that message.
- Pin the relay image by digest (`0.2.1@sha256:b677658c…`), overridable with `RELAY_IMAGE`. The readiness checks depend on the shape of an undocumented endpoint of that image; leaving it on `:latest` means its behaviour can change with no commit here.

The topic-key parsing was **not** the problem — keys are namespaced `<uuid>/job_setup` and the existing `endswith("/job_setup")` matches correctly. Verified against a live relay.

## Validation

- Reproduced both defects against a locally running relay from this compose file, and re-ran the same probes after the change: the drain check now refuses a live consumer (previously passed on the first sample) and still reports drained within ~2.2s when nothing is consuming.
- Readiness detection latency against a consumer on a 2s poll cycle, 5 trials: 0.01s, 0.01s, 0.36s, 1.09s, 2.78s.
- flake8 clean.
- `test/resilience/scenarios/test_pulsar_restart.py` against a real stack: 4 passed in relay mode (including `test_a2_sigkill_during_execution`, the CI failure above), then 12 passed across all three messaging modes.

## Open question

Pinning the relay image means this harness no longer catches relay-side drift. If tracking the relay's tip was the point of `:latest`, a scheduled job running with `RELAY_IMAGE=ghcr.io/mvdbeek/pulsar-relay:latest` would give that back without letting an upstream change turn a PR red for reasons unrelated to it. Happy to switch to that shape.
