### PR TITLE
Use recorded TES task IDs for polling and cancellation

### DIFF
--- a/pulsar/client/client.py
+++ b/pulsar/client/client.py
@@ -120,6 +120,7 @@ class BaseJobClient:
         self.cvmfsexec = destination_params.get("cvmfsexec", None)
         self.files_endpoint = destination_params.get("files_endpoint", None)
         self.token_endpoint = destination_params.get("token_endpoint", None)
+        self.external_id = destination_params.get("external_id", None)
 
         default_file_action = self.destination_params.get("default_file_action", "transfer")
         if default_file_action not in actions:
@@ -874,17 +875,22 @@ class LaunchesTesContainersMixin(CoexecutionLaunchMixin):
         job_name = produce_unique_k8s_job_name(app_prefix="pulsar", job_id=job_id, instance_id=self.instance_id)
         return job_name
 
+    @property
+    def _tes_task_id(self):
+        """Return the provider-assigned TES id when Galaxy recorded one."""
+        return self.external_id or self.job_id
+
     def _setup_tes_client_properties(self, destination_params):
         self.instance_id = tes_galaxy_instance_id(destination_params)
 
     def kill(self):
-        self._tes_client.cancel_task(self.job_id)
+        self._tes_client.cancel_task(self._tes_task_id)
 
     def clean(self):
         pass
 
     def raw_check_complete(self) -> Dict[str, Any]:
-        tes_task: TesTask = self._tes_client.get_task(self.job_id, "FULL")
+        tes_task: TesTask = self._tes_client.get_task(self._tes_task_id, "FULL")
         tes_state = tes_task.state
         return {
             "status": tes_state_to_pulsar_status(tes_state),

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -1,8 +1,16 @@
 import os
 import tempfile
 from collections import deque
+from types import SimpleNamespace
+from unittest.mock import (
+    patch,
+    PropertyMock,
+)
 
-from pulsar.client.client import JobClient
+from pulsar.client.client import (
+    JobClient,
+    TesPollingCoexecutionJobClient,
+)
 from pulsar.client.decorators import (
     MAX_RETRY_COUNT,
     retry,
@@ -208,3 +216,53 @@ def test_clean():
     client.expect_open(request_checker, 'OK')
     client.clean()
     request_checker.assert_called()
+
+
+def _tes_client_stub(job_id="543", external_id=None):
+    client = object.__new__(TesPollingCoexecutionJobClient)
+    client.job_id = job_id
+    client.external_id = external_id
+    return client
+
+
+class RecordingTesClient:
+    def __init__(self):
+        self.cancelled = []
+        self.polled = []
+
+    def cancel_task(self, task_id):
+        self.cancelled.append(task_id)
+
+    def get_task(self, task_id, view):
+        self.polled.append((task_id, view))
+        return SimpleNamespace(state=None)
+
+
+def test_client_reads_external_id():
+    interface = HttpPulsarInterface({"url": "http://test:803/"}, TestTransport(None))
+    client = JobClient({"external_id": "tes-task-abc"}, "543", interface)
+    assert client.external_id == "tes-task-abc"
+    assert JobClient({}, "543", interface).external_id is None
+
+
+def test_tes_task_id_falls_back_to_galaxy_job_id():
+    client = _tes_client_stub()
+    assert client._tes_task_id == "543"
+
+
+def test_tes_poll_and_cancel_use_recorded_external_id():
+    client = _tes_client_stub(external_id="tes-task-abc")
+    tes_client = RecordingTesClient()
+    with patch.object(
+        TesPollingCoexecutionJobClient,
+        "_tes_client",
+        new_callable=PropertyMock,
+        return_value=tes_client,
+    ), patch("pulsar.client.client.tes_state_to_pulsar_status", return_value="running"), patch(
+        "pulsar.client.client.tes_state_is_complete", return_value=False
+    ):
+        client.kill()
+        client.raw_check_complete()
+
+    assert tes_client.cancelled == ["tes-task-abc"]
+    assert tes_client.polled == [("tes-task-abc", "FULL")]


### PR DESCRIPTION
## What this fixes

TES `create_task()` returns a provider-assigned task ID, which Galaxy persists as the job runner external ID. During status polling Galaxy must keep the Galaxy job ID as the Pulsar client's primary ID so its files and OIDC token endpoints remain valid. That left the TES client using the Galaxy ID for `get_task()` instead of the task ID returned by TES.

## Changes

- Record the optional `external_id` supplied by Galaxy.
- Prefer that ID for TES `get_task()` and `cancel_task()` operations.
- Fall back to `job_id` for compatibility with Galaxy versions that do not pass the external ID separately.
- Cover external-ID ingestion, fallback behavior, polling, and cancellation.

## Compatibility

This preserves existing behavior when `external_id` is absent. The companion Galaxy change can land before or after this PR without introducing a regression; both changes are required to fix TES polling.

Companion: galaxyproject/galaxy#23367

## Testing

- `pytest -q test/client_test.py` — 13 passed
- flake8 — passed
- mypy — passed
- isort — passed
