### PR TITLE
Fix daemon handling in webless mode

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ History
 0.15.16.dev0
 ---------------------
 
+* Honor daemon-control arguments in ``--mode webless``, preserve daemon logs
+  in ``pulsar.log``, and add a ``daemon`` installation extra (thanks to
+  `@gkr0110`_).
 * Add native ``cvmfsexec`` support to Pulsar managers (``mountrepo`` and
   ``namespace`` modes), configured via a ``cvmfsexec`` manager option or a
   per-job override, for accessing CVMFS repositories (and CVMFS-hosted

--- a/docs/scripts/pulsar_main.rst
+++ b/docs/scripts/pulsar_main.rst
@@ -5,8 +5,9 @@
 **Usage**::
 
     pulsar-main [-h] [-c CONFIG_DIR] [--ini_path INI_PATH]
-                [--app_conf_path APP_CONF_PATH] [--app APP] [-d]
-                [--daemon-log-file DAEMON_LOG_FILE] [--pid-file PID_FILE]
+                [--app_conf_path APP_CONF_PATH]
+                [--app_conf_base64 APP_CONF_BASE64] [--app APP] [-d]
+                [--log-file DAEMON_LOG_FILE] [--pid PID_FILE] [--stop-daemon]
 
 **Help**
 
@@ -41,9 +42,14 @@ delegate to this script.
       --app_conf_path APP_CONF_PATH
                             Specify an explicit path to Pulsar's app.yml
                             configuration file.
+      --app_conf_base64 APP_CONF_BASE64
+                            Specify an application configuration as a base64
+                            encoded JSON blob.
       --app APP
-      -d, --daemonize       Daemonzie process (requires daemonize library).
-      --daemon-log-file DAEMON_LOG_FILE
-                            Log file for daemon, if --daemonize supplied.
-      --pid-file PID_FILE   Pid file for daemon, if --daemonize supplied (default
-                            is pulsar.pid).
+      -d, --daemon, --daemonize
+                            Run as a daemon process.
+      --log-file, --daemon-log-file DAEMON_LOG_FILE
+                            Log file for daemon (default is pulsar.log).
+      --pid, --pid-file PID_FILE
+                            Pid file for daemon (default is pulsar.pid).
+      --stop-daemon         Stop a running daemon by reading the PID file.

--- a/pulsar/main.py
+++ b/pulsar/main.py
@@ -40,9 +40,11 @@ from argparse import (
     RawDescriptionHelpFormatter,
 )
 
+from pulsar.scripts.serve import stop_daemon
+
 log = logging.getLogger(__name__)
 
-REQUIRES_DAEMONIZE_MESSAGE = "Attempted to use Pulsar in daemon mode, but daemonize is unavailable."
+REQUIRES_DAEMONIZE_MESSAGE = "Daemon mode requires daemonize. Install it with: pip install 'pulsar-app[daemon]'"
 
 PULSAR_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if "PULSAR_CONFIG_DIR" in os.environ:
@@ -56,12 +58,13 @@ DEFAULT_APP_YAML = "app.yml"
 DEFAULT_MANAGER = "_default_"
 
 DEFAULT_PID = "pulsar.pid"
+DEFAULT_DAEMON_LOG = "pulsar.log"
 DEFAULT_VERBOSE = True
 HELP_CONFIG_DIR = "Default directory to search for relevant Pulsar configuration files (e.g. app.yml, server.ini)."
 HELP_INI_PATH = "Specify an explicit path to Pulsar's server.ini configuration file."
 HELP_APP_CONF_PATH = "Specify an explicit path to Pulsar's app.yml configuration file."
 HELP_APP_CONF_BASE64 = "Specify an application configuration as a base64 encoded JSON blob."
-HELP_DAEMONIZE = "Daemonzie process (requires daemonize library)."
+HELP_DAEMONIZE = "Run as a daemon process."
 CONFIG_PREFIX = "PULSAR_CONFIG_"
 
 
@@ -281,9 +284,16 @@ class PulsarConfigBuilder:
         arg_parser.add_argument("--app_conf_base64", default=None, help=HELP_APP_CONF_BASE64)
         arg_parser.add_argument("--app", default=DEFAULT_INI_APP)
         # daemon related options...
-        arg_parser.add_argument("-d", "--daemonize", default=False, help=HELP_DAEMONIZE, action="store_true")
-        arg_parser.add_argument("--daemon-log-file", default=None, help="Log file for daemon, if --daemonize supplied.")
-        arg_parser.add_argument("--pid-file", default=DEFAULT_PID, help="Pid file for daemon, if --daemonize supplied (default is %s)." % DEFAULT_PID)
+        arg_parser.add_argument("-d", "--daemon", "--daemonize", dest="daemonize", default=False, help=HELP_DAEMONIZE, action="store_true")
+        arg_parser.add_argument(
+            "--log-file", "--daemon-log-file", dest="daemon_log_file", default=None,
+            help="Log file for daemon (default is %s)." % DEFAULT_DAEMON_LOG,
+        )
+        arg_parser.add_argument(
+            "--pid", "--pid-file", dest="pid_file", default=DEFAULT_PID,
+            help="Pid file for daemon (default is %s)." % DEFAULT_PID,
+        )
+        arg_parser.add_argument("--stop-daemon", default=False, help="Stop a running daemon by reading the PID file.", action="store_true")
 
     def load(self):
         load_kwds = dict(
@@ -359,36 +369,43 @@ def main(argv=None, config_env=False):
 
     pid_file = args.pid_file
 
+    if args.stop_daemon:
+        return stop_daemon(pid_file)
+
     log.setLevel(logging.DEBUG)
     log.propagate = False
 
     if args.daemonize:
         if Daemonize is None:
-            raise ImportError(REQUIRES_DAEMONIZE_MESSAGE)
+            arg_parser.error(REQUIRES_DAEMONIZE_MESSAGE)
 
-        keep_fds = []
-        if args.daemon_log_file:
-            fh = logging.FileHandler(args.daemon_log_file, "w")
-            fh.setLevel(logging.DEBUG)
-            log.addHandler(fh)
-            keep_fds.append(fh.stream.fileno())
-        else:
-            fh = logging.StreamHandler(sys.stderr)
-            fh.setLevel(logging.DEBUG)
-            log.addHandler(fh)
+        daemon_log_file = os.path.abspath(args.daemon_log_file or DEFAULT_DAEMON_LOG)
+        fh = logging.FileHandler(daemon_log_file, "a")
+        fh.setLevel(logging.DEBUG)
+        log.addHandler(fh)
+        output_fd = fh.stream.fileno()
 
         daemon = Daemonize(
             app="pulsar",
             pid=pid_file,
-            action=functools.partial(app_loop, args, log, config_env),
+            action=functools.partial(_daemon_app_loop, args, log, config_env, output_fd),
             verbose=DEFAULT_VERBOSE,
             logger=log,
-            keep_fds=keep_fds,
+            keep_fds=[output_fd],
         )
         daemon.start()
     else:
         app_loop(args, log, config_env)
 
 
+def _daemon_app_loop(args, log, config_env, output_fd):
+    """Restore daemon output after daemonize redirects standard streams."""
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os.dup2(output_fd, sys.stdout.fileno())
+    os.dup2(output_fd, sys.stderr.fileno())
+    app_loop(args, log, config_env)
+
+
 if __name__ == "__main__":
-    main(config_env=True)
+    sys.exit(main(config_env=True))

--- a/pulsar/scripts/serve.py
+++ b/pulsar/scripts/serve.py
@@ -43,7 +43,7 @@ def main(argv=None):
     log_file = args.log_file
 
     if args.stop_daemon:
-        return _stop_daemon(pid_file or "pulsar.pid")
+        return stop_daemon(pid_file or "pulsar.pid")
 
     # Read server settings from INI
     host, port, ssl_pem = _read_server_config(config_file)
@@ -123,8 +123,8 @@ def _daemonize(pid_file, log_file):
     os.close(log_fd)
 
 
-def _stop_daemon(pid_file):
-    """Stop a daemonized pulsar-serve process."""
+def stop_daemon(pid_file):
+    """Stop a daemonized Pulsar process."""
     if not os.path.exists(pid_file):
         print("No PID file found at %s" % pid_file, file=sys.stderr)
         return 1

--- a/scripts/pulsar
+++ b/scripts/pulsar
@@ -137,13 +137,6 @@ elif [ "$MODE" == "paster" ]; then
     echo "Starting pulsar with command [pulsar-serve \"$PULSAR_CONFIG_FILE\" \"$@\"]"
     pulsar-serve "$PULSAR_CONFIG_FILE" "$@"
 elif [ "$MODE" == "webless" ]; then
-    # Unlike the other modes above, this branch used to ignore "$@"
-    # entirely, so flags such as --daemon were silently dropped and Pulsar
-    # ran attached to the caller's terminal instead of backgrounding itself.
-    # pulsar-main also does not share pulsar-serve's flag names: it exposes
-    # -d/--daemonize (not --daemon) and has no --stop-daemon support at all,
-    # so translate/validate before forwarding rather than passing "$@"
-    # through unchanged.
     WEBLESS_ARGS=()
     for arg in "$@"; do
         case "$arg" in

--- a/scripts/pulsar
+++ b/scripts/pulsar
@@ -137,18 +137,40 @@ elif [ "$MODE" == "paster" ]; then
     echo "Starting pulsar with command [pulsar-serve \"$PULSAR_CONFIG_FILE\" \"$@\"]"
     pulsar-serve "$PULSAR_CONFIG_FILE" "$@"
 elif [ "$MODE" == "webless" ]; then
+    # Unlike the other modes above, this branch used to ignore "$@"
+    # entirely, so flags such as --daemon were silently dropped and Pulsar
+    # ran attached to the caller's terminal instead of backgrounding itself.
+    # pulsar-main also does not share pulsar-serve's flag names: it exposes
+    # -d/--daemonize (not --daemon) and has no --stop-daemon support at all,
+    # so translate/validate before forwarding rather than passing "$@"
+    # through unchanged.
+    WEBLESS_ARGS=()
+    for arg in "$@"; do
+        case "$arg" in
+          --daemon)
+              WEBLESS_ARGS+=("--daemonize")
+              ;;
+          --stop-daemon)
+              echo "pulsar-main does not support --stop-daemon. Stop the process directly (see its --pid-file), or manage it with a process supervisor, e.g. 'pulsar-config --supervisor'." 1>&2
+              exit 1
+              ;;
+          *)
+              WEBLESS_ARGS+=("$arg")
+              ;;
+        esac
+    done
     if hash pulsar-main 2>/dev/null; then
         # Running from pip install since
         # pulsar-main is available on PATH.
-        echo "Starting pulsar with command [pulsar-main]"
-        pulsar-main
+        echo "Starting pulsar with command [pulsar-main ${WEBLESS_ARGS[@]}]"
+        pulsar-main "${WEBLESS_ARGS[@]}"
     else
         # Running locally.
         PROJECT_DIRECTORY=$PULSAR_SCRIPTS_DIR/..
         cd $PROJECT_DIRECTORY
         export PYTHONPATH=.:$PYTHONPATH
-        echo "Starting pulsar with command [python pulsar/main.py]"
-        python pulsar/main.py
+        echo "Starting pulsar with command [python pulsar/main.py ${WEBLESS_ARGS[@]}]"
+        python pulsar/main.py "${WEBLESS_ARGS[@]}"
     fi
 else
     echo "Unknown mode passed to --mode argument." 1>&2

--- a/scripts/pulsar
+++ b/scripts/pulsar
@@ -137,33 +137,18 @@ elif [ "$MODE" == "paster" ]; then
     echo "Starting pulsar with command [pulsar-serve \"$PULSAR_CONFIG_FILE\" \"$@\"]"
     pulsar-serve "$PULSAR_CONFIG_FILE" "$@"
 elif [ "$MODE" == "webless" ]; then
-    WEBLESS_ARGS=()
-    for arg in "$@"; do
-        case "$arg" in
-          --daemon)
-              WEBLESS_ARGS+=("--daemonize")
-              ;;
-          --stop-daemon)
-              echo "pulsar-main does not support --stop-daemon. Stop the process directly (see its --pid-file), or manage it with a process supervisor, e.g. 'pulsar-config --supervisor'." 1>&2
-              exit 1
-              ;;
-          *)
-              WEBLESS_ARGS+=("$arg")
-              ;;
-        esac
-    done
     if hash pulsar-main 2>/dev/null; then
         # Running from pip install since
         # pulsar-main is available on PATH.
-        echo "Starting pulsar with command [pulsar-main ${WEBLESS_ARGS[@]}]"
-        pulsar-main "${WEBLESS_ARGS[@]}"
+        echo "Starting pulsar with command [pulsar-main \"$@\"]"
+        pulsar-main "$@"
     else
         # Running locally.
-        PROJECT_DIRECTORY=$PULSAR_SCRIPTS_DIR/..
+        PROJECT_DIRECTORY=$SCRIPTS_DIRECTORY/..
         cd $PROJECT_DIRECTORY
         export PYTHONPATH=.:$PYTHONPATH
-        echo "Starting pulsar with command [python pulsar/main.py ${WEBLESS_ARGS[@]}]"
-        python pulsar/main.py "${WEBLESS_ARGS[@]}"
+        echo "Starting pulsar with command [python pulsar/main.py \"$@\"]"
+        python pulsar/main.py "$@"
     fi
 else
     echo "Unknown mode passed to --mode argument." 1>&2

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
     install_requires=requirements,
     extras_require={
         'amqp': ['kombu'],
+        'daemon': ['daemonize; sys_platform != "win32"'],
         'web': ['gunicorn'],
         'galaxy_extended_metadata': ['galaxy-job-execution', 'galaxy-util[template]'],
     },

--- a/test/cli_help_tests.py
+++ b/test/cli_help_tests.py
@@ -1,4 +1,5 @@
 import pulsar.client.test.check
+import pulsar.main
 import pulsar.scripts.chown_working_directory
 import pulsar.scripts.drmaa_kill
 import pulsar.scripts.drmaa_launch
@@ -7,6 +8,7 @@ import pulsar.scripts.mesos_framework
 import pulsar.scripts.submit
 
 MODULES = [
+    pulsar.main,
     pulsar.scripts.drmaa_kill,
     pulsar.scripts.drmaa_launch,
     pulsar.scripts.mesos_executor,

--- a/test/main_util_test.py
+++ b/test/main_util_test.py
@@ -1,5 +1,8 @@
 """ Test utilities in pulsar.main """
+from argparse import ArgumentParser
 from os.path import join
+
+import pytest
 
 from pulsar import main
 from .test_utils import temp_directory
@@ -79,6 +82,88 @@ def test_pulsar_manager_config_builder_overrides():
         assert as_dict["app"] == "cool1"
 
 
+def test_daemon_argument_aliases():
+    for daemon_flag in ["-d", "--daemon", "--daemonize"]:
+        args = _parse_main_args([daemon_flag])
+        assert args.daemonize
+
+    args = _parse_main_args([
+        "--daemon",
+        "--log-file", "custom.log",
+        "--pid", "custom.pid",
+    ])
+    assert args.daemon_log_file == "custom.log"
+    assert args.pid_file == "custom.pid"
+
+    legacy_args = _parse_main_args([
+        "--daemonize",
+        "--daemon-log-file", "legacy.log",
+        "--pid-file", "legacy.pid",
+    ])
+    assert legacy_args.daemon_log_file == "legacy.log"
+    assert legacy_args.pid_file == "legacy.pid"
+
+
+def test_stop_daemon_uses_shared_helper(monkeypatch):
+    stopped = []
+    monkeypatch.setattr(main, "stop_daemon", lambda pid_file: stopped.append(pid_file) or 0)
+    monkeypatch.setattr(main, "app_loop", lambda *args: pytest.fail("app should not start"))
+
+    assert main.main(["--stop-daemon", "--pid", "custom.pid"]) == 0
+    assert stopped == ["custom.pid"]
+
+
+def test_daemon_defaults_to_pulsar_log(monkeypatch, tmp_path):
+    daemon_options = {}
+
+    class MockDaemonize:
+
+        def __init__(self, **kwds):
+            daemon_options.update(kwds)
+
+        def start(self):
+            daemon_options["started"] = True
+
+    original_handlers = list(main.log.handlers)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(main, "Daemonize", MockDaemonize)
+    try:
+        main.main(["--daemon"])
+    finally:
+        for handler in set(main.log.handlers) - set(original_handlers):
+            main.log.removeHandler(handler)
+            handler.close()
+
+    assert daemon_options["started"]
+    assert len(daemon_options["keep_fds"]) == 1
+    assert (tmp_path / "pulsar.log").exists()
+
+
+def test_daemon_app_loop_redirects_output(monkeypatch):
+    dup2_calls = []
+    app_loop_calls = []
+    monkeypatch.setattr(main.os, "dup2", lambda source, target: dup2_calls.append((source, target)))
+    monkeypatch.setattr(main, "app_loop", lambda *args: app_loop_calls.append(args))
+
+    main._daemon_app_loop("args", "log", True, 42)
+
+    assert dup2_calls == [
+        (42, main.sys.stdout.fileno()),
+        (42, main.sys.stderr.fileno()),
+    ]
+    assert app_loop_calls == [("args", "log", True)]
+
+
+def test_missing_daemon_dependency_has_install_hint(monkeypatch, capsys):
+    monkeypatch.setattr(main, "Daemonize", None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main.main(["--daemon"])
+
+    assert exc_info.value.code == 2
+    assert "pip install 'pulsar-app[daemon]'" in capsys.readouterr().err
+
+
 class MockArgs:
 
     def __init__(self, ini_path, app):
@@ -86,6 +171,12 @@ class MockArgs:
         self.app_conf_path = None
         self.app_conf_base64 = None
         self.app = app
+
+
+def _parse_main_args(argv):
+    parser = ArgumentParser()
+    main.PulsarConfigBuilder.populate_options(parser)
+    return parser.parse_args(argv)
 
 
 def __write_mock_ini(path, **kwds):

--- a/test/pulsar_script_test.py
+++ b/test/pulsar_script_test.py
@@ -1,0 +1,30 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_webless_mode_forwards_arguments_unchanged(tmp_path):
+    captured_args = tmp_path / "args"
+    pulsar_main = tmp_path / "pulsar-main"
+    pulsar_main.write_text("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$PULSAR_ARG_CAPTURE\"\n")
+    pulsar_main.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = "%s%s%s" % (tmp_path, os.pathsep, env["PATH"])
+    env["PULSAR_ARG_CAPTURE"] = str(captured_args)
+    pulsar_script = Path(__file__).parents[1] / "scripts" / "pulsar"
+    forwarded_args = [
+        "--daemon",
+        "--pid", "custom pid",
+        "--log-file", "custom log",
+        "--custom-option", "custom value",
+    ]
+
+    subprocess.run(
+        [str(pulsar_script), "--mode", "webless"] + forwarded_args,
+        cwd=str(tmp_path),
+        env=env,
+        check=True,
+    )
+
+    assert captured_args.read_text().splitlines() == forwarded_args


### PR DESCRIPTION
## Summary

This is a rebased and expanded replacement for #480. It retains @gkr0110's original commits and authorship while addressing the review concerns around the first implementation.

- forward webless arguments unchanged instead of translating them in Bash
- give `pulsar-main` the same daemon, PID, log, and stop flag names as `pulsar-serve`, while retaining its existing aliases
- reuse the existing daemon-stop helper
- default daemon output to `pulsar.log` and redirect stdout/stderr there after `daemonize` replaces the standard descriptors
- add a `daemon` installation extra and an actionable error when it is unavailable
- fix the local webless-launch path and update the CLI documentation/history

## Testing

- full unit suite: 308 passed, 63 skipped
- focused CLI and shell-forwarding tests
- flake8
- isort
- `bash -n scripts/pulsar`
- `git diff --check`
- wheel build and daemon-extra metadata inspection

Thanks to @gkr0110 for identifying and fixing the original argument-dropping bug.
