### PR TITLE
Fix typos and grammar in documentation

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -3,7 +3,7 @@ Pulsar Project Code of Conduct
 ------------------------------
 
 This code of conduct outlines our expectations for participants within the
-Pulsar community, as well as steps to reporting unacceptable behavior. We are
+Pulsar community, as well as steps for reporting unacceptable behavior. We are
 committed to providing a welcoming and inspiring community for all and expect
 our code of conduct to be honored. Anyone who violates this code of conduct may
 be banned from the community.
@@ -19,10 +19,10 @@ Our open source community strives to:
   orientation, gender identity and expression, age, size, family status,
   political belief, religion, and mental and physical ability.
 
-* **Be considerate**: Your work will be used by other people, and you in turn
+* **Be considerate**: Your work will be used by other people, and you, in turn,
   will depend on the work of others. Any decision you take will affect users
   and colleagues, and you should take those consequences into account when
-  making decisions. Remember that we're a world-wide community, so you might
+  making decisions. Remember that we're a worldwide community, so you might
   not be communicating in someone else's primary language.
 
 * **Be respectful**: Not all of us will agree all the time, but disagreement is
@@ -34,13 +34,13 @@ Our open source community strives to:
 * **Be careful in the words that we choose**: We are a community of
   professionals, and we conduct ourselves professionally. Be kind to others. Do
   not insult or put down other participants. Harassment and other exclusionary
-  behavior aren't acceptable. This includes, but is not limited to: Violent
-  threats or language directed against another person, Discriminatory jokes and
-  language, Posting sexually explicit or violent material, Posting (or
+  behavior aren't acceptable. This includes, but is not limited to: violent
+  threats or language directed against another person, discriminatory jokes and
+  language, posting sexually explicit or violent material, posting (or
   threatening to post) other people’s personally identifying information
-  (“doxing”), Personal insults, especially those using racist or sexist terms,
-  Unwelcome sexual attention, Advocating for, or encouraging, any of the above
-  behavior, Repeated harassment of others. In general, if someone asks you to
+  (“doxing”), personal insults, especially those using racist or sexist terms,
+  unwelcome sexual attention, advocating for, or encouraging, any of the above
+  behavior, repeated harassment of others. In general, if someone asks you to
   stop, then stop.
 
 * **Try to understand why we disagree**: Disagreements, both social and
@@ -57,7 +57,7 @@ Diversity Statement
 -------------------
 
 We encourage everyone to participate and are committed to building a community
-for all. Although we will fail at times, we seek to treat everyone both as
+for all. Although we will fail at times, we seek to treat everyone as
 fairly and equally as possible. Whenever a participant has made a mistake, we
 expect them to take responsibility for it. If someone has been harmed or
 offended, it is our responsibility to listen carefully and respectfully, and do
@@ -79,7 +79,7 @@ the most comfortable:
 
 - Dave Clements (clementsgalaxy@gmail.com). Dave is the Galaxy Project community
   outreach manager and has experience handling Code of Conduct related issues.
-- Dr. Mike Schatz (mschatz@cs.jhu.edu). Mike is Dave Clements' direct manager
+- Dr. Mike Schatz (mschatz@cs.jhu.edu). Mike is Dave Clements' direct manager,
   and issues related to Dave in some way should be reported to Mike.
 - Helena Rasche (helena.rasche@gmail.com). Helena is a well-known, trusted
   community member, is LGBT+, and has completely separate funding and

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,8 +3,8 @@ Contributing
 ============
 
 Please note that this project is released with a `Contributor Code of Conduct
-<https://pulsar.readthedocs.org/en/latest/conduct.html>`. By participating in
-this project you agree to abide by its terms.
+<https://pulsar.readthedocs.org/en/latest/conduct.html>`_. By participating in
+this project, you agree to abide by its terms.
 
 Contributions are welcome, and they are greatly appreciated! Every
 little bit helps, and credit will always be given.
@@ -21,7 +21,7 @@ Report bugs at https://github.com/galaxyproject/pulsar/issues.
 
 If you are reporting a bug, please include:
 
-* Your operating system name and version, versions of other relevant software 
+* Your operating system name and version, along with versions of any other relevant software,
   such as Galaxy or Docker.
 * Links to relevant tools.
 * Any details about your local setup that might be helpful in troubleshooting.
@@ -31,19 +31,19 @@ Fix Bugs
 ~~~~~~~~
 
 Look through the GitHub issues for bugs. Most things there are up for grabs
-but the tag "Help Wanted" may be particulary good places to start.
+but the tag "Help Wanted" may be a particularly good place to start.
 
 Implement Features
 ~~~~~~~~~~~~~~~~~~
 
 Look through the GitHub issues for features (tagged with "enhancement").
 Again, most things there are up for grabs but the tag "Help Wanted" may be
-particulary good places to start.
+a particularly good place to start.
 
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-Pulsar is cronically under documented, whether as part of the
+Pulsar is chronically underdocumented, whether as part of the
 official Pulsar docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
@@ -55,7 +55,7 @@ The best way to send feedback is to file an issue at https://github.com/galaxypr
 If you are proposing a feature:
 
 * Explain in detail how it would work.
-* Keep the scope as narrow as possible, to make it easier to implement.
+* Keep the scope as narrow as possible to make it easier to implement.
 * This will hopefully become a community-driven project and contributions
   are welcome :)
 
@@ -89,15 +89,15 @@ Ready to contribute? Here's how to set up `pulsar` for local development.
 
     $ make lint
 
-and ensure the tests look good. The easiest way to test is with Docker if it is
+And ensure the tests look good. The easiest way to test is with Docker if it is
 available (given the need to test commands with DRMAA, condor, sudo, etc...).::
 
     $ docker run -v `pwd`:/pulsar -t jmchilton/pulsar_testing
 
 This will mount your copy of `pulsar` in a Docker container preconfigured with all
 optional dependencies needed to run a wide range of integration tests. If Docker
-is to much of an ordeal many of Pulsar's tests can be executed by simply running 
-``pytest`` from within an ``virtualenv`` configured as explained above.::
+is too much of an ordeal, many of Pulsar's tests can be executed by simply running
+``pytest`` from within a ``virtualenv`` configured as explained above.::
 
     $ make tests
 

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 
 This project is a Python server application that allows a `Galaxy
 <http://galaxyproject.org>`_ server to run jobs on remote systems (including
-Windows) without requiring a shared mounted file systems. Unlike traditional
+Windows) without requiring a shared mounted file system. Unlike traditional
 Galaxy job runners - input files, scripts, and config files may be transferred
 to the remote system, the job is executed, and the results are transferred back
 to the Galaxy server - eliminating the need for a shared file system.
@@ -43,7 +43,7 @@ Quickstart
 Full details on different ways to install Pulsar can be found in the `install
 section <https://pulsar.readthedocs.org/en/latest/install.html>`__ of the
 documentation, but if your machine has the proper Python dependencies
-available it can be quickly download and a test job run with::
+available, it can be quickly downloaded and a test job run with::
 
     $ mkdir pulsar
     $ cd pulsar
@@ -81,7 +81,7 @@ changes you make to the source code will be reflected when running the pulsar
 commands installed in the virtual environment.
 
 This project is distributed with unit and integration tests (many of which will
-not run under Windows), the following command will install the needed python
+not run under Windows). The following command will install the needed python
 components to run these tests. The following command will then run these tests::
 
     $ make tests
@@ -98,7 +98,7 @@ for many more details on developing and contributing to Pulsar.
 
 Please note that this project is released with a `Contributor Code of Conduct
 <https://pulsar.readthedocs.org/en/latest/conduct.html>`__. By participating
-in this project you agree to abide by its terms.
+in this project, you agree to abide by its terms.
 
 -----------------------
 Support
@@ -107,7 +107,7 @@ Support
 This documentation is an incomplete work in progress. There are more ways to
 configure and use Pulsar than are documented, and a growing number of Pulsar
 experts who would be more than happy to answer your questions and help with any
-problems you may run in to while setting up a Pulsar deployment. Please do not
+problems you may run into while setting up a Pulsar deployment. Please do not
 hesitate to reach out on the `Galaxy Admins Gitter Channel`_
 
 .. _Galaxy Admins Gitter Channel: https://gitter.im/galaxyproject/admins

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -29,7 +29,7 @@ Security
 
 Out of the box, **Pulsar essentially allows anyone with network access to the
 Pulsar server to execute arbitrary code and read and write any files the web
-server can access.** Hence, in most settings steps should be taken to secure the
+server can access.** Hence, in most settings, steps should be taken to secure the
 Pulsar server.
 
 Private Token
@@ -52,19 +52,19 @@ use.
 
 .. tip::
 
-    SSL support is built in to `uWSGI`_, an alternate webserver that can be
+    SSL support is built in to `uWSGI`_, an alternate web server that can be
     installed (see :ref:`install`).
 
-``pyOpenSSL`` is required to configure a Pulsar web server to server content via
+``pyOpenSSL`` is required to configure a Pulsar web server to serve content via
 HTTPS/SSL. This dependency can be difficult to install and seems to be getting
 more difficult. Under Linux you will want to ensure the needed dependencies to
-compile pyOpenSSL are available - for instance in a fresh Ubuntu image you
+compile pyOpenSSL are available - for instance, in a fresh Ubuntu image, you
 will likely need::
 
     $ sudo apt-get install libffi-dev python3-dev libssl-dev
 
 Then pyOpenSSL can be installed with the following command (be sure to source
-your virtualenv if setup above)::
+your virtualenv if set up above)::
 
     $ pip install pyOpenSSL
 
@@ -119,8 +119,8 @@ You can configure Pulsar to authenticate user during request processing and chec
 if this user is allowed to run a job.
 
 Various authentication/authorization plugins can be configured in `app.yml` to
-do that and plugin parameters depend on auth type. For example, the following
-configuration uses `oidc` plugin for authentication and `userlist` for
+do that and plugin parameters depend on the auth type. For example, the following
+configuration uses the `oidc` plugin for authentication and `userlist` for
 authorization::
 
     user_auth:
@@ -136,7 +136,7 @@ authorization::
             - xxx
 
 
-see `plugins folder
+See the `plugins folder
 <https://github.com/galaxyproject/pulsar/blob/master/pulsar/user_auth/methods>`_
 for available plugins and their parameters.
 
@@ -145,12 +145,12 @@ Customizing the Pulsar Environment (\*nix only)
 
 For many deployments, Pulsar's environment will need to be tweaked. For
 instance to define a ``DRMAA_LIBRARY_PATH`` environment variable for the
-``drmaa`` Python module or to define the location to a find a location of
+``drmaa`` Python module or to define the location of
 Galaxy (via ``GALAXY_HOME``) if certain Galaxy tools require it or if Galaxy
 metadata is being set by the Pulsar.
 
 The file ``local_env.sh`` (created automatically by ``pulsar-config``) will be
-source by ``pulsar`` before launching the application and by child process
+sourced by ``pulsar`` before launching the application and by child processes
 created by Pulsar that require this configuration.
 
 Job Managers (Queues)

--- a/docs/containers.rst
+++ b/docs/containers.rst
@@ -137,17 +137,17 @@ Galaxy and Shared File Systems
 
 Galaxy can be configured to run Pulsar with traditional job managers and just submit jobs
 that launch containers. Simply setting ``docker_enabled`` on the job environment in Galaxy's
-job_conf.yml file will accomplish this.
+``job_conf.yml`` file will accomplish this.
 
-There are limitations to using DRM systems that submit job scripts that launch containers
-though. Modern container scheduling environments (AWS Batch or Kubernetes or instance) are
+There are limitations to using DRM systems that submit job scripts that launch containers,
+though. Modern container scheduling environments (AWS Batch or Kubernetes, for instance) are
 capable of scheduling containers directly. This is conceptually cleaner, presumably scales better,
-and side steps all sorts of issues for the deployer and developer such as configuring Docker and
+and sidesteps all sorts of issues for the deployer and developer such as configuring Docker and
 managing the interaction between the DRM and the container host server (i.e. the Docker server).
 
 There are a couple approaches to scheduling containers directly in Galaxy - such as the Galaxy
-Kubernetes runner and the Galaxy AWS Batch runner. These approaches require Galaxy be deployed
-alongside the compute infrasture (i.e. on Amazon with the same EFS volume or inside of Kubernetes
+Kubernetes runner and the Galaxy AWS Batch runner. These approaches require Galaxy to be deployed
+alongside the compute infrastructure (i.e. on Amazon with the same EFS volume or inside of Kubernetes
 with the same mounts).
 
 These two scenarios and some of their limitations are described below.
@@ -162,27 +162,27 @@ These two scenarios and some of their limitations are described below.
 
 The most glaring disadvantage of not using Pulsar in the above scenarios is that Galaxy must
 be deployed in the same container with the same mounts as the job execution environment. This
-prevents leveraging external cloud compute, multi-cloud compute, and makes it unsuitable for
-common Galaxy use cases such as large public instances, Galaxy's leveraging institution non-cloud
-storage, etc... Even within the same cloud - a large shared file system can be an expensive prospect
-and Pulsar may allow making use of buckets and such more tractable. Finally, Pulsar offers more
-options in terms of how to collect metadata which can have big implications in terms of metadata.
+prevents leveraging external cloud and multi-cloud compute and makes it unsuitable for
+common Galaxy use cases such as large public instances and Galaxy deployments using institutional,
+non-cloud storage. Even within the same cloud, a large shared file system can be expensive. Pulsar may
+make the use of buckets and similar storage more tractable. Finally, Pulsar offers more
+options in terms of how to collect metadata, which can have big implications in terms of metadata.
 
 Co-execution
 -------------------------------
 
-Galaxy job inputs and outputs are very flexible and staging up job inputs, configs, and scripts,
-and staging down results doesn't map cleanly to cloud APIs and cannot be fully reasoned about
-until job runtime. For this reason, code that needs to know how stage Galaxy jobs up and down needs
-to run in the cloud when disk isn't shared and Galaxy cannot do this directly. Galaxy jobs however
-are typically executed in Biocontainers that are minimal containers just for the tool being executed
-and not appropriate for executing Galaxy code.
+Galaxy job inputs and outputs are very flexible, and staging up job inputs, configs, and scripts
+and staging down results do not map cleanly to cloud APIs and cannot be fully reasoned about
+until job runtime. For this reason, code that needs to know how to stage Galaxy jobs up and down needs
+to run in the cloud when the disk isn't shared, and Galaxy cannot do this directly. Galaxy jobs,
+however, are typically executed in minimal BioContainers images designed specifically for the tool
+being executed and are not appropriate for executing Galaxy code.
 
-For this reason, the Pulsar runners that schedule containers will run a container beside (or before
-and after) that is responsible for staging the job up and down, communicating with Galaxy, etc..
+For this reason, the Pulsar runners that schedule containers run a Pulsar container beside the tool
+container (or before and after it) to stage the job up and down and communicate with Galaxy.
 
 Perhaps the most typical potential scenario is using the Kubernetes Job API along with a message queue
-for communication with Galaxy and a Biocontainer. A diagram for this deployment would look something
+for communication with Galaxy and a BioContainer. A diagram for this deployment would look something
 like:
 
 .. figure:: pulsar_k8s_coexecution_mq_deployment.plantuml.svg
@@ -199,19 +199,19 @@ like:
 
 .. figure:: pulsar_tes_coexecution_mq_deployment.plantuml.svg
 
-Notice when executing jobs on Kubernetes, the containers of the pod run concurrrently. The Pulsar container
-will compute a command-line and write it out, the tool container will wait for it on boot and execute it
-when available, while the Pulsar container waits for a return code from the tool container to proceed to
-staging out the job. In the GA4GH TES case, 3 containers are used instead of 2, but they run sequentially
+Notice when executing jobs on Kubernetes, the containers of the pod run concurrently. The Pulsar container
+will compute a command line and write it out. The tool container will wait for it on boot and execute it
+when available, while the Pulsar container expects a return code from the tool container to proceed to
+staging out the job. In the GA4GH TES case, three containers are used instead of two, but they run sequentially
 one at a time.
 
-Typically, a MQ is needed to communicate between Pulsar and Galaxy even though the status of the job
+Typically, a message queue is needed to communicate between Pulsar and Galaxy, even though the status of the job
 could potentially be inferred from the container scheduling environment. This is because Pulsar needs
 to transfer information about job state, etc. after the job is complete.
 
 More experimentally this shouldn't be needed if extended metadata is being collected because then the
 whole job state that needs to be ingested by Galaxy should be populated as part of the job. In this case
-it may be possible to get away without a MQ.
+it may be possible to get away without a message queue.
 
 .. figure:: pulsar_k8s_coexecution_deployment.plantuml.svg
 
@@ -223,7 +223,7 @@ Kubernetes
 
 .. figure:: pulsar_k8s_coexecution_mq_deployment.plantuml.svg
 
-   Kuberentes job execution with a biocontainer for the tool and RabbitMQ for communicating with
+   Kubernetes job execution with a biocontainer for the tool and RabbitMQ for communicating with
    Galaxy.
 
 .. figure:: pulsar_k8s_mq_deployment.plantuml.svg
@@ -293,8 +293,8 @@ A Galaxy job configuration (job_conf.yml) for using TES with Pulsar and RabbitMQ
    - class: local
      environment: local
 
-For testing on a Macbook with RabbitMQ installed via homebrew and Docker Desktop available
-and a Funnel with default configuration server running locally, a configuration might look like:
+For testing on a MacBook with RabbitMQ installed via Homebrew and Docker Desktop available,
+and with a Funnel server running locally using its default configuration, the configuration might look like:
 
 ::
 

--- a/docs/galaxy_conf.rst
+++ b/docs/galaxy_conf.rst
@@ -38,7 +38,7 @@ jobs to the remote cluster - namely the ``trinity`` and ``abyss`` tools.
 .. literalinclude:: files/job_conf_sample_remote_cluster.yml
    :language: yaml
 
-For this configuration, on the Pulsar side be sure to also set a
+For this configuration, on the Pulsar side, be sure to also set a
 ``DRMAA_LIBRARY_PATH`` in ``local_env.sh``, install the Python ``drmaa``
 module, and configure a DRMAA job manager for Pulsar in ``app.yml`` as described
 in :ref:`job_managers`.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -18,7 +18,7 @@ using the standard pip_ and venv_ Python tools.
 
 The older method also requires these tools to install Pulsar's dependencies
 but Pulsar itself is served directly from a clone of the Pulsar source tree -
-this mirrors how `Galaxy`_ is most typically deployed. This may be beneficial
+this mirrors how Galaxy_ is most typically deployed. This may be beneficial
 during Pulsar development and is required for certain experimental features such
 as Mesos support.
 
@@ -29,7 +29,7 @@ Both methods presented here require a Python 3.5 (or later) runtime for either
 no longer supported as of the 0.14.0 release of Pulsar**.
 
 These instructions also require venv_. Open a console on your machine and
-type ``python3 -m venv`` - if the module is missing you will need to install it.
+type ``python3 -m venv`` - if the module is missing, you will need to install it.
 It is part of any full Python installation, but some Linux distributions (such
 as Debian and its derivatives) package it separately. On Debian systems, you can
 
@@ -155,7 +155,7 @@ Finally, install Pulsar's required dependencies into the virtual environment::
 
     $ pip install -r requirements.txt
 
-If using the standard webserver, install gunicorn with::
+If using the standard web server, install gunicorn with::
 
     $ pip install gunicorn
 
@@ -192,13 +192,13 @@ job can be submitted using the command::
 If Pulsar's ``server.ini`` has been modified and it is not running on the
 default port ``8913``, ``run_client_tests.py`` should be called with an
 explicit URL using the argument ``--url=http://localhost:8913``. Likewise if a
-private token has been configured it can be supplied using
+private token has been configured, it can be supplied using
 ``--private_token=<token>``.
 
 Pulsar Webservers
 ----------------------
 
-Pulsar's default webserver (if web dependencies are installed) is `gunicorn`_.
+Pulsar's default web server (if web dependencies are installed) is `gunicorn`_.
 However, `uWSGI`_ or `circus`_ will be used instead, if found.
 
 A precompiled version of uWSGI can be installed with::
@@ -214,9 +214,9 @@ Pulsar Dependencies
 
 Several Python packages must be installed to run the Pulsar server. The core set
 of required dependencies were installed during the Pulsar installation in the
-previous section. Additional dependencies are required for features such
+previous section. Additional dependencies are required for features such as
 submitting to a cluster (``drmaa``), communicating via message queue
-(``kombu``), etc.... Most of the time these can just be installed with ``pip
+(``kombu``), etc. Most of the time, these can just be installed with ``pip
 install <dependency_name>``.
 
 .. TODO better optional dependency handling/docs

--- a/docs/organization.rst
+++ b/docs/organization.rst
@@ -23,7 +23,7 @@ is currently too small to support full and open governance at this time. In
 order to keep things evolving quickly, it is better to keep procedures and
 process to a minimum and centralize important decisions with a trusted
 developer. The BDFN is explicitly meant to be replaced with a more formal and
-democratice process if the project grows to a sufficient size or importance.
+democratic process if the project grows to a sufficient size or importance.
 
 The *committers* group is the group of trusted developers and advocates who
 manage the Pulsar code base. They assume many roles required to achieve
@@ -35,7 +35,7 @@ discretion, but everyone (including the BDFN) should open pull requests for
 larger changes.
 
 In order to encourage a shared sense of ownership and openness, any committer
-may decide at any time to request a open governance model for the project be
+may decide at any time to request an open governance model for the project be
 established and the BDFN must replace this informal policy with a more formal
 one and work with the project committers to establish a consensus on these
 procedures.

--- a/docs/public_server.rst
+++ b/docs/public_server.rst
@@ -4,14 +4,14 @@ Configuring a Public Pulsar Server
 
 (This is highly experimental and not recommended at this time.)
 
-An Pulsar server can be pointed at a Galaxy toolbox XML file and opened
-to the world. By default, an Pulsar is allowed to run anything Galaxy (or
+A Pulsar server can be pointed at a Galaxy toolbox XML file and opened
+to the world. By default, a Pulsar server is allowed to run anything Galaxy (or
 other client) sends it. The toolbox and referenced tool files are used
-to restrict what what the Pulsar will run.
+to restrict what the Pulsar will run.
 
-This can be sort of thought of as web services defined by Galaxy tool
+This can be thought of as web services defined by Galaxy tool
 files - with all the advantages (dead simple configuration for
-clients, ability to hide details related date and computation) and
+clients, ability to hide details related to data and computation) and
 disadvantages (lack of reproducibility if the Pulsar server goes away,
 potential lack of transparency).
 
@@ -19,10 +19,10 @@ Securing a Public Pulsar
 -----------------------------
 
 The following options should be set in ``server.ini`` to configure a
-public `Pulsar` server.
+public Pulsar server.
 
-- ``assign_ids=uuid`` - By default the `Pulsar` will just the ids Galaxy
-  instances. Setting this setting to ``uuid`` will result in each job
+- ``assign_ids=uuid`` - By default, Pulsar will use the IDs supplied by Galaxy
+  instances. Setting this option to ``uuid`` will result in each job
   being assigned a UUID, ensuring different clients will not and
   cannot interfere with each other.
 
@@ -35,10 +35,9 @@ public `Pulsar` server.
 Writing Secure Tools
 --------------------
 
-Validating in this fashion is complicated and potentially error prone,
-so it is advisable to keep command-lines as simple as
-possible. configfiles and reorganizing parameter handling in wrappers
-scripts can assist in this.
+Validating in this fashion is complicated and potentially error-prone,
+so it is advisable to keep command lines as simple as possible. Using ``configfiles``
+arguments in wrapper scripts and reorganizing parameter handling can assist with this.
 
 Consider the following simple example:
 
@@ -59,7 +58,7 @@ Consider the following simple example:
          (options, args) = parser.parse_args()
 
 Even this simple example is easier to validate and secure if it is
-reworked as so:
+reworked as follows:
 
 ``tool.xml``::
 


### PR DESCRIPTION
Replacement for #447, rebased onto current master.

This retains Martin Carrere’s valid documentation corrections while resolving the README conflict, removing the unrelated tox dependency change, and correcting malformed links and prose regressions found during review.

The commit preserves Martin as author and credits Matthias Bernt as co-author.

Validation:
- tox -e docs
- git diff --check