### PR TITLE
Fix job recovery startup race

### DIFF
--- a/pulsar/core.py
+++ b/pulsar/core.py
@@ -50,8 +50,11 @@ class PulsarApp:
         self.__setup_user_auth_manager(conf)
         self.__setup_managers(conf)
         self.__setup_file_cache(conf)
+        # Recovery failures need the status callback, but the monitor must not
+        # poll until external job IDs have been restored.
+        self.__setup_bind_to_message_queue(conf, start_monitor=False)
         self.__recover_jobs()
-        self.__setup_bind_to_message_queue(conf)
+        self.__start_manager_monitors(conf)
         self.ensure_cleanup = conf.get("ensure_cleanup", False)
 
     def shutdown(self, timeout=None):
@@ -66,12 +69,22 @@ class PulsarApp:
             if self.ensure_cleanup:
                 self.__queue_state.join(timeout)
 
-    def __setup_bind_to_message_queue(self, conf):
+    def __setup_bind_to_message_queue(self, conf, start_monitor=True):
         message_queue_url = conf.get("message_queue_url", None)
         queue_state = None
         if message_queue_url:
-            queue_state = messaging.bind_app(self, message_queue_url, conf)
+            queue_state = messaging.bind_app(
+                self,
+                message_queue_url,
+                conf,
+                start_monitor=start_monitor,
+            )
         self.__queue_state = queue_state
+
+    def __start_manager_monitors(self, conf):
+        if self.__queue_state and conf.get("message_queue_publish", True):
+            for manager in self.managers.values():
+                manager.start_monitor()
 
     def __setup_user_auth_manager(self, conf):
         self.user_auth_manager = UserAuthManager(conf)

--- a/pulsar/core.py
+++ b/pulsar/core.py
@@ -50,8 +50,8 @@ class PulsarApp:
         self.__setup_user_auth_manager(conf)
         self.__setup_managers(conf)
         self.__setup_file_cache(conf)
-        self.__setup_bind_to_message_queue(conf)
         self.__recover_jobs()
+        self.__setup_bind_to_message_queue(conf)
         self.ensure_cleanup = conf.get("ensure_cleanup", False)
 
     def shutdown(self, timeout=None):

--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -61,8 +61,8 @@ JOB_FILE_PREPROCESSED = "preprocessed"
 JOB_FILE_PREPROCESSING_FAILED = "preprocessing_failed"
 JOB_METADATA_RUNNING = "running"
 
-# LOST is excluded because the monitor starts before external job IDs are
-# recovered; treating it as terminal could discard recoverable jobs at startup.
+# LOST is excluded because it can be transient while external job IDs are
+# being recovered; treating it as terminal could discard recoverable jobs.
 TERMINAL_STATUSES = (status.COMPLETE, status.CANCELLED, status.FAILED)
 
 # Stage outputs before reporting completion or failure to the client.
@@ -102,10 +102,19 @@ class StatefulManagerProxy(ManagerProxy):
         self.__monitor = None
 
     def set_state_change_callback(
-        self, state_change_callback: Callable[[str, str], None]
+        self,
+        state_change_callback: Callable[[str, str], None],
+        start_monitor: bool = True,
     ) -> None:
+        """Bind status publishing, optionally deferring monitor startup."""
         self.__state_change_callback = state_change_callback
-        self.__monitor = ManagerMonitor(self)
+        if start_monitor:
+            self.start_monitor()
+
+    def start_monitor(self) -> None:
+        """Start status polling once, after persisted jobs are recovered."""
+        if self.__monitor is None:
+            self.__monitor = ManagerMonitor(self)
 
     def _default_status_change_callback(
         self, status: "StateLiteral", job_id: str

--- a/pulsar/messaging/__init__.py
+++ b/pulsar/messaging/__init__.py
@@ -14,7 +14,7 @@ from ..messaging import (
 log = logging.getLogger(__name__)
 
 
-def bind_app(app, queue_id, conf=None):
+def bind_app(app, queue_id, conf=None, start_monitor=True):
     connection_string = __id_to_connection_string(app, queue_id)
 
     # Check if this is a relay connection
@@ -32,6 +32,7 @@ def bind_app(app, queue_id, conf=None):
             bind_relay.bind_manager_to_relay(
                 manager, relay_state, relay_url, merged_conf,
                 relay_transport=relay_transport,
+                start_monitor=start_monitor,
             )
             bind_relay.publish_manager_capabilities_to_relay(
                 app, manager, relay_transport, merged_conf,
@@ -41,7 +42,13 @@ def bind_app(app, queue_id, conf=None):
         # Use AMQP binding
         queue_state = QueueState()
         for manager in app.managers.values():
-            bind_amqp.bind_manager_to_queue(manager, queue_state, connection_string, conf)
+            bind_amqp.bind_manager_to_queue(
+                manager,
+                queue_state,
+                connection_string,
+                conf,
+                start_monitor=start_monitor,
+            )
         return queue_state
 
 

--- a/pulsar/messaging/bind_amqp.py
+++ b/pulsar/messaging/bind_amqp.py
@@ -41,7 +41,13 @@ def get_exchange(connection_string, manager_name, conf):
     return pulsar_exchange
 
 
-def bind_manager_to_queue(manager, queue_state, connection_string, conf):
+def bind_manager_to_queue(
+    manager,
+    queue_state,
+    connection_string,
+    conf,
+    start_monitor=True,
+):
     manager_name = manager.name
     log.info("bind_manager_to_queue called for [{}] and manager [{}]".format(mask_password_from_url(connection_string), manager_name))
     pulsar_exchange = get_exchange(connection_string, manager_name, conf)
@@ -91,7 +97,10 @@ def bind_manager_to_queue(manager, queue_state, connection_string, conf):
                     "(no outbox configured; status update may be lost).", job_id,
                 )
 
-        manager.set_state_change_callback(bind_on_status_change)
+        manager.set_state_change_callback(
+            bind_on_status_change,
+            start_monitor=start_monitor,
+        )
 
 
 def __start_consumer(name, exchange, target):

--- a/pulsar/messaging/bind_relay.py
+++ b/pulsar/messaging/bind_relay.py
@@ -60,7 +60,14 @@ def build_relay_transport(manager, relay_url, conf):
     )
 
 
-def bind_manager_to_relay(manager, relay_state: RelayState, relay_url, conf, relay_transport=None):
+def bind_manager_to_relay(
+    manager,
+    relay_state: RelayState,
+    relay_url,
+    conf,
+    relay_transport=None,
+    start_monitor=True,
+):
     """Bind a specific manager to the relay.
 
     Args:
@@ -148,7 +155,10 @@ def bind_manager_to_relay(manager, relay_state: RelayState, relay_url, conf, rel
                     job_id,
                 )
 
-        manager.set_state_change_callback(bind_on_status_change)
+        manager.set_state_change_callback(
+            bind_on_status_change,
+            start_monitor=start_monitor,
+        )
 
 
 def start_consumer(

--- a/test/stateful_test.py
+++ b/test/stateful_test.py
@@ -40,6 +40,28 @@ class _FailingLaunchManager(_ScriptedStatusManager):
         raise Exception("Test failure launching job")
 
 
+class _RecoveringStatusManager(_ScriptedStatusManager):
+    """Requires recovery to finish before the first status check."""
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        self.recovered = False
+        self.status_checked = threading.Event()
+
+    def _recover_active_job(self, job_id):
+        self.recovered = True
+
+    def get_status(self, job_id):
+        assert self.recovered
+        self.status_checked.set()
+        return super().get_status(job_id)
+
+
+class _FailingRecoveryManager(_ScriptedStatusManager):
+    def _recover_active_job(self, job_id):
+        raise Exception("Test recovery failure")
+
+
 class _RecordingStatefulManagerProxy(StatefulManagerProxy):
     """Records state changes without starting a monitor thread.
 
@@ -132,6 +154,36 @@ def test_preprocessing_failure_is_reported_once():
         # No postprocessing or second callback is needed before launch.
         time.sleep(.1)
         assert proxy.callbacks == [(status.FAILED, job_id)]
+
+
+def test_monitor_can_start_after_external_job_recovery():
+    with _proxy(_RecoveringStatusManager) as (proxy, manager):
+        job_id = proxy.setup_job(TEST_JOB_ID, "tool1", "1.0.0")
+        manager.job_directory(job_id).store_metadata(
+            stateful.JOB_FILE_PREPROCESSED,
+            True,
+        )
+        proxy.active_jobs.activate_job(job_id)
+        callback = mock.Mock()
+        proxy.set_state_change_callback(callback, start_monitor=False)
+
+        assert not manager.status_checked.wait(.1)
+        proxy.recover_active_jobs()
+        proxy.start_monitor()
+
+        assert manager.status_checked.wait(1)
+
+
+def test_recovery_failure_notifies_bound_callback_before_monitor_starts():
+    with _proxy(_FailingRecoveryManager) as (proxy, manager):
+        proxy.active_jobs.activate_job(TEST_JOB_ID)
+        callback = mock.Mock()
+        proxy.set_state_change_callback(callback, start_monitor=False)
+
+        proxy.recover_active_jobs()
+
+        callback.assert_called_once_with(status.LOST, TEST_JOB_ID)
+        assert proxy.active_jobs.active_job_ids() == []
 
 
 @contextmanager


### PR DESCRIPTION
Follow-up to #439.

PR #439 correctly identifies a startup race: ManagerMonitor can poll active jobs before their external IDs have been recovered. Simply moving recovery before message-queue binding, however, means recovery failures occur before the status callback is installed, so Galaxy never receives the LOST notification.

This branch makes the startup lifecycle explicit:

1. Bind the status-publishing callback without starting the monitor.
2. Recover persisted jobs and external IDs.
3. Start manager monitoring.

The existing immediate-monitor behavior remains the default for direct messaging-bind callers.

Marius van den Beek’s rebased commit is retained with its original authorship, followed by the lifecycle fix and regression coverage.

Validation:
- 313 unit tests passed, 63 skipped
- mypy passed across 190 files
- flake8 passed
- isort passed
- git diff --check passed