### PR TITLE
Limit stdout and stderr in status responses

### DIFF
--- a/pulsar/manager_endpoint_util.py
+++ b/pulsar/manager_endpoint_util.py
@@ -18,6 +18,8 @@ from pulsar.managers.stateful import ACTIVE_STATUS_PREPROCESSING
 
 log = logging.getLogger(__name__)
 
+MAXIMUM_STATUS_STREAM_SIZE = 64 * 1024
+
 
 def status_dict(manager, job_id):
     job_status = manager.get_status(job_id)
@@ -39,8 +41,12 @@ def __job_complete_dict(complete_status, manager, job_id):
     return_code = manager.return_code(job_id)
     if return_code == PULSAR_UNKNOWN_RETURN_CODE:
         return_code = None
-    stdout_contents = unicodify(manager.stdout_contents(job_id))
-    stderr_contents = unicodify(manager.stderr_contents(job_id))
+    stdout_contents = unicodify(
+        manager.stdout_contents(job_id)[:MAXIMUM_STATUS_STREAM_SIZE]
+    )
+    stderr_contents = unicodify(
+        manager.stderr_contents(job_id)[:MAXIMUM_STATUS_STREAM_SIZE]
+    )
     job_stdout_contents = unicodify(manager.job_stdout_contents(job_id).decode("utf-8"))
     job_stderr_contents = unicodify(manager.job_stderr_contents(job_id).decode("utf-8"))
     job_directory = manager.job_directory(job_id)

--- a/test/manager_endpoint_util_test.py
+++ b/test/manager_endpoint_util_test.py
@@ -1,10 +1,6 @@
-"""Tests for the manager_endpoint_util submit-message idempotency guard.
+"""Tests for manager endpoint utilities."""
+from unittest.mock import Mock
 
-When an AMQP setup message is redelivered (after a Pulsar SIGKILL between
-setup_job and message.ack(), for example), submit_job must NOT re-run the
-job. Once ``launch_config`` metadata is present on disk, the redelivered
-message is a no-op.
-"""
 from pulsar import manager_endpoint_util
 
 
@@ -64,6 +60,54 @@ def _job_config(job_id="j1", **overrides):
     }
     cfg.update(overrides)
     return cfg
+
+
+def _completed_manager(stdout=b"tool stdout", stderr=b"tool stderr"):
+    job_directory = Mock(job_directory="/jobs/j1")
+    job_directory.working_directory.return_value = "/jobs/j1/working"
+    job_directory.metadata_directory.return_value = "/jobs/j1/metadata"
+    job_directory.working_directory_contents.return_value = ["working.txt"]
+    job_directory.metadata_directory_contents.return_value = ["metadata.txt"]
+    job_directory.outputs_directory_contents.return_value = ["output.txt"]
+    job_directory.job_directory_contents.return_value = ["working", "metadata", "outputs"]
+    job_directory.load_metadata.return_value = None
+
+    manager = Mock()
+    manager.return_code.return_value = 0
+    manager.stdout_contents.return_value = stdout
+    manager.stderr_contents.return_value = stderr
+    manager.job_stdout_contents.return_value = b"job stdout"
+    manager.job_stderr_contents.return_value = b"job stderr"
+    manager.job_directory.return_value = job_directory
+    manager.system_properties.return_value = {"separator": "/"}
+    return manager
+
+
+def test_completed_status_preserves_short_tool_streams_and_metadata():
+    result = manager_endpoint_util.full_status(_completed_manager(), "complete", "j1")
+
+    assert result["stdout"] == "tool stdout"
+    assert result["stderr"] == "tool stderr"
+    assert result["job_stdout"] == "job stdout"
+    assert result["job_stderr"] == "job stderr"
+    assert result["returncode"] == 0
+    assert result["working_directory_contents"] == ["working.txt"]
+    assert result["metadata_directory_contents"] == ["metadata.txt"]
+    assert result["outputs_directory_contents"] == ["output.txt"]
+    assert result["job_directory_contents"] == ["working", "metadata", "outputs"]
+
+
+def test_completed_status_caps_tool_streams_at_64_kib():
+    stream_limit = manager_endpoint_util.MAXIMUM_STATUS_STREAM_SIZE
+    manager = _completed_manager(
+        stdout=b"o" * (stream_limit + 1),
+        stderr=b"e" * (stream_limit + 1),
+    )
+
+    result = manager_endpoint_util.full_status(manager, "complete", "j1")
+
+    assert result["stdout"] == "o" * stream_limit
+    assert result["stderr"] == "e" * stream_limit
 
 
 def test_first_setup_proceeds_to_preprocess_and_launch():


### PR DESCRIPTION
This rescues the intent of #386 without removing the status fields or the manager API.

Tool stdout and stderr are transferred as files, but Galaxy still consumes their inline status values for compatibility. Cap each inline tool stream at 64 KiB so a large configured `maximum_stream_size` cannot produce the oversized completion message seen in #384.

This deliberately does not close #384: job streams and very large directory-content listings remain separate payload-size risks.

Marius van den Beek remains the author of the carried-forward commit.

Validation:
- `tox -e test-unit -- test/manager_endpoint_util_test.py` (8 passed)
- `tox -e lint,format`
- `git diff --check`