### PR TITLE
Close leaked file and transport handles

### DIFF
--- a/pulsar/client/action_mapper.py
+++ b/pulsar/client/action_mapper.py
@@ -463,7 +463,8 @@ class RemoteCopyAction(BaseAction):
         return RemoteCopyAction(source=action_dict["source"])
 
     def write_to_path(self, path):
-        copy_to_path(open(self.path, "rb"), path)
+        with open(self.path, "rb") as f:
+            copy_to_path(f, path)
 
     def write_from_path(self, pulsar_path):
         destination = self.path
@@ -551,7 +552,8 @@ class RemoteObjectStoreCopyAction(BaseAction):
             object_store_id=object_store_ref["object_store_id"],
         )
         filename = self.object_store.get_filename(dataset_object)
-        copy_to_path(open(filename, 'rb'), path)
+        with open(filename, "rb") as f:
+            copy_to_path(f, path)
 
     def write_from_path(self, pulsar_path):
         raise NotImplementedError("Writing raw files to object store not supported at this time.")
@@ -677,7 +679,8 @@ class MessageAction:
         return MessageAction(contents=action_dict["contents"])
 
     def write_to_path(self, path):
-        open(path, "w").write(self.contents)
+        with open(path, "w") as f:
+            f.write(self.contents)
 
 
 DICTIFIABLE_ACTION_CLASSES = [

--- a/pulsar/client/transport/curl.py
+++ b/pulsar/client/transport/curl.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import os.path
+from contextlib import contextmanager
 
 import requests
 
@@ -36,32 +37,32 @@ class PycurlTransport:
         buf = _open_output(output_path)
         input_fh = None
         try:
-            c = _new_curl_object_for_url(url)
-            c.setopt(c.WRITEFUNCTION, buf.write)
-            if method:
-                c.setopt(c.CUSTOMREQUEST, method)
-            if input_path:
-                input_fh = open(input_path, "rb")
-                c.setopt(c.UPLOAD, 1)
-                c.setopt(c.READFUNCTION, input_fh.read)
-                filesize = os.path.getsize(input_path)
-                c.setopt(c.INFILESIZE, filesize)
-            if data:
-                c.setopt(c.POST, 1)
-                if isinstance(data, str):
-                    data = data.encode('UTF-8')
-                c.setopt(c.POSTFIELDS, data)
-            if self.timeout:
-                c.setopt(c.TIMEOUT, self.timeout)
-            try:
-                c.perform()
-            except error as exc:
-                raise PulsarClientTransportError(
-                    _error_curl_to_pulsar(exc.args[0]),
-                    transport_code=exc.args[0],
-                    transport_message=exc.args[1])
-            if not output_path:
-                return buf.getvalue()
+            with _curl_object_for_url(url) as c:
+                c.setopt(c.WRITEFUNCTION, buf.write)
+                if method:
+                    c.setopt(c.CUSTOMREQUEST, method)
+                if input_path:
+                    input_fh = open(input_path, "rb")
+                    c.setopt(c.UPLOAD, 1)
+                    c.setopt(c.READFUNCTION, input_fh.read)
+                    filesize = os.path.getsize(input_path)
+                    c.setopt(c.INFILESIZE, filesize)
+                if data:
+                    c.setopt(c.POST, 1)
+                    if isinstance(data, str):
+                        data = data.encode('UTF-8')
+                    c.setopt(c.POSTFIELDS, data)
+                if self.timeout:
+                    c.setopt(c.TIMEOUT, self.timeout)
+                try:
+                    c.perform()
+                except error as exc:
+                    raise PulsarClientTransportError(
+                        _error_curl_to_pulsar(exc.args[0]),
+                        transport_code=exc.args[0],
+                        transport_message=exc.args[1])
+                if not output_path:
+                    return buf.getvalue()
         finally:
             buf.close()
             if input_fh:
@@ -74,27 +75,27 @@ def post_file(url, path):
         # wrap it in a better one.
         message = NO_SUCH_FILE_MESSAGE % (path, url)
         raise Exception(message)
-    c = _new_curl_object_for_url(url)
-    c.setopt(c.HTTPPOST, [("file", (c.FORM_FILE, path.encode('ascii')))])
-    c.perform()
-    status_code = int(c.getinfo(HTTP_CODE))
-    if status_code != 200:
-        raise PulsarClientTransportError(
-            transport_code=status_code,
-            transport_message=POST_FAILED_MESSAGE % (url, status_code),
-        )
+    with _curl_object_for_url(url) as c:
+        c.setopt(c.HTTPPOST, [("file", (c.FORM_FILE, path.encode('ascii')))])
+        c.perform()
+        status_code = int(c.getinfo(HTTP_CODE))
+        if status_code != 200:
+            raise PulsarClientTransportError(
+                transport_code=status_code,
+                transport_message=POST_FAILED_MESSAGE % (url, status_code),
+            )
 
 
 def get_size(url) -> int:
-    response = requests.head(url, headers={"accept-encoding": "identity"})
-    if response.status_code >= 299:
-        log.warning("Response to HEAD request for '%s' with status code %s, cannot resume download", url, response.status_code)
-        return -1
-    try:
-        return int(response.headers["content-length"])
-    except KeyError:
-        log.error("'content-length' header not sent for '%s', cannot resume download", url)
-        return -1
+    with requests.head(url, headers={"accept-encoding": "identity"}) as response:
+        if response.status_code >= 299:
+            log.warning("Response to HEAD request for '%s' with status code %s, cannot resume download", url, response.status_code)
+            return -1
+        try:
+            return int(response.headers["content-length"])
+        except KeyError:
+            log.error("'content-length' header not sent for '%s', cannot resume download", url)
+            return -1
 
 
 def get_file(url, path: str):
@@ -118,18 +119,18 @@ def get_file(url, path: str):
         # definitely a new download
         buf = _open_output(path)
     try:
-        c = _new_curl_object_for_url(url)
-        c.setopt(c.WRITEFUNCTION, buf.write)
-        if size > 0:
-            log.info('transfer of %s will resume at %s bytes', url, size)
-            c.setopt(c.RESUME_FROM, size)
-        c.perform()
-        status_code = int(c.getinfo(HTTP_CODE))
-        if status_code not in success_codes:
-            raise PulsarClientTransportError(
-                transport_code=status_code,
-                transport_message=GET_FAILED_MESSAGE % (url, status_code),
-            )
+        with _curl_object_for_url(url) as c:
+            c.setopt(c.WRITEFUNCTION, buf.write)
+            if size > 0:
+                log.info('transfer of %s will resume at %s bytes', url, size)
+                c.setopt(c.RESUME_FROM, size)
+            c.perform()
+            status_code = int(c.getinfo(HTTP_CODE))
+            if status_code not in success_codes:
+                raise PulsarClientTransportError(
+                    transport_code=status_code,
+                    transport_message=GET_FAILED_MESSAGE % (url, status_code),
+                )
     finally:
         buf.close()
 
@@ -138,10 +139,14 @@ def _open_output(output_path, mode='wb'):
     return open(output_path, mode) if output_path else io.BytesIO()
 
 
-def _new_curl_object_for_url(url):
+@contextmanager
+def _curl_object_for_url(url):
     c = _new_curl_object()
-    c.setopt(c.URL, url.encode('ascii'))
-    return c
+    try:
+        c.setopt(c.URL, url.encode('ascii'))
+        yield c
+    finally:
+        c.close()
 
 
 def _new_curl_object():

--- a/pulsar/client/transport/curl.py
+++ b/pulsar/client/transport/curl.py
@@ -34,14 +34,16 @@ class PycurlTransport:
 
     def execute(self, url, method=None, data=None, input_path=None, output_path=None):
         buf = _open_output(output_path)
+        input_fh = None
         try:
             c = _new_curl_object_for_url(url)
             c.setopt(c.WRITEFUNCTION, buf.write)
             if method:
                 c.setopt(c.CUSTOMREQUEST, method)
             if input_path:
+                input_fh = open(input_path, "rb")
                 c.setopt(c.UPLOAD, 1)
-                c.setopt(c.READFUNCTION, open(input_path, 'rb').read)
+                c.setopt(c.READFUNCTION, input_fh.read)
                 filesize = os.path.getsize(input_path)
                 c.setopt(c.INFILESIZE, filesize)
             if data:
@@ -62,6 +64,8 @@ class PycurlTransport:
                 return buf.getvalue()
         finally:
             buf.close()
+            if input_fh:
+                input_fh.close()
 
 
 def post_file(url, path):

--- a/pulsar/client/transport/requests.py
+++ b/pulsar/client/transport/requests.py
@@ -12,28 +12,27 @@ log = logging.getLogger(__name__)
 
 
 def post_file(url, path):
-    if requests_toolbelt is not None:
-        # Streaming multipart upload — avoids loading the whole file into memory.
-        m = requests_toolbelt.MultipartEncoder(
-            fields={'file': ('filename', open(path, 'rb'))}
-        )
-        response = requests.post(url, data=m, headers={'Content-Type': m.content_type})
-    else:
-        log.warning(
-            "Posting %s without requests_toolbelt: the entire file will be loaded into memory. "
-            "Install requests_toolbelt (or pycurl, and use the curl transport) for streaming uploads.",
-            path,
-        )
-        with open(path, 'rb') as f:
+    with open(path, "rb") as f:
+        if requests_toolbelt is not None:
+            # Streaming multipart upload — avoids loading the whole file into memory.
+            m = requests_toolbelt.MultipartEncoder(fields={"file": ("filename", f)})
+            response = requests.post(url, data=m, headers={"Content-Type": m.content_type})
+        else:
+            log.warning(
+                "Posting %s without requests_toolbelt: the entire file will be loaded into memory. "
+                "Install requests_toolbelt (or pycurl, and use the curl transport) for streaming uploads.",
+                path,
+            )
             response = requests.post(url, files={'file': f})
-    response.raise_for_status()
+        with response:
+            response.raise_for_status()
 
 
 def get_file(url, path):
-    r = requests.get(url, stream=True)
-    r.raise_for_status()
-    with open(path, 'wb') as f:
-        for chunk in r.iter_content(chunk_size=1024):
-            if chunk:
-                f.write(chunk)
-                f.flush()
+    with requests.get(url, stream=True) as response:
+        response.raise_for_status()
+        with open(path, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:
+                    f.write(chunk)
+                    f.flush()

--- a/pulsar/client/util.py
+++ b/pulsar/client/util.py
@@ -283,10 +283,12 @@ class MessageQueueUUIDStore:
         return exists(self.__path(item))
 
     def __setitem__(self, key, value):
-        open(self.__path(key), 'w').write(json.dumps(value))
+        with open(self.__path(key), "w") as f:
+            f.write(json.dumps(value))
 
     def __getitem__(self, key):
-        return json.loads(open(self.__path(key)).read())
+        with open(self.__path(key)) as f:
+            return json.loads(f.read())
 
     def __delitem__(self, key):
         try:

--- a/pulsar/managers/base/__init__.py
+++ b/pulsar/managers/base/__init__.py
@@ -230,7 +230,8 @@ class BaseManager(ManagerInterface, ABC):
         for file in self._list_dir(tool_files_dir):
             if os.path.isdir(join(tool_files_dir, file)):
                 continue
-            contents = open(join(tool_files_dir, file), "rb").read()
+            with open(join(tool_files_dir, file), "rb") as fh:
+                contents = fh.read()
             log.debug("job_id: {} - checking tool file {}".format(job_id, file))
             authorization.authorize_tool_file(basename(file), contents)
         config_files_dir = job_directory.configs_directory()

--- a/pulsar/managers/queued_condor.py
+++ b/pulsar/managers/queued_condor.py
@@ -58,7 +58,9 @@ class CondorQueueManager(ExternalBaseManager):
             setup_params=setup_params,
         )
         log_path = self.__condor_user_log(job_id)
-        open(log_path, "w")  # Touch log file
+        with open(log_path, "w"):
+            # Touch log file
+            pass
 
         submit_params.update(self.submission_params)
         build_submit_params = dict(

--- a/pulsar/managers/queued_external_drmaa.py
+++ b/pulsar/managers/queued_external_drmaa.py
@@ -67,7 +67,8 @@ class ExternalDrmaaQueueManager(BaseDrmaaManager):
             submit_params=submit_params,
             setup_params=setup_params,
         )
-        print(open(attributes["remoteCommand"]).read())
+        with open(attributes["remoteCommand"]) as fh:
+            print(fh.read())
         job_attributes_file = self._write_job_file(job_id, "jt.json", dumps(attributes))
         user = submit_params.get("user", None)
         log.info("Submit as user %s" % user)

--- a/pulsar/managers/stateful.py
+++ b/pulsar/managers/stateful.py
@@ -143,7 +143,8 @@ class StatefulManagerProxy(ManagerProxy):
         job_directory = self._proxied_manager.job_directory(job_id)
         for name in touch_outputs:
             path = job_directory.calculate_path(name, "output")
-            job_directory.open_file(path, mode="a")
+            with contextlib.closing(job_directory.open_file(path, mode="a")):
+                pass
 
     def preprocess_and_launch(self, job_id: str, launch_config: Dict[str, Any]) -> None:
         self._persist_launch_config(job_id, launch_config)

--- a/pulsar/scripts/config.py
+++ b/pulsar/scripts/config.py
@@ -483,7 +483,8 @@ def _handle_server_ini(args, directory):
         server_config = SERVER_CONFIG_TEMPLATE.safe_substitute(
             **config_dict
         )
-        open(ini_file, "w").write(server_config)
+        with open(ini_file, "w") as fh:
+            fh.write(server_config)
 
 
 def _handle_app_yaml(args, directory):
@@ -512,7 +513,8 @@ def _handle_app_yaml(args, directory):
     contents += 'conda_auto_install: {}\n'.format(auto_conda)
     if not IS_WINDOWS and args.libdrmaa_path:
         contents += 'manager:\n  type: queued_drmaa\n'
-    open(yaml_file, "w").write(contents)
+    with open(yaml_file, "w") as fh:
+        fh.write(contents)
 
 
 def _handle_local_env(args, directory, dependencies):
@@ -527,7 +529,8 @@ def _handle_local_env(args, directory, dependencies):
     local_env_contents = LOCAL_ENV_TEMPLATE.safe_substitute(
         libdrmaa_line=libdrmaa_line,
     )
-    open(local_env_file, "w").write(local_env_contents)
+    with open(local_env_file, "w") as fh:
+        fh.write(local_env_contents)
 
 
 def _handle_supervisor(args, mode, directory, dependencies):
@@ -539,7 +542,8 @@ def _handle_supervisor(args, mode, directory, dependencies):
             mode=mode,
         )
         conf_path = os.path.join(directory, "supervisor.conf")
-        open(conf_path, "w").write(config)
+        with open(conf_path, "w") as fh:
+            fh.write(config)
         dependencies.append("supervisor")
 
 

--- a/pulsar/scripts/drmaa_launch.py
+++ b/pulsar/scripts/drmaa_launch.py
@@ -10,7 +10,8 @@ def main(argv=None):
     arg_parser = ArgumentParser(description=DESCRIPTION)
     arg_parser.add_argument("--job_attributes", required=True)
     args = arg_parser.parse_args(argv)
-    job_attributes = load(open(args.job_attributes))
+    with open(args.job_attributes) as fh:
+        job_attributes = load(fh)
     session = DrmaaSessionFactory().get()
     external_id = session.run_job(**job_attributes)
     print(external_id)

--- a/pulsar/scripts/run.py
+++ b/pulsar/scripts/run.py
@@ -97,7 +97,8 @@ def _run_client_for_job(args):
         result_status = waiter.wait()
         pulsar_outputs = PulsarOutputs.from_status_response(result_status)
         if args.result_json:
-            open(args.result_json, "w").write(json_dumps(result_status))
+            with open(args.result_json, "w") as fh:
+                fh.write(json_dumps(result_status))
         finish_args = dict(
             client=client,
             job_completed_normally=True,

--- a/pulsar/scripts/submit_util.py
+++ b/pulsar/scripts/submit_util.py
@@ -77,7 +77,8 @@ def _load_job_config(args):
         base64_job_config = args.base64
         job_config = from_base64_json(base64_job_config)
     else:
-        job_config = json.load(open(args.file))
+        with open(args.file) as fh:
+            job_config = json.load(fh)
     return job_config
 
 

--- a/pulsar/tools/authorization.py
+++ b/pulsar/tools/authorization.py
@@ -43,7 +43,8 @@ class ToolBasedAuthorization(AllowAnyAuthorization):
         tool = self.tool
         tool_dir = tool.get_tool_dir()
         tool_dir_file = join(tool_dir, name)
-        allowed_contents = open(tool_dir_file, "rb").read()
+        with open(tool_dir_file, "rb") as fh:
+            allowed_contents = fh.read()
         if contents != allowed_contents:
             self.__unauthorized("Attempt to write tool file with contents differing from Pulsar copy of tool file.")
 

--- a/pulsar/tools/toolbox.py
+++ b/pulsar/tools/toolbox.py
@@ -72,7 +72,8 @@ class InputsValidator:
         config_validator = self.config_validators.get(name, None)
         valid = True
         if config_validator:
-            contents = open(path, encoding="UTF-8").read()
+            with open(path, encoding="UTF-8") as fh:
+                contents = fh.read()
             valid = config_validator.validate(job_directory, contents)
         return valid
 

--- a/pulsar/web/routes.py
+++ b/pulsar/web/routes.py
@@ -241,10 +241,11 @@ class PulsarDataset:
 
 
 def _handle_upload(file_cache, path, body, cache_token=None):
-    source = body
     if cache_token:
         cached_file = file_cache.destination(cache_token)
-        source = open(cached_file, 'rb')
-        log.info("Copying cached file {} to {}".format(cached_file, path))
-    copy_to_path(source, path)
+        with open(cached_file, 'rb') as source:
+            log.info("Copying cached file {} to {}".format(cached_file, path))
+            copy_to_path(source, path)
+    else:
+        copy_to_path(body, path)
     return {"path": path}

--- a/test/client_transport_test.py
+++ b/test/client_transport_test.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from unittest import mock
 from uuid import uuid4
 
 import requests as requests_module
@@ -9,7 +10,11 @@ from simplejobfiles.app import JobFilesApp
 from webtest import TestApp
 
 from pulsar.client.exceptions import PulsarClientTransportError
-from pulsar.client.transport import get_transport
+from pulsar.client.transport import (
+    curl as curl_transport,
+    get_transport,
+    requests as requests_transport,
+)
 from pulsar.client.transport.curl import (
     get_file,
     post_file,
@@ -38,6 +43,50 @@ def test_urllib_transports():
 @skip_unless_module("pycurl")
 def test_pycurl_transport():
     _test_transport(PycurlTransport())
+
+
+def test_curl_object_is_closed():
+    curl = mock.Mock()
+    with mock.patch.object(curl_transport, "_new_curl_object", return_value=curl):
+        with curl_transport._curl_object_for_url("https://example.org") as opened:
+            assert opened is curl
+
+    curl.close.assert_called_once_with()
+
+
+def test_curl_object_is_closed_on_error():
+    curl = mock.Mock()
+    with mock.patch.object(curl_transport, "_new_curl_object", return_value=curl):
+        try:
+            with curl_transport._curl_object_for_url("https://example.org"):
+                raise RuntimeError("test error")
+        except RuntimeError:
+            pass
+
+    curl.close.assert_called_once_with()
+
+
+def test_requests_download_response_is_closed(tmp_path):
+    response = mock.MagicMock()
+    response.__enter__.return_value = response
+    response.iter_content.return_value = [b"downloaded"]
+    with mock.patch.object(requests_transport.requests, "get", return_value=response):
+        requests_transport.get_file("https://example.org", tmp_path / "output")
+
+    response.__exit__.assert_called_once()
+
+
+def test_requests_download_response_is_closed_on_error(tmp_path):
+    response = mock.MagicMock()
+    response.__enter__.return_value = response
+    response.raise_for_status.side_effect = requests_module.HTTPError("test error")
+    with mock.patch.object(requests_transport.requests, "get", return_value=response):
+        try:
+            requests_transport.get_file("https://example.org", tmp_path / "output")
+        except requests_module.HTTPError:
+            pass
+
+    response.__exit__.assert_called_once()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Replacement for #367.

This carries the still-relevant parts of Marius van den Beek’s original cleanup onto current master, while omitting deleted modules, independently fixed code, and rewrites of paths that already closed handles safely.

It also closes resources missed by the original patch:

- pycurl `Curl` handles on success and error
- streaming Requests responses
- upload streams after exactly the blocking transfer lifetime

Marius retains authorship on the adapted original commit. The transport hardening and regression tests are isolated in a second commit.

Validation:

- `tox -e test-unit`: 315 passed, 63 skipped
- `tox -e mypy`: clean across 190 source files
- `tox -e lint,format`
- `git diff --check`