### PR TITLE
Support configuring the AMQP heartbeat interval, or disabling heartbeats

### DIFF
--- a/app.yml.sample
+++ b/app.yml.sample
@@ -145,8 +145,10 @@
 ## this value is used as the timeout argument to the producer.publish function.
 #amqp_publish_timeout: 2.0
 
-# AMQP heartbeat interval (see: https://www.rabbitmq.com/docs/heartbeats). Set
-# to false or 0 to disable heartbeats.
+## Interval in seconds at which Pulsar requests AMQP heartbeats on its consumer
+## connections (see: https://www.rabbitmq.com/docs/heartbeats). The broker may
+## negotiate a shorter interval - RabbitMQ proposes 60 by default, and the lower
+## of the two wins. Set to false or 0 to disable heartbeats entirely.
 #amqp_heartbeat: 580
 
 # AMQP does not guarantee that a published message is received by the AMQP

--- a/app.yml.sample
+++ b/app.yml.sample
@@ -145,6 +145,10 @@
 ## this value is used as the timeout argument to the producer.publish function.
 #amqp_publish_timeout: 2.0
 
+# AMQP heartbeat interval (see: https://www.rabbitmq.com/docs/heartbeats). Set
+# to false or 0 to disable heartbeats.
+#amqp_heartbeat: 580
+
 # AMQP does not guarantee that a published message is received by the AMQP
 # server, so Pulsar can request that the consumer acknowledge messages and will
 # resend them if acknowledgement is not received after a configurable timeout

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -222,6 +222,10 @@ In the event that the connection to the AMQP server is lost during message
 publish, the Pulsar server can retry the connection, governed by the
 ``amqp_publish*`` options documented in `app.yml.sample`_.
 
+By default, `AMQP heartbeats`_ are enabled at an interval of 580 seconds. This
+can be adjusted by setting ``amqp_heartbeat`` or disabled by setting it to
+``false`` or ``0``.
+
 Message Queue (pulsar-relay)
 -----------------------------
 
@@ -561,3 +565,4 @@ and future plans and progress can be tracked on `this Trello card <https://trell
 .. _RabbitMQ: https://www.rabbitmq.com/
 .. _app.yml.sample: https://github.com/galaxyproject/pulsar/blob/master/app.yml.sample
 .. _Two Generals Problem: https://en.wikipedia.org/wiki/Two_Generals%27_Problem
+.. _AMQP heartbeats: https://www.rabbitmq.com/docs/heartbeats

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -222,9 +222,12 @@ In the event that the connection to the AMQP server is lost during message
 publish, the Pulsar server can retry the connection, governed by the
 ``amqp_publish*`` options documented in `app.yml.sample`_.
 
-By default, `AMQP heartbeats`_ are enabled at an interval of 580 seconds. This
-can be adjusted by setting ``amqp_heartbeat`` or disabled by setting it to
-``false`` or ``0``.
+By default, Pulsar requests `AMQP heartbeats`_ on its consumer connections at
+an interval of 580 seconds. The broker may negotiate a shorter interval -
+RabbitMQ proposes 60 seconds by default and the lower of the two values wins.
+The requested interval can be adjusted by setting ``amqp_heartbeat``, or
+heartbeats disabled altogether by setting it to ``false`` or ``0``. Publisher
+connections are pooled and do not use heartbeats.
 
 Message Queue (pulsar-relay)
 -----------------------------

--- a/docs/error_handling.rst
+++ b/docs/error_handling.rst
@@ -148,6 +148,15 @@ When Pulsar talks to RabbitMQ:
   ``interval_start: 1``, ``interval_step: 2``, ``interval_max: 30``) so a
   single transient hiccup is absorbed in-band without round-tripping
   through the outbox drain loop.
+* ``amqp_heartbeat`` (``580`` by default) is the heartbeat interval Pulsar
+  requests on its consumer connections; the broker negotiates the lower of
+  its own proposal and this one, so the effective interval is 60 seconds on
+  a stock RabbitMQ. Heartbeats are how a blackholed or firewall-dropped
+  connection gets *detected* - without them a half-open connection is only
+  noticed on the next write, and the broker keeps counting the dead
+  consumer. Setting ``amqp_heartbeat: false`` (or ``0``) disables them in
+  both directions; only do that if something else is keeping the connection
+  observably alive.
 * ``amqp_acknowledge: true`` (off by default) layers an additional
   publisher-confirms protocol on top, with its own UUID store under
   ``<persistence_directory>/amqp_ack-<manager>/``. This is independent of
@@ -395,6 +404,7 @@ Setting                           Default                                  Effec
 ``amqp_publish_retry``            unset (off)                              kombu publish retry; defaults bounded when on
 ``amqp_acknowledge``              ``false``                                additional publisher-confirms layer
 ``amqp_consumer_timeout``         ``0.2``                                  consumer drain_events timeout (responsiveness)
+``amqp_heartbeat``                ``580`` (negotiated down)                consumer-connection heartbeat interval; false/0 disables
 ``message_queue_publish``         ``true``                                 disable to make Pulsar receive-only
 ``message_queue_consume``         ``true``                                 disable to make Pulsar send-only
 ``ensure_cleanup``                ``false``                                join consumer threads on shutdown

--- a/pulsar/client/amqp_exchange.py
+++ b/pulsar/client/amqp_exchange.py
@@ -76,6 +76,7 @@ class PulsarExchange:
         consume_uuid_store=None,
         republish_time=DEFAULT_REPUBLISH_TIME,
         durable=True,
+        heartbeat=DEFAULT_HEARTBEAT,
     ):
         """
         """
@@ -107,6 +108,7 @@ class PulsarExchange:
         )
         self.__timeout = timeout
         self.__republish_time = republish_time
+        self.__heartbeat = heartbeat
         # Be sure to log message publishing failures.
         if publish_kwds.get("retry", False):
             if "retry_policy" not in publish_kwds:
@@ -142,10 +144,13 @@ class PulsarExchange:
             callbacks.append(callback)
         while check:
             heartbeat_thread = None
+            if self.__heartbeat:
+                connection_kwargs["heartbeat"] = self.__heartbeat
             try:
-                with self.connection(self.__url, heartbeat=DEFAULT_HEARTBEAT, **connection_kwargs) as connection:
+                with self.connection(self.__url, **connection_kwargs) as connection:
                     with kombu.Consumer(connection, queues=[queue], callbacks=callbacks, accept=['json']):
-                        heartbeat_thread = self.__start_heartbeat(queue_name, connection)
+                        if self.__heartbeat:
+                            heartbeat_thread = self.__start_heartbeat(queue_name, connection)
                         while check and connection.connected:
                             try:
                                 connection.drain_events(timeout=self.__timeout)

--- a/pulsar/client/amqp_exchange.py
+++ b/pulsar/client/amqp_exchange.py
@@ -108,7 +108,10 @@ class PulsarExchange:
         )
         self.__timeout = timeout
         self.__republish_time = republish_time
-        self.__heartbeat = heartbeat
+        # 0 disables heartbeats; py-amqp raises TypeError on a non-numeric value
+        # and that is not a recoverable exception, so normalize here as well as
+        # in the factory to protect direct construction.
+        self.__heartbeat = int(heartbeat or 0)
         # Be sure to log message publishing failures.
         if publish_kwds.get("retry", False):
             if "retry_policy" not in publish_kwds:
@@ -136,7 +139,11 @@ class PulsarExchange:
     def acks_enabled(self):
         return self.publish_uuid_store is not None
 
-    def consume(self, queue_name, callback, check=True, connection_kwargs={}):
+    def consume(self, queue_name, callback, check=True, connection_kwargs=None):
+        # Copy rather than mutate: a shared default dict here would apply one
+        # exchange's heartbeat to every later consumer in the process.
+        connection_kwargs = dict(connection_kwargs or {})
+        connection_kwargs.setdefault("heartbeat", self.__heartbeat)
         queue = self.__queue(queue_name)
         log.debug("Consuming queue '%s'", queue)
         callbacks = [self.__ack_callback]
@@ -144,8 +151,6 @@ class PulsarExchange:
             callbacks.append(callback)
         while check:
             heartbeat_thread = None
-            if self.__heartbeat:
-                connection_kwargs["heartbeat"] = self.__heartbeat
             try:
                 with self.connection(self.__url, **connection_kwargs) as connection:
                     with kombu.Consumer(connection, queues=[queue], callbacks=callbacks, accept=['json']):

--- a/pulsar/client/amqp_exchange_factory.py
+++ b/pulsar/client/amqp_exchange_factory.py
@@ -23,6 +23,8 @@ def get_exchange(url, manager_name, params):
     exchange_kwds["durable"] = bool(durable_param)
     if params.get('amqp_acknowledge', False):
         exchange_kwds.update(parse_ack_kwds(params, manager_name))
+    if params.get("amqp_heartbeat") is not None:
+        exchange_kwds["heartbeat"] = params.get("amqp_heartbeat")
     timeout = params.get('amqp_consumer_timeout', False)
     if timeout is not False:
         exchange_kwds['timeout'] = timeout

--- a/pulsar/client/amqp_exchange_factory.py
+++ b/pulsar/client/amqp_exchange_factory.py
@@ -1,4 +1,7 @@
-from .amqp_exchange import PulsarExchange
+from .amqp_exchange import (
+    DEFAULT_HEARTBEAT,
+    PulsarExchange,
+)
 from .util import (
     filter_destination_params,
     MessageQueueUUIDStore,
@@ -23,13 +26,35 @@ def get_exchange(url, manager_name, params):
     exchange_kwds["durable"] = bool(durable_param)
     if params.get('amqp_acknowledge', False):
         exchange_kwds.update(parse_ack_kwds(params, manager_name))
-    if params.get("amqp_heartbeat") is not None:
-        exchange_kwds["heartbeat"] = params.get("amqp_heartbeat")
+    heartbeat_param = params.get("amqp_heartbeat")
+    if heartbeat_param is not None:
+        exchange_kwds["heartbeat"] = parse_amqp_heartbeat(heartbeat_param)
     timeout = params.get('amqp_consumer_timeout', False)
     if timeout is not False:
         exchange_kwds['timeout'] = timeout
     exchange = PulsarExchange(url, **exchange_kwds)
     return exchange
+
+
+def parse_amqp_heartbeat(value):
+    """Coerce an ``amqp_heartbeat`` config value to an interval in seconds.
+
+    Zero disables heartbeats. Strings have to be handled explicitly: Galaxy
+    destination params and Pulsar's ini config both arrive as strings, and a
+    non-numeric heartbeat raises ``TypeError`` inside py-amqp's tune handshake
+    - which is not a recoverable exception, so it kills the consumer thread.
+    """
+    if value is True:
+        return DEFAULT_HEARTBEAT
+    if value is False:
+        return 0
+    if isinstance(value, str):
+        value = value.strip()
+        if value.lower() in ("false", "none", "off", "no", ""):
+            return 0
+        if value.lower() in ("true", "on", "yes"):
+            return DEFAULT_HEARTBEAT
+    return int(value)
 
 
 def parse_amqp_connect_ssl_params(params):

--- a/test/amqp_test.py
+++ b/test/amqp_test.py
@@ -5,7 +5,10 @@ import time
 
 import pytest
 
-from pulsar.client import amqp_exchange
+from pulsar.client import (
+    amqp_exchange,
+    amqp_exchange_factory,
+)
 from .test_utils import (
     skip_unless_module,
 )
@@ -113,7 +116,6 @@ def test_non_durable_publishes_do_not_force_persistent_mode():
 
 @skip_unless_module("kombu")
 def test_factory_defaults_durable_true():
-    from pulsar.client import amqp_exchange_factory
     exchange = amqp_exchange_factory.get_exchange(TEST_CONNECTION, "factory_durable_default", {})
     queue = exchange._PulsarExchange__queue("status_update")
     assert queue.durable is True
@@ -121,7 +123,6 @@ def test_factory_defaults_durable_true():
 
 @skip_unless_module("kombu")
 def test_factory_respects_amqp_durable_false():
-    from pulsar.client import amqp_exchange_factory
     exchange = amqp_exchange_factory.get_exchange(
         TEST_CONNECTION, "factory_durable_off", {"amqp_durable": False},
     )
@@ -131,7 +132,6 @@ def test_factory_respects_amqp_durable_false():
 
 @skip_unless_module("kombu")
 def test_factory_respects_amqp_durable_true():
-    from pulsar.client import amqp_exchange_factory
     exchange = amqp_exchange_factory.get_exchange(
         TEST_CONNECTION, "factory_durable_on", {"amqp_durable": True},
     )
@@ -141,7 +141,6 @@ def test_factory_respects_amqp_durable_true():
 
 @skip_unless_module("kombu")
 def test_factory_respects_amqp_durable_string_true():
-    from pulsar.client import amqp_exchange_factory
     exchange = amqp_exchange_factory.get_exchange(
         TEST_CONNECTION, "factory_durable_on_str", {"amqp_durable": "true"},
     )
@@ -153,8 +152,7 @@ def test_publish_kwds_no_retry_by_default():
     """Without an explicit opt-in we leave kombu's defaults alone, so existing
     deployments don't get surprise retry behavior; the persistent outbox is
     the primary durability layer."""
-    from pulsar.client.amqp_exchange_factory import parse_amqp_publish_kwds
-    publish_kwds = parse_amqp_publish_kwds({})
+    publish_kwds = amqp_exchange_factory.parse_amqp_publish_kwds({})
     assert "retry" not in publish_kwds
     assert "retry_policy" not in publish_kwds
 
@@ -162,21 +160,13 @@ def test_publish_kwds_no_retry_by_default():
 def test_publish_kwds_retry_true_populates_default_policy():
     """When the operator opts into retries we fill in bounded defaults so a
     single hiccup doesn't drop a message before the outbox sees it."""
-    from pulsar.client.amqp_exchange_factory import (
-        DEFAULT_PUBLISH_RETRY_POLICY,
-        parse_amqp_publish_kwds,
-    )
-    publish_kwds = parse_amqp_publish_kwds({"amqp_publish_retry": True})
+    publish_kwds = amqp_exchange_factory.parse_amqp_publish_kwds({"amqp_publish_retry": True})
     assert publish_kwds["retry"] is True
-    assert publish_kwds["retry_policy"] == DEFAULT_PUBLISH_RETRY_POLICY
+    assert publish_kwds["retry_policy"] == amqp_exchange_factory.DEFAULT_PUBLISH_RETRY_POLICY
 
 
 def test_publish_kwds_explicit_retry_policy_wins_over_defaults():
-    from pulsar.client.amqp_exchange_factory import (
-        DEFAULT_PUBLISH_RETRY_POLICY,
-        parse_amqp_publish_kwds,
-    )
-    publish_kwds = parse_amqp_publish_kwds({
+    publish_kwds = amqp_exchange_factory.parse_amqp_publish_kwds({
         "amqp_publish_retry": True,
         "amqp_publish_retry_max_retries": 99,
         "amqp_publish_retry_interval_start": 7,
@@ -185,7 +175,7 @@ def test_publish_kwds_explicit_retry_policy_wins_over_defaults():
     assert publish_kwds["retry_policy"]["max_retries"] == 99
     assert publish_kwds["retry_policy"]["interval_start"] == 7
     # Non-overridden defaults are still filled in.
-    assert publish_kwds["retry_policy"]["interval_max"] == DEFAULT_PUBLISH_RETRY_POLICY["interval_max"]
+    assert publish_kwds["retry_policy"]["interval_max"] == amqp_exchange_factory.DEFAULT_PUBLISH_RETRY_POLICY["interval_max"]
 
 
 __all__ = ["test_amqp"]

--- a/test/amqp_test.py
+++ b/test/amqp_test.py
@@ -148,6 +148,113 @@ def test_factory_respects_amqp_durable_string_true():
     assert queue.durable is True
 
 
+class ConsumeOnce:
+    """``check`` object letting ``consume()`` run exactly one iteration."""
+
+    def __init__(self):
+        self.checks = 0
+
+    def __bool__(self):
+        self.checks += 1
+        return self.checks <= 1
+
+
+def spy_on_consume(monkeypatch):
+    """Record connection kwargs and heartbeat-thread starts across consume()."""
+    connection_kwargs = []
+    heartbeat_queues = []
+    original_connection = amqp_exchange.PulsarExchange.connection
+
+    def connection(self, connection_string, **kwargs):
+        connection_kwargs.append(kwargs)
+        return original_connection(self, connection_string, **kwargs)
+
+    def start_heartbeat(self, queue_name, connection):
+        heartbeat_queues.append(queue_name)
+        return None
+
+    monkeypatch.setattr(amqp_exchange.PulsarExchange, "connection", connection)
+    monkeypatch.setattr(
+        amqp_exchange.PulsarExchange, "_PulsarExchange__start_heartbeat", start_heartbeat
+    )
+    return connection_kwargs, heartbeat_queues
+
+
+@skip_unless_module("kombu")
+def test_factory_defaults_heartbeat():
+    exchange = amqp_exchange_factory.get_exchange(TEST_CONNECTION, "factory_hb_default", {})
+    assert exchange._PulsarExchange__heartbeat == amqp_exchange.DEFAULT_HEARTBEAT
+
+
+@skip_unless_module("kombu")
+@pytest.mark.parametrize("value", [False, 0, "false", "0", "off", ""])
+def test_factory_disables_heartbeat(value):
+    """``false`` and ``0`` are the documented opt-outs; py-amqp treats a falsy
+    client heartbeat as a hard disable and ignores the broker's proposal."""
+    exchange = amqp_exchange_factory.get_exchange(
+        TEST_CONNECTION, "factory_hb_off", {"amqp_heartbeat": value},
+    )
+    assert exchange._PulsarExchange__heartbeat == 0
+
+
+@skip_unless_module("kombu")
+@pytest.mark.parametrize("value,expected", [
+    (60, 60),
+    ("580", 580),
+    (" 60 ", 60),
+    (True, amqp_exchange.DEFAULT_HEARTBEAT),
+])
+def test_factory_coerces_heartbeat(value, expected):
+    """Galaxy destination params and Pulsar's ini config hand over strings. A
+    non-numeric heartbeat raises TypeError inside py-amqp's tune handshake, and
+    TypeError is not in recoverable_exceptions - it kills the consumer thread.
+    """
+    exchange = amqp_exchange_factory.get_exchange(
+        TEST_CONNECTION, "factory_hb_coerce", {"amqp_heartbeat": value},
+    )
+    heartbeat = exchange._PulsarExchange__heartbeat
+    assert heartbeat == expected
+    assert isinstance(heartbeat, int)
+
+
+@skip_unless_module("kombu")
+@pytest.mark.timeout(15)
+def test_consume_passes_configured_heartbeat(monkeypatch):
+    connection_kwargs, heartbeat_queues = spy_on_consume(monkeypatch)
+    exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "hb_consume", heartbeat=42)
+    exchange.consume("setup", callback=None, check=ConsumeOnce())
+    assert [kwargs["heartbeat"] for kwargs in connection_kwargs] == [42]
+    assert heartbeat_queues == ["setup"]
+
+
+@skip_unless_module("kombu")
+@pytest.mark.timeout(15)
+def test_consume_with_heartbeat_disabled_starts_no_thread(monkeypatch):
+    connection_kwargs, heartbeat_queues = spy_on_consume(monkeypatch)
+    exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "hb_consume_off", heartbeat=0)
+    exchange.consume("setup", callback=None, check=ConsumeOnce())
+    assert [kwargs["heartbeat"] for kwargs in connection_kwargs] == [0]
+    assert heartbeat_queues == []
+
+
+@skip_unless_module("kombu")
+@pytest.mark.timeout(15)
+def test_heartbeat_does_not_leak_between_exchanges(monkeypatch):
+    """consume() must not stash the heartbeat in its own default argument: that
+    dict is shared process-wide, so an exchange with heartbeats disabled would
+    negotiate one with the broker while starting no thread to send it, and the
+    broker would drop the connection every couple of intervals forever.
+    """
+    connection_kwargs, _ = spy_on_consume(monkeypatch)
+    default_exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "hb_leak_default")
+    default_exchange.consume("setup", callback=None, check=ConsumeOnce())
+    disabled_exchange = amqp_exchange.PulsarExchange(TEST_CONNECTION, "hb_leak_off", heartbeat=0)
+    disabled_exchange.consume("setup", callback=None, check=ConsumeOnce())
+    assert [kwargs["heartbeat"] for kwargs in connection_kwargs] == [
+        amqp_exchange.DEFAULT_HEARTBEAT, 0,
+    ]
+
+
 def test_publish_kwds_no_retry_by_default():
     """Without an explicit opt-in we leave kombu's defaults alone, so existing
     deployments don't get surprise retry behavior; the persistent outbox is

--- a/test/resilience/harness/pulsar_control.py
+++ b/test/resilience/harness/pulsar_control.py
@@ -142,7 +142,8 @@ class PulsarControl:
         _docker_compose("kill", "-s", signal, self.service, project_dir=self.project_dir)
         if self.mode in ("amqp", "amqp_ack"):
             # RabbitMQ doesn't notice the TCP drop until the AMQP heartbeat
-            # times out (default 580s) so the queue's `consumers` count
+            # times out (two missed intervals; the negotiated interval is the
+            # broker's 60s here) so the queue's `consumers` count
             # stays at 1 long after the container is dead. The next
             # ``start.wait_until_consuming`` would then see the stale count
             # and return before the new pulsar has actually attached. Force
@@ -322,7 +323,7 @@ def _force_drop_setup_consumer_connections():
     """Close every connection currently consuming from pulsar control queues.
 
     pulsar.kill leaves AMQP heartbeats unacknowledged but the broker won't
-    drop the dead consumer until heartbeat timeout (~580s by default). Use
+    drop the dead consumer until heartbeat timeout (two missed intervals). Use
     the RabbitMQ management API to look up consumers on the pulsar control
     queues and explicitly close their connections. Idempotent and safe to
     call when no consumers are present.


### PR DESCRIPTION

Supersedes #357, preserving Nate Coraor's authorship on the original commit. The branch
is that commit rebased onto current `master`, plus fixes for two defects found reviewing
the rebase, and the tests and documentation the option needs.

Branch: `jmchilton/pulsar:rescue-357-amqp-heartbeat`

## Summary

Adds `amqp_heartbeat`, which sets the interval Pulsar requests for AMQP heartbeats on its
consumer connections, or disables heartbeats entirely when set to `false`/`0`. Previously
the interval was hard-coded to `DEFAULT_HEARTBEAT` (580) with no way to change or turn it
off.

Original motivation, from #357: heartbeats have been considered unnecessary and disabled
by default upstream since 2013, but they are sometimes needed to keep connections alive
through firewalls — so make it configurable rather than picking a side.

## Rebase notes

Two conflicts, both from changes that postdate the 2024 commit:

- `PulsarExchange.__init__` gained `durable=True` (`91945e2`); the new `heartbeat` kwarg
  sits alongside it.
- `docs/configure.rst` gained the pulsar-relay section; the heartbeat paragraph stays
  immediately after the `amqp_publish*` paragraph, ahead of it.

## Review follow-up

Two defects in the original patch, fixed here with regression tests (both were red before
the fix):

- **`consume()` wrote the heartbeat into its own mutable default argument.** That dict is
  created once at definition time and shared by every `PulsarExchange` in the process, so
  once any exchange with a heartbeat consumed, every later consumer inherited it — including
  one configured with `amqp_heartbeat: 0`, which then negotiated a heartbeat with the broker
  *while skipping the thread that sends them*. Outbound heartbeat frames only ever come from
  `heartbeat_check()` in that thread, so RabbitMQ closed the connection after two missed
  intervals; `ConnectionForced` is recoverable, so the consumer reconnect-churned
  indefinitely. Realistic on the Galaxy side, where each `PulsarMQJobRunner` builds its own
  exchange. Now the dict is copied and `setdefault` used, and the heartbeat is always passed
  explicitly rather than conditionally.
- **The value reached kombu uncoerced.** Galaxy destination params and Pulsar's ini config
  both hand over strings, and a non-numeric heartbeat raises `TypeError` inside py-amqp's
  `_on_tune`. `TypeError` is not in `recoverable_exceptions`, so `consume()` re-raises and
  the consumer thread — unsupervised in `bind_amqp` — is dead for the life of the process.
  `"0"` is truthy, so the documented "set to 0 to disable" recipe was the worst case.
  Coercion lives in `amqp_exchange_factory`, next to the `amqp_durable` coercion that exists
  for exactly this reason, because `pulsar/client/manager.py` reaches the factory directly
  and bypasses `bind_amqp.TYPED_PARAMS`. The constructor normalises again so direct
  construction is covered.

Documentation corrections in the same pass:

- 580 is the *requested* interval. py-amqp negotiates `min(client, server)` and RabbitMQ has
  proposed 60 by default since 3.5.5, so the effective interval on a stock broker is 60s.
- The setting governs consumer connections. Publisher connections are pooled and have never
  carried a heartbeat; `configure.rst` now says so rather than implying otherwise.
- `docs/error_handling.rst` postdates #357 and is the document operators are pointed at for
  AMQP resilience. It gains a bullet in §3 and a row in §11's tunables table.
- Two comments in the resilience harness described the heartbeat timeout as "580s by
  default", which was already wrong against the suite's stock `rabbitmq:3-management`.

Unrelated tidy-up in its own commit: `test/amqp_test.py` imported `amqp_exchange_factory`
inside six test bodies with no cycle or optional-dependency reason; those are hoisted to
module scope.

## Tests

New coverage in `test/amqp_test.py`, following the existing `amqp_durable` tests:

- factory default is `DEFAULT_HEARTBEAT`
- `False`, `0`, `"false"`, `"0"`, `"off"`, `""` all disable
- `60`, `"580"`, `" 60 "`, `True` all coerce to an `int`
- `consume()` passes the configured heartbeat and starts the heartbeat thread
- with heartbeats disabled, `consume()` passes `0` and starts no thread
- a heartbeat configured on one exchange does not leak into a later one

Local validation:

- `test/amqp_test.py`: 26 passed.
- Unit suite (`test/`, excluding `resilience/` and the integration tests): 308 passed,
  4 pre-existing environment failures that reproduce unchanged on `master` (missing
  `cow` binary).
- mypy on the changed modules: no issues.
- flake8 and isort clean on the changed files.

## Deliberately not in scope

- Extending heartbeats to the publish path. Pooled producer connections have no thread
  calling `heartbeat_check()`, so negotiating a heartbeat there would reproduce the failure
  mode fixed above. Doing it properly needs a publisher-side sender and belongs in its own
  change; for now the docs state the limit.
- Folding `bind_amqp.TYPED_PARAMS` into the factory so every `amqp_*` option is typed once,
  for both the Pulsar server and the Galaxy client, instead of the four parsing idioms that
  exist today. That would make this class of bug impossible by construction, but it is a
  wider change than a rescue of #357 should carry.
- Setting a low `amqp_heartbeat` in `test/resilience/config/app_amqp.yml` so the real-broker
  suite exercises the knob — the harness currently force-drops dead consumers via the
  management API precisely because the timeout is too long to wait on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
